### PR TITLE
[ENH] Add deterministic Mode to ZugferdDocumentPdfBuilderAbstract

### DIFF
--- a/src/ZugferdDocumentPdfBuilderAbstract.php
+++ b/src/ZugferdDocumentPdfBuilderAbstract.php
@@ -340,6 +340,20 @@ abstract class ZugferdDocumentPdfBuilderAbstract
     }
 
     /**
+     * Set the the deterministic mode. This mode should only be used
+     * for testing purposes
+     *
+     * @param  bool $deterministicModeEnabled
+     * @return static
+     */
+    public function setDeterministicModeEnabled(bool $deterministicModeEnabled)
+    {
+        $this->pdfWriter->setDeterministicModeEnabled($deterministicModeEnabled);
+
+        return $this;
+    }
+
+    /**
      * Get the content of XML to attach
      *
      * @return string

--- a/src/ZugferdDocumentPdfBuilderAbstract.php
+++ b/src/ZugferdDocumentPdfBuilderAbstract.php
@@ -11,7 +11,6 @@ namespace horstoeko\zugferd;
 
 use DOMDocument;
 use DOMXpath;
-use InvalidArgumentException;
 use Throwable;
 use horstoeko\mimedb\MimeDb;
 use horstoeko\stringmanagement\FileUtils;
@@ -19,6 +18,7 @@ use horstoeko\zugferd\codelists\ZugferdInvoiceType;
 use horstoeko\zugferd\exception\ZugferdFileNotFoundException;
 use horstoeko\zugferd\exception\ZugferdFileNotReadableException;
 use horstoeko\zugferd\exception\ZugferdUnknownMimetype;
+use horstoeko\zugferd\exception\ZugferdInvalidArgumentException;
 use horstoeko\zugferd\ZugferdPackageVersion;
 use horstoeko\zugferd\ZugferdPdfWriter;
 use horstoeko\zugferd\ZugferdSettings;
@@ -240,7 +240,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
      * @param  string $displayName
      * @param  string $relationshipType
      * @return static
-     * @throws InvalidArgumentException
+     * @throws ZugferdInvalidArgumentException
      * @throws ZugferdFileNotFoundException
      * @throws ZugferdFileNotReadableException
      * @throws ZugferdUnknownMimetype
@@ -250,7 +250,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
         // Checks that the file really exists
 
         if (empty($fullFilename)) {
-            throw new InvalidArgumentException("You must specify a filename for the content to attach");
+            throw new ZugferdInvalidArgumentException("You must specify a filename for the content to attach");
         }
 
         if (!file_exists($fullFilename)) {
@@ -285,7 +285,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
      * @param  string $displayName
      * @param  string $relationshipType
      * @return static
-     * @throws InvalidArgumentException
+     * @throws ZugferdInvalidArgumentException
      * @throws ZugferdUnknownMimetype
      */
     public function attachAdditionalFileByContent(string $content, string $filename, string $displayName = "", string $relationshipType = "")
@@ -293,13 +293,13 @@ abstract class ZugferdDocumentPdfBuilderAbstract
         // Check content. The content must not be empty
 
         if (empty($content)) {
-            throw new InvalidArgumentException("You must specify a content to attach");
+            throw new ZugferdInvalidArgumentException("You must specify a content to attach");
         }
 
         // Check filename. The filename must not be empty
 
         if (empty($filename)) {
-            throw new InvalidArgumentException("You must specify a filename for the content to attach");
+            throw new ZugferdInvalidArgumentException("You must specify a filename for the content to attach");
         }
 
         // Mimetype for the file must exist

--- a/src/exception/ZugferdExceptionCodes.php
+++ b/src/exception/ZugferdExceptionCodes.php
@@ -32,4 +32,5 @@ class ZugferdExceptionCodes
     public const NOPDFATTACHMENTFOUND = -1110;
     public const FILENOTFOUND = -2000;
     public const FILENOTREADABLE = -2001;
+    public const INVALIDARGUMENT = -3000;
 }

--- a/src/exception/ZugferdInvalidArgumentException.php
+++ b/src/exception/ZugferdInvalidArgumentException.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is a part of horstoeko/zugferd.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace horstoeko\zugferd\exception;
+
+use Throwable;
+
+/**
+ * Class representing an exception if an argument is invalid or an argument is not of the expected type
+ *
+ * @category Zugferd
+ * @package  Zugferd
+ * @author   D. Erling <horstoeko@erling.com.de>
+ * @license  https://opensource.org/licenses/MIT MIT
+ * @link     https://github.com/horstoeko/zugferd
+ */
+class ZugferdInvalidArgumentException extends ZugferdBaseException
+{
+    /**
+     * Constructor
+     *
+     * @param string         $message
+     * @param Throwable|null $previous
+     */
+    public function __construct(string $message, ?Throwable $previous = null)
+    {
+        parent::__construct($message, ZugferdExceptionCodes::INVALIDARGUMENT, $previous);
+    }
+}

--- a/tests/testcases/PdfBuilderEn16931Test.php
+++ b/tests/testcases/PdfBuilderEn16931Test.php
@@ -2,10 +2,10 @@
 
 namespace horstoeko\zugferd\tests\testcases;
 
-use InvalidArgumentException;
 use horstoeko\zugferd\codelists\ZugferdPaymentMeans;
 use horstoeko\zugferd\exception\ZugferdFileNotFoundException;
 use horstoeko\zugferd\exception\ZugferdUnknownMimetype;
+use horstoeko\zugferd\exception\ZugferdInvalidArgumentException;
 use horstoeko\zugferd\tests\TestCase;
 use horstoeko\zugferd\tests\traits\HandlesXmlTests;
 use horstoeko\zugferd\ZugferdDocumentBuilder;
@@ -251,7 +251,7 @@ class PdfBuilderEn16931Test extends TestCase
 
     public function testAttachAdditionalFileFileIsEmpty(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ZugferdInvalidArgumentException::class);
         $this->expectExceptionMessage("You must specify a filename for the content to attach");
 
         $pdfBuilder = ZugferdDocumentPdfBuilder::fromPdfFile(self::$document, self::$sourcePdfFilename);
@@ -404,7 +404,7 @@ class PdfBuilderEn16931Test extends TestCase
 
     public function testAttachAdditionalFileByContentEmptyContent(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ZugferdInvalidArgumentException::class);
         $this->expectExceptionMessage("You must specify a content to attach");
 
         $pdfBuilder = ZugferdDocumentPdfBuilder::fromPdfFile(self::$document, self::$sourcePdfFilename);
@@ -413,7 +413,7 @@ class PdfBuilderEn16931Test extends TestCase
 
     public function testAttachAdditionalFileByContentEmptyFilename(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ZugferdInvalidArgumentException::class);
         $this->expectExceptionMessage("You must specify a filename for the content to attach");
 
         $filename = dirname(__FILE__) . "/../assets/txt_addattachment_1.txt";


### PR DESCRIPTION
# Description

Used to write unit tests where input files A & B should consistently produce the same output PDF C. The random bits and timestamps make this challenging

See  issue #201

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
