### PR TITLE
#136 Added "getDocumentSellerCommunication" and "getDocumentBuyerCommunication" to ZugferdDocumentReader

### DIFF
--- a/src/ZugferdDocumentReader.php
+++ b/src/ZugferdDocumentReader.php
@@ -650,6 +650,21 @@ class ZugferdDocumentReader extends ZugferdDocument
     }
 
     /**
+     * Get detailed information on the seller's electronic communication information
+     *
+     * @param  string|null $uriScheme __BT-34-1, From BASIC WL__
+     * @param  string|null $uri       __BT-34, From BASIC WL__
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentSellerCommunication(?string &$uriScheme, ?string &$uri): ZugferdDocumentReader
+    {
+        $uri = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getSellerTradeParty.getURIUniversalCommunication.getURIID.value", "");
+        $uriScheme = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getSellerTradeParty.getURIUniversalCommunication.getURIID.getSchemeID", "");
+
+        return $this;
+    }
+
+    /**
      * Get detailed information about the buyer (service recipient)
      *
      * @param  string|null $name
@@ -827,6 +842,21 @@ class ZugferdDocumentReader extends ZugferdDocument
         $contactphoneno = $this->getInvoiceValueByPathFrom($contact, "getTelephoneUniversalCommunication.getCompleteNumber.value", "");
         $contactfaxno = $this->getInvoiceValueByPathFrom($contact, "getFaxUniversalCommunication.getCompleteNumber.value", "");
         $contactemailadd = $this->getInvoiceValueByPathFrom($contact, "getEmailURIUniversalCommunication.getURIID.value", "");
+
+        return $this;
+    }
+
+    /**
+     * Get detailed information on the seller's electronic communication information
+     *
+     * @param  string|null $uriScheme __BT-49-1, From BASIC WL__
+     * @param  string|null $uri       __BT-49, From BASIC WL__
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentBuyerCommunication(?string &$uriScheme, ?string &$uri): ZugferdDocumentReader
+    {
+        $uri = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTradeParty.getURIUniversalCommunication.getURIID.value", "");
+        $uriScheme = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTradeParty.getURIUniversalCommunication.getURIID.getSchemeID", "");
 
         return $this;
     }

--- a/tests/testcases/PdfReaderEn16931AllowanceChargeTest.php
+++ b/tests/testcases/PdfReaderEn16931AllowanceChargeTest.php
@@ -187,6 +187,13 @@ class PdfReaderEn16931AllowanceChargeTest extends TestCase
         );
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -242,6 +249,13 @@ class PdfReaderEn16931AllowanceChargeTest extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/PdfReaderEn16931Test.php
+++ b/tests/testcases/PdfReaderEn16931Test.php
@@ -179,6 +179,13 @@ class PdfReaderEn16931Test extends TestCase
         );
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -234,6 +241,13 @@ class PdfReaderEn16931Test extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/PdfReaderExtended2Test.php
+++ b/tests/testcases/PdfReaderExtended2Test.php
@@ -171,6 +171,13 @@ class PdfReaderExtended2Test extends TestCase
         );
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("EM", $uriScheme);
+        $this->assertEquals("moi@seller.com", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -231,6 +238,13 @@ class PdfReaderExtended2Test extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("EM", $uriScheme);
+        $this->assertEquals("me@buyer.com", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/PdfReaderExtendedTest.php
+++ b/tests/testcases/PdfReaderExtendedTest.php
@@ -187,6 +187,13 @@ class PdfReaderExtendedTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentSellerContact());
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -243,6 +250,13 @@ class PdfReaderExtendedTest extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/PdfReaderMinimumTest.php
+++ b/tests/testcases/PdfReaderMinimumTest.php
@@ -153,6 +153,13 @@ class PdfReaderMinimumTest extends TestCase
         );
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -207,6 +214,13 @@ class PdfReaderMinimumTest extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/PdfReaderXRechnungTest.php
+++ b/tests/testcases/PdfReaderXRechnungTest.php
@@ -179,6 +179,13 @@ class PdfReaderXRechnungTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentSellerContact());
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -234,6 +241,13 @@ class PdfReaderXRechnungTest extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/ReaderBasicTest.php
+++ b/tests/testcases/ReaderBasicTest.php
@@ -190,6 +190,13 @@ class ReaderBasicTest extends TestCase
         );
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -244,6 +251,13 @@ class ReaderBasicTest extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/ReaderEn16931AllowanceChargeTest.php
+++ b/tests/testcases/ReaderEn16931AllowanceChargeTest.php
@@ -200,6 +200,13 @@ class ReaderEn16931AllowanceChargeTest extends TestCase
         );
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -255,6 +262,13 @@ class ReaderEn16931AllowanceChargeTest extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/ReaderEn16931Test.php
+++ b/tests/testcases/ReaderEn16931Test.php
@@ -192,6 +192,13 @@ class ReaderEn16931Test extends TestCase
         );
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -247,6 +254,13 @@ class ReaderEn16931Test extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/ReaderExtended2Test.php
+++ b/tests/testcases/ReaderExtended2Test.php
@@ -185,6 +185,13 @@ class ReaderExtended2Test extends TestCase
         );
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("EM", $uriScheme);
+        $this->assertEquals("moi@seller.com", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -245,6 +252,13 @@ class ReaderExtended2Test extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("EM", $uriScheme);
+        $this->assertEquals("me@buyer.com", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/ReaderExtendedTest.php
+++ b/tests/testcases/ReaderExtendedTest.php
@@ -206,6 +206,13 @@ class ReaderExtendedTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentSellerContact());
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -262,6 +269,13 @@ class ReaderExtendedTest extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void

--- a/tests/testcases/ReaderXRechnungTest.php
+++ b/tests/testcases/ReaderXRechnungTest.php
@@ -193,6 +193,13 @@ class ReaderXRechnungTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentSellerContact());
     }
 
+    public function testGetDocumentSellerCommunication(): void
+    {
+        self::$document->getDocumentSellerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
+    }
+
     public function testDocumentBuyerGeneral(): void
     {
         self::$document->getDocumentBuyer($buyername, $buyerids, $buyerdescription);
@@ -248,6 +255,13 @@ class ReaderXRechnungTest extends TestCase
                 self::$document->getDocumentBuyerContact($buyercontactpersonname, $buyercontactdepartmentname, $buyercontactphoneno, $buyercontactfaxno, $buyercontactemailaddr);
             }
         );
+    }
+
+    public function testGetDocumentBuyerCommunication(): void
+    {
+        self::$document->getDocumentBuyerCommunication($uriScheme, $uri);
+        $this->assertEquals("", $uriScheme);
+        $this->assertEquals("", $uri);
     }
 
     public function testDocumentSellerTaxRepresentativeGeneral(): void


### PR DESCRIPTION
The following functions were missing in ZugferdDocumentReader.php to get the Seller electronic address (BT-34) an the Buyer electronic address (BT-49):

* getDocumentSellerCommunication
* getDocumentBuyerCommunication