### PR TITLE
ZugferdDocumentPdfReader accepts ZUGFeRD 1.0 filenames on unix systems

### DIFF
--- a/src/ZugferdDocumentBuilder.php
+++ b/src/ZugferdDocumentBuilder.php
@@ -2421,7 +2421,7 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * Seller's banking institution, An identifier for the payment service provider with whom the payment account
      * is managed, such as the BIC or a national bank code, if required. No identification scheme is to be used.
      * @param string|null $paymentReference
-     * Intended use for payment
+     * Intended use for payment. It can also be set using `setDocumentGeneralPaymentInformation()`.
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentPaymentMeanToCreditTransfer(string $payeeIban, ?string $payeeAccountName = null, ?string $payeePropId = null, ?string $payeeBic = null, ?string $paymentReference = null): ZugferdDocumentBuilder
@@ -2448,8 +2448,8 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * @param  string $buyerIban
      * Direct debit: ID of the account to be debited
      * @param  string|null $creditorReferenceID
-     * Identifier of the creditor (German: "Glaeubiger ID").
-     * It can also be set using setDocumentGeneralPaymentInformation().
+     * Identifier of the creditor (German: "Gläubiger ID").
+     * It can also be set using `setDocumentGeneralPaymentInformation()`.
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentPaymentMeanToDirectDebit(string $buyerIban, ?string $creditorReferenceID = null): ZugferdDocumentBuilder

--- a/src/ZugferdDocumentPdfReader.php
+++ b/src/ZugferdDocumentPdfReader.php
@@ -27,7 +27,7 @@ class ZugferdDocumentPdfReader
     /**
      * List of filenames which are possible in PDF
      */
-    const ATTACHMENT_FILEAMES = ['factur-x.xml', 'zugferd-invoice.xml', 'xrechnung.xml'];
+    const ATTACHMENT_FILENAMES = ['ZUGFeRD-invoice.xml'/*1.0*/, 'zugferd-invoice.xml'/*2.0*/, 'factur-x.xml'/*2.1*/, 'xrechnung.xml'];
 
     /**
      * Load a PDF file (ZUGFeRD/Factur-X)
@@ -54,7 +54,7 @@ class ZugferdDocumentPdfReader
         try {
             foreach ($filespecs as $filespec) {
                 $filespecDetails = $filespec->getDetails();
-                if (in_array($filespecDetails['F'], static::ATTACHMENT_FILEAMES)) {
+                if (in_array($filespecDetails['F'], static::ATTACHMENT_FILENAMES)) {
                     $attachmentFound = true;
                     break;
                 }


### PR DESCRIPTION
ZUGFeRD 1.0: file name »ZUGFeRD-invoice.xml«
ZUGFeRD 2.0: file name »zugferd-invoice.xml«
ZUGFeRD 2.1 and Factur-X: file name  »factur-x.xml«

Since unix systems treat filenames case sensitive, it is important to distinct between ZUGFeRD-invoice.xml and zugferd-invoice.xml. I have also added the ZUGFeRD version numbers as comment next to the name. And I fixed a typo in the constant name.