### PR TITLE
Allow symfony 6 dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,11 @@
         "adrienrn/php-mimetyper": "^0.2",
         "goetas-webservices/xsd2php-runtime": "^0.2.13",
         "ext-simplexml": "*",
-        "symfony/validator": "^5",
+        "symfony/validator": "^5|^6",
         "smalot/pdfparser": "^0",
         "setasign/fpdf": "^1",
         "setasign/fpdi": "^2",
-        "symfony/yaml": "^5",
+        "symfony/yaml": "^5|^6",
         "horstoeko/stringmanagement": "^1"
     },
     "require-dev": {


### PR DESCRIPTION
Allow dependency on version 6 of `symfony/yaml` and `symfony/validator`. 

This library being compatible with php 8, there does not seem to be any problem or breaking change.