### PR TITLE
[ENH] #245 Add Support for Setting SerializerBuilder Cache Directory

### DIFF
--- a/src/ZugferdDocument.php
+++ b/src/ZugferdDocument.php
@@ -245,6 +245,10 @@ class ZugferdDocument
             )
         );
 
+        if (ZugferdSettings::hasSerializerCacheDirectory()) {
+            $this->serializerBuilder->setCacheDir(ZugferdSettings::getSerializerCacheDirectory());
+        }
+
         $this->serializerBuilder->addDefaultListeners();
         $this->serializerBuilder->addDefaultHandlers();
 

--- a/src/ZugferdSettings.php
+++ b/src/ZugferdSettings.php
@@ -10,6 +10,7 @@
 namespace horstoeko\zugferd;
 
 use horstoeko\stringmanagement\PathUtils;
+use horstoeko\stringmanagement\StringUtils;
 
 /**
  * Class representing the general settings
@@ -84,6 +85,13 @@ class ZugferdSettings
      * @var array<string,integer>
      */
     protected static $specialDecimalPlacesMaps = [];
+
+    /**
+     * The configured cache directory for the serializer
+     *
+     * @var string
+     */
+    protected static $serializerCacheDirectory = "";
 
     /**
      * Get the number of decimals to use for amount values
@@ -311,6 +319,37 @@ class ZugferdSettings
     {
         ZugferdSettings::addSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount', $amountDecimals);
         ZugferdSettings::addSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount', $amountDecimals);
+    }
+
+    /**
+     * Set the cache directory for the internal serializer
+     *
+     * @param  string $serializerCacheDirectoty
+     * @return void
+     */
+    public static function setSerializerCacheDirectory(string $serializerCacheDirectoty): void
+    {
+        static::$serializerCacheDirectory = $serializerCacheDirectoty;
+    }
+
+    /**
+     * Returns the cache directory for the internal serializer. This might be empty
+     *
+     * @return string
+     */
+    public static function getSerializerCacheDirectory(): string
+    {
+        return static::$serializerCacheDirectory;
+    }
+
+    /**
+     * Returns true if a cache directory for the internal serializer is configured, otherwise false
+     *
+     * @return boolean
+     */
+    public static function hasSerializerCacheDirectory(): bool
+    {
+        return StringUtils::stringIsNullOrEmpty(static::$serializerCacheDirectory) === false;
     }
 
     /**

--- a/tests/testcases/SettingsTest.php
+++ b/tests/testcases/SettingsTest.php
@@ -189,4 +189,20 @@ class SettingsTest extends TestCase
         $this->assertSame(6, ZugferdSettings::getSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount', 2));
         $this->assertSame(6, ZugferdSettings::getSpecialDecimalPlacesMap('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount', 2));
     }
+
+    public function testSerializerCacheDirectory(): void
+    {
+        $this->assertSame('', ZugferdSettings::getSerializerCacheDirectory());
+        $this->assertFalse(ZugferdSettings::hasSerializerCacheDirectory());
+
+        ZugferdSettings::setSerializerCacheDirectory(sys_get_temp_dir());
+
+        $this->assertSame(sys_get_temp_dir(), ZugferdSettings::getSerializerCacheDirectory());
+        $this->assertTrue(ZugferdSettings::hasSerializerCacheDirectory());
+
+        ZugferdSettings::setSerializerCacheDirectory('');
+
+        $this->assertSame('', ZugferdSettings::getSerializerCacheDirectory());
+        $this->assertFalse(ZugferdSettings::hasSerializerCacheDirectory());
+    }
 }


### PR DESCRIPTION
# Description

Currently, this library uses the JMS\Serializer\SerializerBuilder, which offers the method setCacheDir() to define a caching directory. However, there is no mechanism in the static ZugferdSettings object to specify the cache directory, which could then be passed when constructing the SerializerBuilder.

Adding this feature would allow users to configure the cache directory via the ZugferdSettings object, improving flexibility and maintainability for applications that use this library.

Fixes #245 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
