### PR TITLE
Fixed php requirement - caret contraint means all non-breaking version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "require": {
-        "php": "^7.3|^7.4|^8.0|^8.1",
+        "php": "^7.3|^7.4|^8",
         "jms/serializer": "^3",
         "goetas-webservices/xsd2php-runtime": "^0.2.13",
         "ext-simplexml": "*",


### PR DESCRIPTION
The php-constraint currently contains `^8.0|^8.1`, which is equal to `^8.0`.

The caret contraint `^` will allow all non-breaking updates in semver, which means: `^8` = `>=8.0.0 <9.0.0`. The current usage of it could lead to missinterpretation.

[Composer Docs](https://getcomposer.org/doc/articles/versions.md#caret-version-range-)
[Semver Checker](https://jubianchi.github.io/semver-check/#/^8/8.3.2)