### PR TITLE
Fix context parameter for wasic-wl profile

### DIFF
--- a/src/ZugferdProfiles.php
+++ b/src/ZugferdProfiles.php
@@ -80,7 +80,7 @@ class ZugferdProfiles
             'description' => 'The BASIC WL profile does not contain any invoice items and therefore cannot display any VAT-compliant ' .
                 'invoices. However, it contains all the information at document level that is required to post the invoice. ' .
                 'It is therefore a booking aid.',
-            'contextparameter' => 'urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic',
+            'contextparameter' => 'urn:factur-x.eu:1p0:basicwl',
             'attachmentfilename' => 'factur-x.xml',
             'xmpname' => 'BASIC WL',
             'xsdfilename' => 'FACTUR-X_BASIC-WL.xsd',

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -33,7 +33,7 @@ class DocumentTest extends TestCase
         $this->assertEquals(ZugferdProfiles::PROFILE_BASICWL, $doc->profile);
         $this->assertArrayHasKey("contextparameter", $doc->profiledef);
         $this->assertArrayHasKey("name", $doc->profiledef);
-        $this->assertEquals("urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic", $doc->profiledef["contextparameter"]);
+        $this->assertEquals("urn:factur-x.eu:1p0:basicwl", $doc->profiledef["contextparameter"]);
         $this->assertEquals("basicwl", $doc->profiledef["name"]);
     }
 


### PR DESCRIPTION
Unless I'm mistaken, it seems that the `contextparameter` for the `basic-wl` profile is incorrect.

It is currently `urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic` which corresponds to a `basic` profile instead of `urn:factur-x.eu:1p0:basicwl`.
