### PR TITLE
Add creator tool name to meta data

### DIFF
--- a/src/ZugferdDocumentPdfBuilderAbstract.php
+++ b/src/ZugferdDocumentPdfBuilderAbstract.php
@@ -579,7 +579,8 @@ abstract class ZugferdDocumentPdfBuilderAbstract
 
         $descXmp = $descriptionNodes[5];
         $xmpNodes = $descXmp->children('xmp', true);
-        $xmpNodes->{'CreatorTool'} = $this->getCreatorToolName();
+        $creatorTool = $this->getCreatorToolName();
+        $xmpNodes->{'CreatorTool'} = $creatorTool;
         $xmpNodes->{'CreateDate'} = $pdfMetadataInfos['createdDate'];
         $xmpNodes->{'ModifyDate'} = $pdfMetadataInfos['modifiedDate'];
         $this->pdfWriter->addMetadataDescriptionNode($descXmp->asXML());
@@ -588,6 +589,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
         $this->pdfWriter->SetKeywords($pdfMetadataInfos['keywords'], true);
         $this->pdfWriter->SetTitle($pdfMetadataInfos['title'], true);
         $this->pdfWriter->SetSubject($pdfMetadataInfos['subject'], true);
+        $this->pdfWriter->SetCreator($creatorTool, true);
     }
 
     /**


### PR DESCRIPTION
Creator tool name was set in XMP data only. Additionally, FPDF allows to set creator name also via SetCreator().

File info before change (via Chrome):
![zugferd-before](https://github.com/user-attachments/assets/b660332a-64b3-4cde-9cb4-f5c1688ff0be)

File info after change:
![zugferd-after](https://github.com/user-attachments/assets/62705449-7980-47ca-b8e6-e5ce83443106)
