### PR TITLE
Fix ZugferdPdfWriter not outputting metadata if there are no files

### DIFF
--- a/src/ZugferdPdfWriter.php
+++ b/src/ZugferdPdfWriter.php
@@ -393,11 +393,13 @@ class ZugferdPdfWriter extends PdfFpdi
             } else {
                 $this->_put(sprintf('/AF %s 0 R', $this->filesIndex));
             }
+        }
 
-            if (0 != $this->descriptionIndex) {
-                $this->_put(sprintf('/Metadata %s 0 R', $this->descriptionIndex));
-            }
+        if (0 != $this->descriptionIndex) {
+            $this->_put(sprintf('/Metadata %s 0 R', $this->descriptionIndex));
+        }
 
+        if (!empty($this->files)) {
             $this->_put('/Names <<');
             $this->_put('/EmbeddedFiles ');
             $this->_put(sprintf('%s 0 R', $this->filesIndex));


### PR DESCRIPTION
### Background information
A customer requires to receive only a single XML with a PDF embedded as base64.
This task was easy to manage using addDocumentAdditionalReferencedDocument().

I wanted to avoid having a XML containing a PDF which itself contains an XML (Matrjoschka), so I just did a XML containing a PDF.

Although not required, I thought that it would be a nice touch if the embedded PDF was PDF/A-3B instead of a plain PDF. [So, I wrote a method](https://gist.github.com/danielmarschall/8f4788ef4ff3b41ff00ba2057acc3234) based on ZugferdPdfWriter, which converts a plain PDF to PDF/A-3B (without attachments).

### The bug
ZugferdPdfWriter has the problem that it does not write any metadata information if no files are included.
This PR fixes the issue.

While it does not affect the "normal usage" of this library, it fixes a problem where other people developing/extending the library might stumble upon.