### PR TITLE
#72 Fixed documentation for *TaxRegistration-Methods

### DIFF
--- a/src/ZugferdDocumentBuilder.php
+++ b/src/ZugferdDocumentBuilder.php
@@ -480,8 +480,10 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * seller. Sales tax number with a prefixed country code. A supplier registered as subject to VAT must provide his sales tax
      * identification number, unless he uses a tax agent.
      *
-     * @param  string|null $taxregtype Type of tax number of the seller
-     * @param  string|null $taxregid   Tax number of the seller or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * @param  string|null $taxregtype
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
+     * @param  string|null $taxregid
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentSellerTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -661,9 +663,10 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * identification number, unless he uses a tax agent.
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the buyers
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the buyers or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
+     * Tax number of the seller or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentBuyerTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -832,7 +835,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * Add Tax registration to tax representative party
      *
      * @param  string|null $taxregtype
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentSellerTaxRepresentativeTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -994,9 +999,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * identification number, unless he uses a tax agent.
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the party
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the party or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentProductEndUserTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -1153,9 +1158,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * Add Tax registration to Ship-To Trade party
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the party
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the party or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentShipToTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -1317,9 +1322,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      *  - This is only available in the EXTENDED profile
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the party
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the party or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentUltimateShipToTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -1487,9 +1492,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      *  - This is only available in the EXTENDED profile
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the party
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the party or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentShipFromTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -1654,9 +1659,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      *  - This is only available in the EXTENDED profile
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the party
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the party or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentInvoicerTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -1826,9 +1831,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      *  - This is only available in the EXTENDED profile
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the party
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the party or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentInvoiceeTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -1992,9 +1997,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * Add Tax registration to payee trade party
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the party
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the party or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentPayeeTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -3377,9 +3382,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * identification number, unless he uses a tax agent.
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the party
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the party or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentPositionShipToTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder
@@ -3539,9 +3544,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * Add Tax registration to Ship-To Trade party
      *
      * @param  string|null $taxregtype
-     * Type of tax number of the party
+     * Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
      * @param  string|null $taxregid
-     * Tax number of the party or sales tax identification number of the (FC = Tax number, VA = Sales tax number)
+     * Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentPositionUltimateShipToTaxRegistration(?string $taxregtype = null, ?string $taxregid = null): ZugferdDocumentBuilder

--- a/src/ZugferdDocumentReader.php
+++ b/src/ZugferdDocumentReader.php
@@ -529,8 +529,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      *    for tax, the buyer will withhold the tax amount and pay it on behalf of the seller
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the seller indexed by __FC__ for _Tax number of the seller_ and __VA__
-     * for _Sales tax identification number of the seller_
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentSellerTaxRegistration(?array &$taxreg): ZugferdDocumentReader
@@ -713,8 +712,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      *    enables the buyer to indicate his reporting status for tax purposes.
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the buyer indexed by __VA__ for _Sales tax identification number of the buyer_
-     * Only the code __VA__ is permitted as an identification scheme
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentBuyerTaxRegistration(?array &$taxreg): ZugferdDocumentReader
@@ -891,8 +889,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      *    or a reference that enables the sellers tax agent to indicate his reporting status for tax purposes.
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the sellers tax agent indexed by __VA__ for _Sales tax identification
-     * number of the tax agent. _ Only the code __VA__ is permitted as an identification scheme
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentSellerTaxRepresentativeTaxRegistration(?array &$taxreg): ZugferdDocumentReader
@@ -1070,8 +1067,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information on the tax number of the product end user
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the product end user indexed by __FC__ for _Tax number of the product end user_ and __VA__
-     * for _Sales tax identification number of the product end user_
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentProductEndUserTaxRegistration(?array &$taxreg): ZugferdDocumentReader
@@ -1247,8 +1243,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information on tax details of the goods recipient
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the party indexed by __FC__ for _Tax number of the party_ and __VA__
-     * for _Sales tax identification number of the party_
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentShipToTaxRegistration(?array &$taxreg): ZugferdDocumentReader
@@ -1433,8 +1428,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      *  - This is only available in the EXTENDED profile
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the party indexed by __FC__ for _Tax number of the party_ and __VA__
-     * for _Sales tax identification number of the party_
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentUltimateShipToTaxRegistration(?array &$taxreg): ZugferdDocumentReader
@@ -1626,8 +1620,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      *  - This is only available in the EXTENDED profile
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the party indexed by __FC__ for _Tax number of the party_ and __VA__
-     * for _Sales tax identification number of the party_
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentShipFromTaxRegistration(?array &$taxreg): ZugferdDocumentReader
@@ -1817,8 +1810,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      *  - This is only available in the EXTENDED profile
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the party indexed by __FC__ for _Tax number of the party_ and __VA__
-     * for _Sales tax identification number of the party_
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentInvoicerTaxRegistration(?array &$taxreg): ZugferdDocumentReader
@@ -2008,8 +2000,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      *  - This is only available in the EXTENDED profile
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the party indexed by __FC__ for _Tax number of the party_ and __VA__
-     * for _Sales tax identification number of the party_
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentInvoiceeTaxRegistration(?array &$taxreg): ZugferdDocumentReader
@@ -2192,8 +2183,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information on tax details of the payee party
      *
      * @param  array|null $taxreg
-     * Array of sales tax identification numbers of the party indexed by __FC__ for _Tax number of the party_ and __VA__
-     * for _Sales tax identification number of the party_
+     * Array of tax numbers indexed by __FC__ for _Tax number_ and __VA__ for _Sales tax identification number_
      * @return ZugferdDocumentReader
      */
     public function getDocumentPayeeTaxRegistration(?array &$taxreg): ZugferdDocumentReader


### PR DESCRIPTION
There are multiple functions to add tax registration of various participants which share parameters, code and documentation.
I guess the order of the two parameters was once reversed and thereby some documentation errors emerged.
I stumbled upon it while comparing the ZugferdQuickDescriptor example with the corresponding documented source code to be able to understand all the parameters.

Fixes #72 