### PR TITLE
#104 ProfileResolver should raise ZugferdUnknownXmlContentException when XML content is not valid

### DIFF
--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -53,6 +53,7 @@
             <file>../tests/testcases/issues/Issue18Test.php</file>
             <file>../tests/testcases/issues/Issue32Test.php</file>
             <file>../tests/testcases/issues/Issue43Test.php</file>
+            <file>../tests/testcases/issues/Issue104Test.php</file>
         </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">

--- a/src/ZugferdProfileResolver.php
+++ b/src/ZugferdProfileResolver.php
@@ -34,8 +34,12 @@ class ZugferdProfileResolver
      */
     public static function resolve(string $xmlContent): array
     {
-        $xmldocument = new SimpleXMLElement($xmlContent);
-        $typeelement = $xmldocument->xpath('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID');
+        try {
+            $xmldocument = new SimpleXMLElement($xmlContent);
+            $typeelement = $xmldocument->xpath('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID');
+        } catch (\Throwable $e) {
+            throw new ZugferdUnknownXmlContentException();
+        }
 
         if (!is_array($typeelement) || !isset($typeelement[0])) {
             throw new ZugferdUnknownXmlContentException();
@@ -81,7 +85,7 @@ class ZugferdProfileResolver
      *
      * @param integer $profileId
      * @return array
-    */
+     */
     public static function resolveById(int $profileId): array
     {
         if (!isset(ZugferdProfiles::PROFILEDEF[$profileId])) {

--- a/tests/assets/invalid.xml
+++ b/tests/assets/invalid.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dummy></dummy>

--- a/tests/testcases/issues/Issue104Test.php
+++ b/tests/testcases/issues/Issue104Test.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace horstoeko\zugferd\tests\testcases\issues;
+
+use horstoeko\zugferd\tests\TestCase;
+use horstoeko\zugferd\ZugferdDocumentReader;
+use horstoeko\zugferd\exception\ZugferdUnknownXmlContentException;
+
+class Issue104Test extends TestCase
+{
+    /**
+     * @return void
+     * @issue 104
+     */
+    public function testInvalidException()
+    {
+        $this->expectException(ZugferdUnknownXmlContentException::class);
+
+        $document = ZugferdDocumentReader::readAndGuessFromFile(dirname(__FILE__) . '/../../assets/invalid.xml');
+
+        $this->assertNull($document);
+    }
+}


### PR DESCRIPTION
#104 ProfileResolver should raise ZugferdUnknownXmlContentException when XML content is not valid