### PR TITLE
Add setName to ExchangedDocumentType.php

### DIFF
--- a/src/entities/en16931/ram/ExchangedDocumentType.php
+++ b/src/entities/en16931/ram/ExchangedDocumentType.php
@@ -16,6 +16,11 @@ class ExchangedDocumentType
     private $iD = null;
 
     /**
+     * @var string $name
+     */
+    private $name = null;
+
+    /**
      * @var string $typeCode
      */
     private $typeCode = null;
@@ -51,6 +56,18 @@ class ExchangedDocumentType
     public function setID(\horstoeko\zugferd\entities\en16931\udt\IDType $iD)
     {
         $this->iD = $iD;
+        return $this;
+    }
+
+    /**
+     * Sets a new name
+     *
+     * @param  string $name
+     * @return self
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
         return $this;
     }
 


### PR DESCRIPTION
Due to the missing routine setName, the node ExchangedDocument name was not filled, although it was passed in the function setDocumentInformation.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] When creating an e-invoice in CII format with profile PROFILE_EN16931, it was noticed that the node <ExchangedDocument><name> was missing. Troubleshooting revealed that the setName function had not yet been implemented. The test after implementing the missing function was successful. The XML contained the node <ExchangedDocument><name>.


**Test Configuration**:

* OS: Ubuntu 
* OS Version: 20.04
* PHP Version: 8.1

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules