### PR TITLE
Fix composer autoload psr-4 mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,7 @@
     },
     "autoload": {
         "psr-4": {
-            "horstoeko\\zugferd\\": "src",
-            "horstoeko\\zugferd\\rsm\\": "src/entities/rsm",
-            "horstoeko\\zugferd\\qdt\\": "src/entities/qdt",
-            "horstoeko\\zugferd\\ram\\": "src/entities/ram",
-            "horstoeko\\zugferd\\udt\\": "src/entities/udt"
+            "horstoeko\\zugferd\\": "src"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
In this commit https://github.com/horstoeko/zugferd/commit/655a7c9dd12ad4a7b171aecbdbb3f152c6763bbc these files were moved into a subfolder. Directories longer exist

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
https://github.com/Roave/BackwardCompatibilityCheck `Roave\BetterReflection\SourceLocator\Type\Composer\Psr\Psr4Mapping` check will fail