### PR TITLE
Define businessprocess in profiles

### DIFF
--- a/src/ZugferdObjectHelper.php
+++ b/src/ZugferdObjectHelper.php
@@ -582,6 +582,10 @@ class ZugferdObjectHelper
         $result->setSupplyChainTradeTransaction($this->createClassInstance('ram\SupplyChainTradeTransactionType'));
         $result->getExchangedDocumentContext()->setGuidelineSpecifiedDocumentContextParameter($this->createClassInstance('ram\DocumentContextParameterType'));
         $result->getExchangedDocumentContext()->getGuidelineSpecifiedDocumentContextParameter()->setID($this->getIdType($this->profiledef['contextparameter']));
+        if ($this->profiledef['businessprocess']) {
+            $result->getExchangedDocumentContext()->setBusinessProcessSpecifiedDocumentContextParameter($this->createClassInstance('ram\DocumentContextParameterType'));
+            $result->getExchangedDocumentContext()->getBusinessProcessSpecifiedDocumentContextParameter()->setID($this->getIdType($this->profiledef['businessprocess']));
+        }
         $result->getSupplyChainTradeTransaction()->setApplicableHeaderTradeAgreement($this->createClassInstance('ram\HeaderTradeAgreementType'));
         $result->getSupplyChainTradeTransaction()->setApplicableHeaderTradeDelivery($this->createClassInstance('ram\HeaderTradeDeliveryType'));
         $result->getSupplyChainTradeTransaction()->setApplicableHeaderTradeSettlement($this->createClassInstance('ram\HeaderTradeSettlementType'));

--- a/src/ZugferdProfiles.php
+++ b/src/ZugferdProfiles.php
@@ -84,6 +84,7 @@ class ZugferdProfiles
             'altname' => 'BASIC',
             'description' => 'The BASIC profile is a subset of EN 16931-1 and can be used for simple VAT-compliant invoices.',
             'contextparameter' => 'urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic',
+            'businessprocess' => null,
             'attachmentfilename' => 'factur-x.xml',
             'xmpname' => 'BASIC',
             'xsdfilename' => 'FACTUR-X_BASIC.xsd',
@@ -96,6 +97,7 @@ class ZugferdProfiles
                 'invoices. However, it contains all the information at document level that is required to post the invoice. ' .
                 'It is therefore a booking aid.',
             'contextparameter' => 'urn:factur-x.eu:1p0:basicwl',
+            'businessprocess' => null,
             'attachmentfilename' => 'factur-x.xml',
             'xmpname' => 'BASIC WL',
             'xsdfilename' => 'FACTUR-X_BASIC-WL.xsd',
@@ -107,6 +109,7 @@ class ZugferdProfiles
             'description' => 'The EN 16931 (COMFORT) profile completely maps the EN 16931-1 and focuses on the core elements ' .
                 'of an electronic invoice.',
             'contextparameter' => 'urn:cen.eu:en16931:2017',
+            'businessprocess' => null,
             'attachmentfilename' => 'factur-x.xml',
             'xmpname' => 'EN 16931',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
@@ -119,6 +122,7 @@ class ZugferdProfiles
                 'in which several deliveries / delivery locations are billed, structured payment conditions, further information at ' .
                 'item level to support warehousing, etc.)',
             'contextparameter' => 'urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended',
+            'businessprocess' => null,
             'attachmentfilename' => 'factur-x.xml',
             'xmpname' => 'EXTENDED',
             'xsdfilename' => 'FACTUR-X_EXTENDED.xsd',
@@ -131,6 +135,7 @@ class ZugferdProfiles
                 'extension of EN 16931-1 with its own business rules, the national German laws and regulations. It is therefore more ' .
                 'specific than the EN 16931 (COMFORT) profile.',
             'contextparameter' => 'urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_1.2',
+            'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
             'xmpname' => 'EN 16931',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
@@ -143,6 +148,7 @@ class ZugferdProfiles
                 'extension of EN 16931-1 with its own business rules, the national German laws and regulations. It is therefore more ' .
                 'specific than the EN 16931 (COMFORT) profile.',
             'contextparameter' => 'urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.0',
+            'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
             'xmpname' => 'EN 16931',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
@@ -155,6 +161,7 @@ class ZugferdProfiles
                 'extension of EN 16931-1 with its own business rules, the national German laws and regulations. It is therefore more ' .
                 'specific than the EN 16931 (COMFORT) profile.',
             'contextparameter' => 'urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.1',
+            'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
             'xmpname' => 'EN 16931',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
@@ -167,6 +174,7 @@ class ZugferdProfiles
                 'extension of EN 16931-1 with its own business rules, the national German laws and regulations. It is therefore more ' .
                 'specific than the EN 16931 (COMFORT) profile.',
             'contextparameter' => 'urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2',
+            'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
             'xmpname' => 'EN 16931',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
@@ -178,6 +186,7 @@ class ZugferdProfiles
             'description' => 'The MINIMUM profile includes the main information about the purchaser and vendor, the total invoice amount, and the total sales tax (VAT).' .
                 'Only the purchaser s reference can be given at item level. A breakdown of the sales tax (VAT) is not supported. It is therefore a booking aid.',
             'contextparameter' => 'urn:factur-x.eu:1p0:minimum',
+            'businessprocess' => null,
             'attachmentfilename' => 'factur-x.xml',
             'xmpname' => 'MINIMUM',
             'xsdfilename' => 'FACTUR-X_MINIMUM.xsd',
@@ -190,6 +199,7 @@ class ZugferdProfiles
                 'extension of EN 16931-1 with its own business rules, the national German laws and regulations. It is therefore more ' .
                 'specific than the EN 16931 (COMFORT) profile.',
             'contextparameter' => 'urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.3',
+            'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
             'xmpname' => 'EN 16931',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
@@ -202,6 +212,7 @@ class ZugferdProfiles
                 'extension of EN 16931-1 with its own business rules, the national German laws and regulations. It is therefore more ' .
                 'specific than the EN 16931 (COMFORT) profile.',
             'contextparameter' => 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0',
+            'businessprocess' => 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
             'attachmentfilename' => 'xrechnung.xml',
             'xmpname' => 'EN 16931',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',

--- a/tests/testcases/issues/Issue18Test.php
+++ b/tests/testcases/issues/Issue18Test.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace horstoeko\zugferd\tests\testcases\issues;
+
+use \horstoeko\zugferd\tests\TestCase;
+use \horstoeko\zugferd\tests\traits\HandlesXmlTests;
+use \horstoeko\zugferd\ZugferdProfiles;
+use \horstoeko\zugferd\ZugferdDocumentBuilder;
+
+class Issue18Test extends TestCase
+{
+    use HandlesXmlTests;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$document = ZugferdDocumentBuilder::CreateNew(ZugferdProfiles::PROFILE_XRECHNUNG_3);
+    }
+
+    /**
+     * @return void
+     * @issue  #18
+     */
+    public function testBusinessProcessSpecifiedDocumentContextParameter(): void
+    {
+        $invoiceObject = self::$document->getInvoiceObject();
+        $this->assertEquals('urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0', $invoiceObject->getExchangedDocumentContext()->getGuidelineSpecifiedDocumentContextParameter()->getId());
+        $this->assertEquals('urn:fdc:peppol.eu:2017:poacc:billing:01:1.0', $invoiceObject->getExchangedDocumentContext()->getBusinessProcessSpecifiedDocumentContextParameter()->getId());
+    }
+}


### PR DESCRIPTION
For XRechnung 3.0 it is mandatory to define a Business Process Specified Document Context Parameter