### PR TITLE
Define decimal places for node paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,67 +101,7 @@ For detailed eplanation you may have a look in the [examples](https://github.com
 
 ### Configuration
 
-By means of the `ZugferdSettings` class it is possible to control various options for XML and PDF generation:
-
-```php
-public static function getAmountDecimals(): int
-```
-
-Returns the currently configured number of decimal places for amount fields _(Default: 2)_.
-
-```php
-public static function setAmountDecimals(int $amountDecimals): void
-```
-
-Set the number of decimal places for amount fields.
-
-```php
-public static function getQuantityDecimals(): int
-```
-
-Returns the currently configured number of decimal places for quantity fields _(Default: 2)_.
-
-```php
-public static function setQuantityDecimals(int $quantityDecimals): void
-```
-
-Set the number of decimal places for quantity fields.
-
-```php
-public static function getPercentDecimals(): int
-```
-
-Returns the currently configured number of decimal places for percentage fields _(Default: 2)_.
-
-```php
-public static function setPercentDecimals(int $percentDecimals): void
-```
-
-Set the number of decimal places for percentage fields.
-
-```php
-public static function getDecimalSeparator(): string
-```
-
-Returns the currently configured character for the decimal separator. _(Default: .)
-
-```php
-public static function setDecimalSeparator(string $decimalSeparator): void
-```
-
-Set the character to use as the decimal separator.
-
-```php
-public static function getThousandsSeparator(): string
-```
-
-Returns the currently configured character for the thousands separator. _(Default: Empty)_
-
-```php
-public static function setThousandsSeparator(string $thousandsSeparator): void
-```
-
-Set the character to use as the thousands separator.
+This library can be configured in various ways. For more information please visit our [Wiki](https://github.com/horstoeko/zugferd/wiki/Configuration).
 
 ### Reading a xml file
 

--- a/src/ZugferdSettings.php
+++ b/src/ZugferdSettings.php
@@ -76,11 +76,7 @@ class ZugferdSettings
      *
      * @var array
      */
-    protected static $specialDecimalPlacesMaps = [
-        //Examples:
-        //'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount' => 2,
-        //'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount' => 2,
-    ];
+    protected static $specialDecimalPlacesMaps = [];
 
     /**
      * Get the number of decimals to use for amount values
@@ -273,6 +269,18 @@ class ZugferdSettings
     public static function addSpecialDecimalPlacesMap(string $nodePath, int $defaultDecimalPlaces): void
     {
         static::$specialDecimalPlacesMaps[$nodePath] = $defaultDecimalPlaces;
+    }
+
+    /**
+     * Set the number of decimals to use for unit single amount (unit prices) values
+     *
+     * @param  integer $amountDecimals
+     * @return void
+     */
+    public static function setUnitAmountDecimals(int $amountDecimals): void
+    {
+        ZugferdSettings::addSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount', $amountDecimals);
+        ZugferdSettings::addSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount', $amountDecimals);
     }
 
     /**

--- a/src/ZugferdSettings.php
+++ b/src/ZugferdSettings.php
@@ -72,6 +72,17 @@ class ZugferdSettings
     protected static $xmpMetaDataFilename = "facturx_extension_schema.xmp";
 
     /**
+     * Node paths which present a unit amount. Used for special amount formatting. See unitAmountDecimals property.
+     *
+     * @var array
+     */
+    protected static $specialDecimalPlacesMaps = [
+        //Examples:
+        //'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount' => 2,
+        //'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount' => 2,
+    ];
+
+    /**
      * Get the number of decimals to use for amount values
      *
      * @return integer
@@ -216,6 +227,52 @@ class ZugferdSettings
     public static function setXmpMetaDataFilename(string $xmpMetaDataFilename): void
     {
         static::$xmpMetaDataFilename = $xmpMetaDataFilename;
+    }
+
+    /**
+     * Returns a list of node paths which have a special number of decimal places
+     *
+     * @return array
+     */
+    public static function getSpecialDecimalPlacesMaps(): array
+    {
+        return static::$specialDecimalPlacesMaps;
+    }
+
+    /**
+     * Get a specific map for node paths with a special number of decimal places. If not map
+     * is found then the default value is returns
+     *
+     * @param string $nodePath
+     * @param integer $defaultDecimalPlaces
+     * @return integer
+     */
+    public static function getSpecialDecimalPlacesMap(string $nodePath, int $defaultDecimalPlaces): int
+    {
+        return static::$specialDecimalPlacesMaps[$nodePath] ?? $defaultDecimalPlaces;
+    }
+
+    /**
+     * Update the map of node paths which have a special number of decimal places
+     *
+     * @param array $specialDecimalPlacesMaps
+     * @return void
+     */
+    public static function setSpecialDecimalPlacesMaps(array $specialDecimalPlacesMaps): void
+    {
+        static::$specialDecimalPlacesMaps = $specialDecimalPlacesMaps;
+    }
+
+    /**
+     * Add a new map for a node path with a special number of decimal places
+     *
+     * @param string $nodePath
+     * @param integer $defaultDecimalPlaces
+     * @return void
+     */
+    public static function addSpecialDecimalPlacesMap(string $nodePath, int $defaultDecimalPlaces): void
+    {
+        static::$specialDecimalPlacesMaps[$nodePath] = $defaultDecimalPlaces;
     }
 
     /**

--- a/src/jms/ZugferdTypesHandler.php
+++ b/src/jms/ZugferdTypesHandler.php
@@ -9,13 +9,13 @@
 
 namespace horstoeko\zugferd\jms;
 
-use DOMText;
 use DOMElement;
+use DOMText;
+use horstoeko\zugferd\ZugferdSettings;
 use JMS\Serializer\Context;
 use JMS\Serializer\GraphNavigator;
-use horstoeko\zugferd\ZugferdSettings;
-use JMS\Serializer\XmlSerializationVisitor;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use JMS\Serializer\XmlSerializationVisitor;
 
 /**
  * Class representing a collection of serialization handlers for amount formatting and so on
@@ -152,7 +152,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
 
     /**
      * Serialize Anount type
-     * The amounts will be serialized with a precission of 2 digits
+     * The amounts will be serialized (by default) with a precission of 2 digits
      *
      * @param  XmlSerializationVisitor $visitor
      * @param  mixed                   $data
@@ -165,7 +165,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
         $node = $visitor->getDocument()->createTextNode(
             number_format(
                 $data->value(),
-                ZugferdSettings::getAmountDecimals(),
+                ZugferdSettings::getSpecialDecimalPlacesMap($visitor->getCurrentNode()->getNodePath(), ZugferdSettings::getAmountDecimals()),
                 ZugferdSettings::getDecimalSeparator(),
                 ZugferdSettings::getThousandsSeparator()
             )
@@ -182,7 +182,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
 
     /**
      * Serialize quantity type
-     * The quantity will be serialized with a precission of 4 digits
+     * The quantity will be serialized (by default) with a precission of 2 digits
      *
      * @param  XmlSerializationVisitor $visitor
      * @param  mixed                   $data
@@ -195,7 +195,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
         $node = $visitor->getDocument()->createTextNode(
             number_format(
                 $data->value(),
-                ZugferdSettings::getQuantityDecimals(),
+                ZugferdSettings::getSpecialDecimalPlacesMap($visitor->getCurrentNode()->getNodePath(), ZugferdSettings::getQuantityDecimals()),
                 ZugferdSettings::getDecimalSeparator(),
                 ZugferdSettings::getThousandsSeparator()
             )
@@ -212,7 +212,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
 
     /**
      * Serialize a percantage value
-     * The valze will be serialized with a precission of 2 digits
+     * The valze will be serialized (by default) with a precission of 2 digits
      *
      * @param  XmlSerializationVisitor $visitor
      * @param  mixed                   $data
@@ -225,7 +225,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
         $node = $visitor->getDocument()->createTextNode(
             number_format(
                 $data->value(),
-                ZugferdSettings::getPercentDecimals(),
+                ZugferdSettings::getSpecialDecimalPlacesMap($visitor->getCurrentNode()->getNodePath(), ZugferdSettings::getPercentDecimals()),
                 ZugferdSettings::getDecimalSeparator(),
                 ZugferdSettings::getThousandsSeparator()
             )

--- a/tests/testcases/SettingsTest.php
+++ b/tests/testcases/SettingsTest.php
@@ -190,4 +190,26 @@ class SettingsTest extends TestCase
             $actual
         );
     }
+
+    /**
+     * @covers \horstoeko\zugferd\ZugferdSettings
+     */
+    public function testSpecialDecimalPlacesMaps(): void
+    {
+        $this->assertEquals(2, ZugferdSettings::getSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount', 2));
+        $this->assertEquals(2, ZugferdSettings::getSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount', 2));
+
+        ZugferdSettings::addSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount', 5);
+
+        $this->assertEquals(5, ZugferdSettings::getSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount', 2));
+        $this->assertEquals(2, ZugferdSettings::getSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount', 2));
+
+        ZugferdSettings::setSpecialDecimalPlacesMaps([
+            '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount' => 6,
+            '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount' => 6
+        ]);
+
+        $this->assertEquals(6, ZugferdSettings::getSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount', 2));
+        $this->assertEquals(6, ZugferdSettings::getSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount', 2));
+    }
 }


### PR DESCRIPTION
Related to #59 

Reviewer:  @danielmarschall 

In some special cases, it may be necessary to define the number of decimal places for a specific XML path. This can now be done with an extension of the ``ZugferdSettings``. An XML path is defined together with the number of digits of the number. This currently affects the serialization of 

- minimum\udt\AmountType
- basic\udt\AmountType
- basicwl\udt\AmountType
- en16931\udt\AmountType
- extended\udt\AmountType
- basic\udt\QuantityType
- basicwl\udt\QuantityType
- en16931\udt\QuantityType
- extended\udt\QuantityType
- basic\udt\PercentType
- basicwl\udt\PercentType
- en16931\udt\PercentType
- extended\udt\PercentType

The following methods have been added

- getSpecialDecimalPlacesMaps
- getSpecialDecimalPlacesMap
- setSpecialDecimalPlacesMaps
- addSpecialDecimalPlacesMap

Class customizations

- ZugferdTypesHandler
  - serializeAmountType
  - serializeQuantityType
  - serializePercentType