### PR TITLE
Update ZugferdProfileResolver.php

### DIFF
--- a/src/ZugferdProfileResolver.php
+++ b/src/ZugferdProfileResolver.php
@@ -38,6 +38,7 @@ class ZugferdProfileResolver
         $prevUseInternalErrors = \libxml_use_internal_errors(true);
 
         try {
+            libxml_clear_errors();
             $xmldocument = new SimpleXMLElement($xmlContent);
             $typeelement = $xmldocument->xpath('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID');
             if (libxml_get_last_error()) {


### PR DESCRIPTION
Fixes #133

The new version of php_zugferd makes use of libxml_get_last_error() in order to verify that SimpleXMLElement() works.

However, if the user code (the code that calls php_zugferd) had accidentally raised an libxml error, then the error status will be preserved until php_zugferd calls libxml_get_last_error(). In other words: The user code had an error, completely unrelated to ZUGFeRD, and ZUGFeRD raises an error telling that the XML is wrong, which is not true.

This PR fixes the issue by making sure that the libxml error storage is clean before checking the SimpleXML result.

I am not 100% happy about the side-effect that `ZugferdProfileResolver::resolve()` clears the XML error storage, though. On the other hand, if the developer of the user code did not check XML errors in time and left them in the error storage, then it is very unlikely that they will need to access the error after php_zugferd has been called.