### PR TITLE
POC for setting CII object directly

### DIFF
--- a/src/ZugferdDocument.php
+++ b/src/ZugferdDocument.php
@@ -92,6 +92,19 @@ class ZugferdDocument
         return $this->invoiceObject;
     }
 
+
+    /**
+     * Sets the internal invoice object
+     *
+     * @param \horstoeko\zugferd\entities\basic\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\basicwl\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\en16931\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\extended\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\minimum\rsm\CrossIndustryInvoice $invoiceObject
+     * @return self
+     */
+    public function setInvoiceObject($invoiceObject): self
+    {
+        $this->invoiceObject = $invoiceObject;
+        return $this;
+    }
+
     /**
      * Create a new instance of the internal invoice object
      *

--- a/src/ZugferdDocument.php
+++ b/src/ZugferdDocument.php
@@ -99,7 +99,7 @@ class ZugferdDocument
      * @param \horstoeko\zugferd\entities\basic\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\basicwl\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\en16931\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\extended\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\minimum\rsm\CrossIndustryInvoice $invoiceObject
      * @return self
      */
-    public function setInvoiceObject(\horstoeko\zugferd\entities\basic\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\basicwl\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\en16931\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\extended\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\minimum\rsm\CrossIndustryInvoice $invoiceObject): self
+    public function setInvoiceObject($invoiceObject): self
     {
         $this->invoiceObject = $invoiceObject;
         return $this;

--- a/src/ZugferdDocument.php
+++ b/src/ZugferdDocument.php
@@ -99,7 +99,7 @@ class ZugferdDocument
      * @param \horstoeko\zugferd\entities\basic\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\basicwl\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\en16931\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\extended\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\minimum\rsm\CrossIndustryInvoice $invoiceObject
      * @return self
      */
-    public function setInvoiceObject($invoiceObject): self
+    public function setInvoiceObject(\horstoeko\zugferd\entities\basic\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\basicwl\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\en16931\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\extended\rsm\CrossIndustryInvoice|\horstoeko\zugferd\entities\minimum\rsm\CrossIndustryInvoice $invoiceObject): self
     {
         $this->invoiceObject = $invoiceObject;
         return $this;

--- a/tests/testcases/SetInvoiceObjectTest.php
+++ b/tests/testcases/SetInvoiceObjectTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace horstoeko\zugferd\tests\testcases;
+
+use horstoeko\zugferd\tests\TestCase;
+use horstoeko\zugferd\ZugferdProfiles;
+use horstoeko\zugferd\ZugferdDocumentBuilder;
+use horstoeko\zugferd\ZugferdDocumentJsonExporter;
+use horstoeko\zugferd\entities\extended\ram\TradeSettlementFinancialCardType;
+use horstoeko\zugferd\entities\extended\ram\TradeSettlementPaymentMeansType;
+use horstoeko\zugferd\entities\extended\ram\HeaderTradeSettlementType;
+use horstoeko\zugferd\entities\extended\ram\SupplyChainTradeTransactionType;
+use horstoeko\zugferd\entities\extended\udt\TextType;
+use horstoeko\zugferd\entities\extended\udt\IDType;
+
+class SetInvoiceObjectTest extends TestCase
+{
+    private const CARD_HOLDER_NAME = "Mr John Doe";
+    private const CARD_ID = "9999";
+
+    public function testSettingsInvoiceObject(): void
+    {
+        $document = $this->createDocumentWithFinancialCard();
+
+        $this->assertDocumentProperties($document);
+        $this->assertJsonExport($document);
+    }
+
+    private function createDocumentWithFinancialCard(): \horstoeko\zugferd\ZugferdDocument
+    {
+        $financialCard = $this->createFinancialCard();
+        $paymentMeans = $this->createPaymentMeans($financialCard);
+        $headerTradeSettlement = $this->createHeaderTradeSettlement($paymentMeans);
+        $supplyChainTransaction = $this->createSupplyChainTransaction($headerTradeSettlement);
+
+        $document = ZugferdDocumentBuilder::CreateNew(ZugferdProfiles::PROFILE_EXTENDED);
+        $cii = $document->getInvoiceObject();
+        $cii->setSupplyChainTradeTransaction($supplyChainTransaction);
+        $document->setInvoiceObject($cii);
+
+        return $document;
+    }
+
+    private function createFinancialCard(): TradeSettlementFinancialCardType
+    {
+        return (new TradeSettlementFinancialCardType())
+            ->setCardholderName(new TextType(self::CARD_HOLDER_NAME))
+            ->setID(new IDType(self::CARD_ID));
+    }
+
+    private function createPaymentMeans(TradeSettlementFinancialCardType $financialCard): TradeSettlementPaymentMeansType
+    {
+        return (new TradeSettlementPaymentMeansType())
+            ->setApplicableTradeSettlementFinancialCard($financialCard);
+    }
+
+    private function createHeaderTradeSettlement(TradeSettlementPaymentMeansType $paymentMeans): HeaderTradeSettlementType
+    {
+        return (new HeaderTradeSettlementType())
+            ->addToSpecifiedTradeSettlementPaymentMeans($paymentMeans);
+    }
+
+    private function createSupplyChainTransaction(HeaderTradeSettlementType $headerTradeSettlement): SupplyChainTradeTransactionType
+    {
+        return (new SupplyChainTradeTransactionType())
+            ->setApplicableHeaderTradeSettlement($headerTradeSettlement);
+    }
+
+    private function assertDocumentProperties(\horstoeko\zugferd\ZugferdDocument $document): void
+    {
+        $this->assertNotNull($document->getContent());
+        $this->assertNotNull($document->getInvoiceObject());
+        $this->assertNotNull($document->getSerializer());
+        $this->assertNotNull($document->getObjectHelper());
+        $this->assertEquals(ZugferdProfiles::PROFILE_EXTENDED, $document->getProfileId());
+    }
+
+    private function assertJsonExport(\horstoeko\zugferd\ZugferdDocument $document): void
+    {
+        $exporter = new ZugferdDocumentJsonExporter($document);
+        $jsonObject = $exporter->toJsonObject();
+
+        $this->assertInstanceOf("stdClass", $jsonObject);
+        $this->assertTrue(isset($jsonObject->SupplyChainTradeTransaction));
+        $this->assertEquals(self::CARD_ID, $jsonObject->SupplyChainTradeTransaction->ApplicableHeaderTradeSettlement->SpecifiedTradeSettlementPaymentMeans[0]->ApplicableTradeSettlementFinancialCard->ID->__value);
+        $this->assertEquals(self::CARD_HOLDER_NAME, $jsonObject->SupplyChainTradeTransaction->ApplicableHeaderTradeSettlement->SpecifiedTradeSettlementPaymentMeans[0]->ApplicableTradeSettlementFinancialCard->CardholderName->__value);
+    }
+}

--- a/tests/testcases/SetInvoiceObjectTest.php
+++ b/tests/testcases/SetInvoiceObjectTest.php
@@ -12,7 +12,6 @@ use horstoeko\zugferd\entities\extended\ram\HeaderTradeSettlementType;
 use horstoeko\zugferd\entities\extended\ram\SupplyChainTradeTransactionType;
 use horstoeko\zugferd\entities\extended\udt\TextType;
 use horstoeko\zugferd\entities\extended\udt\IDType;
-use TypeError;
 
 class SetInvoiceObjectTest extends TestCase
 {
@@ -36,7 +35,7 @@ class SetInvoiceObjectTest extends TestCase
         }      
         catch(\Throwable $th){
 
-            $this->assertInstanceOf(TypeError::class, $th);
+            $this->assertInstanceOf(\TypeError::class, $th);
             
         }
     }

--- a/tests/testcases/SetInvoiceObjectTest.php
+++ b/tests/testcases/SetInvoiceObjectTest.php
@@ -12,6 +12,7 @@ use horstoeko\zugferd\entities\extended\ram\HeaderTradeSettlementType;
 use horstoeko\zugferd\entities\extended\ram\SupplyChainTradeTransactionType;
 use horstoeko\zugferd\entities\extended\udt\TextType;
 use horstoeko\zugferd\entities\extended\udt\IDType;
+use TypeError;
 
 class SetInvoiceObjectTest extends TestCase
 {
@@ -26,17 +27,49 @@ class SetInvoiceObjectTest extends TestCase
         $this->assertJsonExport($document);
     }
 
-    private function createDocumentWithFinancialCard(): \horstoeko\zugferd\ZugferdDocument
+    public function testIncorrectProfileScenario()
     {
+        try{
+
+            $document = $this->createDocumentWithBadProfile();
+
+        }      
+        catch(\Throwable $th){
+
+            $this->assertInstanceOf(TypeError::class, $th);
+            
+        }
+    }
+
+
+    private function createDocumentWithBadProfile()
+    {
+
         $financialCard = $this->createFinancialCard();
         $paymentMeans = $this->createPaymentMeans($financialCard);
         $headerTradeSettlement = $this->createHeaderTradeSettlement($paymentMeans);
         $supplyChainTransaction = $this->createSupplyChainTransaction($headerTradeSettlement);
 
-        $document = ZugferdDocumentBuilder::CreateNew(ZugferdProfiles::PROFILE_EXTENDED);
+        $document = ZugferdDocumentBuilder::CreateNew(ZugferdProfiles::PROFILE_BASIC);
         $cii = $document->getInvoiceObject();
         $cii->setSupplyChainTradeTransaction($supplyChainTransaction);
         $document->setInvoiceObject($cii);
+
+    }
+
+    private function createDocumentWithFinancialCard(): \horstoeko\zugferd\ZugferdDocument
+    {
+
+$financialCard = $this->createFinancialCard();
+$paymentMeans = $this->createPaymentMeans($financialCard);
+$headerTradeSettlement = $this->createHeaderTradeSettlement($paymentMeans);
+$supplyChainTransaction = $this->createSupplyChainTransaction($headerTradeSettlement);
+
+$document = ZugferdDocumentBuilder::CreateNew(ZugferdProfiles::PROFILE_EXTENDED);
+$cii = $document->getInvoiceObject();
+$cii->setSupplyChainTradeTransaction($supplyChainTransaction);
+$document->setInvoiceObject($cii);
+
 
         return $document;
     }


### PR DESCRIPTION
# Description

This adds a setter to ZugferdDocument::class which allows setting a CII object directly.

The motivation for this is where partial details are stored elsewhere, the ability to access the underlying CII object allows improved DX for document creation.

Fixes #143 
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

new testcase added `SetInvoiceObjectTest` which stubs a new payment mean from CII objects and injects this into a document. 

**Test Configuration**:

* OS: Ubuntu 
* OS Version: 24.04
* PHP Version: 8.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules