### PR TITLE
Added setAdditionalCreatorTool() to the PDF builder

### DIFF
--- a/examples/En16931PdfMerger.php
+++ b/examples/En16931PdfMerger.php
@@ -12,4 +12,4 @@ if (!file_exists($existingXml) || !file_exists($existingPdf)) {
     throw new \Exception("XML and/or PDF does not exist");
 }
 
-(new ZugferdDocumentPdfMerger($existingXml, $existingPdf))->generateDocument()->saveDocument($mergeToPdf);
+(new ZugferdDocumentPdfMerger($existingXml, $existingPdf))->setAdditionalCreatorTool('Contoso ERP 1.0')->generateDocument()->saveDocument($mergeToPdf);

--- a/src/ZugferdDocumentPdfBuilderAbstract.php
+++ b/src/ZugferdDocumentPdfBuilderAbstract.php
@@ -31,6 +31,13 @@ use setasign\Fpdi\PdfParser\StreamReader as PdfStreamReader;
 abstract class ZugferdDocumentPdfBuilderAbstract
 {
     /**
+     * Addition creator (e.g. ERP software that called the PHP library)
+     *
+     * @var string
+     */
+    private $additionalCreatorTool = null;
+
+    /**
      * Instance of the pdfwriter
      *
      * @var ZugferdPdfWriter
@@ -38,7 +45,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
     private $pdfWriter = null;
 
     /**
-     * Contains the data of the original PDF documjent
+     * Contains the data of the original PDF document
      *
      * @var string
      */
@@ -104,6 +111,20 @@ abstract class ZugferdDocumentPdfBuilderAbstract
     public function downloadString(string $toFilename): string
     {
         return $this->pdfWriter->Output($toFilename, 'S');
+    }
+
+    /**
+     * Sets an addition creator (e.g. ERP software that called the PHP library)
+     *
+     * @param  string $additionalCreatorTool
+     * The name of the creator
+     * @return self
+     */
+    public function setAdditionalCreatorTool(string $additionalCreatorTool)
+    {
+        $this->additionalCreatorTool = $additionalCreatorTool;
+
+        return $this;
     }
 
     /**
@@ -215,7 +236,11 @@ abstract class ZugferdDocumentPdfBuilderAbstract
 
         $descXmp = $descriptionNodes[5];
         $xmpNodes = $descXmp->children('xmp', true);
-        $xmpNodes->{'CreatorTool'} = sprintf('Factur-X PHP library v%s by HorstOeko', ZugferdPackageVersion::getInstalledVersion());
+        if ($this->additionalCreatorTool) {
+            $xmpNodes->{'CreatorTool'} = sprintf($this->additionalCreatorTool . ' / Factur-X PHP library v%s by HorstOeko', ZugferdPackageVersion::getInstalledVersion());
+        } else {
+            $xmpNodes->{'CreatorTool'} = sprintf('Factur-X PHP library v%s by HorstOeko', ZugferdPackageVersion::getInstalledVersion());
+        }
         $xmpNodes->{'CreateDate'} = $pdfMetadataInfos['createdDate'];
         $xmpNodes->{'ModifyDate'} = $pdfMetadataInfos['modifiedDate'];
         $this->pdfWriter->addMetadataDescriptionNode($descXmp->asXML());


### PR DESCRIPTION
This pull request adds a new method `setAdditionalCreatorTool` to the PDF builder/merger.

Currently, the creator tool attribute is:
`Factur-X PHP library v1.0.0.0 by HorstOeko`

Now, the ERP can add its own name to it, using `->setAdditionalCreatorTool('Contoso ERP')`:
`Contoso ERP / Factur-X PHP library v1.0.0.0 by HorstOeko`

The idea behind this is to give the calling application the possibility to add its own name to the creator tool attribute; after all, it provided all the data and hence it could be argued that it is part of the "creation" of the ZUGFeRD PDF.
