### PR TITLE
Fixed issue: Using addDocumentAllowanceCharge with Code SERVICE_OUTSIDE_SCOPE_OF_TAX never passes validation because Taxtype is omitted if you pass no VAT rate

### DIFF
--- a/src/ZugferdObjectHelper.php
+++ b/src/ZugferdObjectHelper.php
@@ -1066,7 +1066,7 @@ class ZugferdObjectHelper
         $this->tryCall($allowanceCharge, "setReasonCode", $this->getCodeType($reasonCode));
         $this->tryCall($allowanceCharge, "setReason", $this->getTextType($reason));
 
-        if (!is_null($taxCategoryCode) && !is_null($taxTypeCode) && !is_null($rateApplicablePercent)) {
+        if (!is_null($taxCategoryCode) && !is_null($taxTypeCode)) {
             $this->tryCall($allowanceCharge, "setCategoryTradeTax", $this->getTradeTaxType($taxCategoryCode, $taxTypeCode, null, null, $rateApplicablePercent));
         }
 


### PR DESCRIPTION
# Description

When trying to set a document allowance with tax code SERVICE_OUTSIDE_SCOPE_OF_TAX and  zero rate, it would never pass Zugferd validation.

The problem is that SERVICE_OUTSIDE_SCOPE_OF_TAX  does not allow a rate to be set at all.

But if I null the rate in $document->addDocumentAllowanceCharge() the resulting XML would also not pass the validation as no tax information will be set, at all.

# Issue type
- [X] Bug fix (non-breaking change which fixes an issue)
- 
# How Has This Been Tested?

Before patch:

Neither
```$document->addDocumentAllowanceCharge(abs($item->net_price_for_item), false, ZugferdDutyTaxFeeCategories::SERVICE_OUTSIDE_SCOPE_OF_TAX, "VAT", null, null, null, null, null, null, ZugferdAllowanceCodes::DISCOUNT);```

nor 

```$document->addDocumentAllowanceCharge(abs($item->net_price_for_item), false, ZugferdDutyTaxFeeCategories::SERVICE_OUTSIDE_SCOPE_OF_TAX, "VAT", 0, null, null, null, null, null, ZugferdAllowanceCodes::DISCOUNT);```

resulted in a valid document.

After applying the patch

```$document->addDocumentAllowanceCharge(abs($item->net_price_for_item), false, ZugferdDutyTaxFeeCategories::SERVICE_OUTSIDE_SCOPE_OF_TAX, "VAT", null, null, null, null, null, null, ZugferdAllowanceCodes::DISCOUNT);```

tests valid (and is IMHO the correct behaviour as no tax rate should be applied)

**Test Configuration**:

Using Mustang Project and online Zugferd validators to confirm my findings.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
