### PR TITLE
[ENH] #244 Make isFile() and xmlDataIsFile() methods overridable

### DIFF
--- a/src/ZugferdDocumentPdfBuilderAbstract.php
+++ b/src/ZugferdDocumentPdfBuilderAbstract.php
@@ -667,11 +667,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
      */
     protected function isFile($pdfData): bool
     {
-        try {
-            return is_file($pdfData) && !is_link($pdfData) && is_readable($pdfData);
-        } catch (Throwable $throwable) {
-            return false;
-        }
+        return is_file($pdfData);
     }
 
     /**

--- a/src/ZugferdDocumentPdfBuilderAbstract.php
+++ b/src/ZugferdDocumentPdfBuilderAbstract.php
@@ -667,7 +667,11 @@ abstract class ZugferdDocumentPdfBuilderAbstract
      */
     protected function isFile($pdfData): bool
     {
-        return is_file($pdfData);
+        try {
+            return is_file($pdfData);
+        } catch (Throwable $throwable) {
+            return false;
+        }
     }
 
     /**

--- a/src/ZugferdDocumentPdfBuilderAbstract.php
+++ b/src/ZugferdDocumentPdfBuilderAbstract.php
@@ -665,10 +665,10 @@ abstract class ZugferdDocumentPdfBuilderAbstract
      * @param  string $pdfData
      * @return boolean
      */
-    private function isFile($pdfData): bool
+    protected function isFile($pdfData): bool
     {
         try {
-            return @is_file($pdfData);
+            return is_file($pdfData) && !is_link($pdfData) && is_readable($pdfData);
         } catch (Throwable $throwable) {
             return false;
         }

--- a/src/ZugferdDocumentPdfMerger.php
+++ b/src/ZugferdDocumentPdfMerger.php
@@ -9,12 +9,13 @@
 
 namespace horstoeko\zugferd;
 
-use horstoeko\zugferd\exception\ZugferdFileNotReadableException;
-use horstoeko\zugferd\exception\ZugferdUnknownProfileException;
-use horstoeko\zugferd\exception\ZugferdUnknownProfileParameterException;
-use horstoeko\zugferd\exception\ZugferdUnknownXmlContentException;
-use horstoeko\zugferd\ZugferdDocumentPdfBuilderAbstract;
+use Throwable;
 use horstoeko\zugferd\ZugferdProfileResolver;
+use horstoeko\zugferd\ZugferdDocumentPdfBuilderAbstract;
+use horstoeko\zugferd\exception\ZugferdUnknownProfileException;
+use horstoeko\zugferd\exception\ZugferdFileNotReadableException;
+use horstoeko\zugferd\exception\ZugferdUnknownXmlContentException;
+use horstoeko\zugferd\exception\ZugferdUnknownProfileParameterException;
 
 /**
  * Class representing the facillity adding existing XML data (file or data-string)
@@ -108,7 +109,7 @@ class ZugferdDocumentPdfMerger extends ZugferdDocumentPdfBuilderAbstract
     {
         try {
             return is_file($this->xmlDataOrFilename);
-        } catch (\TypeError $typeError) {
+        } catch (Throwable $throwable) {
             return false;
         }
     }

--- a/src/ZugferdDocumentPdfMerger.php
+++ b/src/ZugferdDocumentPdfMerger.php
@@ -106,11 +106,7 @@ class ZugferdDocumentPdfMerger extends ZugferdDocumentPdfBuilderAbstract
      */
     protected function xmlDataIsFile(): bool
     {
-        try {
-            return is_file($this->xmlDataOrFilename) && !is_link($this->xmlDataOrFilename) && is_readable($this->xmlDataOrFilename);;
-        } catch (\TypeError $typeError) {
-            return false;
-        }
+        return is_file($this->xmlDataOrFilename);
     }
 
     /**

--- a/src/ZugferdDocumentPdfMerger.php
+++ b/src/ZugferdDocumentPdfMerger.php
@@ -104,10 +104,10 @@ class ZugferdDocumentPdfMerger extends ZugferdDocumentPdfBuilderAbstract
      *
      * @return boolean
      */
-    private function xmlDataIsFile(): bool
+    protected function xmlDataIsFile(): bool
     {
         try {
-            return @is_file($this->xmlDataOrFilename);
+            return is_file($this->xmlDataOrFilename) && !is_link($this->xmlDataOrFilename) && is_readable($this->xmlDataOrFilename);;
         } catch (\TypeError $typeError) {
             return false;
         }

--- a/src/ZugferdDocumentPdfMerger.php
+++ b/src/ZugferdDocumentPdfMerger.php
@@ -106,7 +106,11 @@ class ZugferdDocumentPdfMerger extends ZugferdDocumentPdfBuilderAbstract
      */
     protected function xmlDataIsFile(): bool
     {
-        return is_file($this->xmlDataOrFilename);
+        try {
+            return is_file($this->xmlDataOrFilename);
+        } catch (\TypeError $typeError) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
# Description

The isFile() method in ZugferdDocumentPdfBuilderAbstract is currently declared as private, making it impossible to override. This poses the following issues:

Security Risk: The isFile() method determines whether the input is a filename or raw content, implicitly loading file contents when a valid filename is provided. This behavior can inadvertently allow unwanted file access.
Performance Issue: Implicitly interpreting input as a file or content adds unnecessary overhead, especially if the use case requires the input to always be treated as raw content.
If the isFile() method were protected, developers could override it to ensure the input is always interpreted as raw content, avoiding implicit file loading.

The same issue applies to the xmlDataIsFile() method in ZugferdDocumentPdfMerger. Making this method overridable would provide similar benefits by ensuring consistent handling of input.

Fixes #244 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
