### PR TITLE
[ENH] #270 Added methods to read ReceivableSpecifiedTradeAccountingAccounts on document- and position-level

### DIFF
--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -61,6 +61,7 @@
             <file>../tests/testcases/issues/Issue113Test.php</file>
             <file>../tests/testcases/issues/Issue206Test.php</file>
             <file>../tests/testcases/issues/Issue268Test.php</file>
+            <file>../tests/testcases/issues/Issue270Test.php</file>
         </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">

--- a/src/ZugferdDocumentReader.php
+++ b/src/ZugferdDocumentReader.php
@@ -3978,8 +3978,8 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get information on the booking reference (on position level)
      *
-     * @param null|string &$id       __BT-133, From EN 16931__ Posting reference of the byuer. If required, this reference shall be provided by the Buyer to the Seller prior to the issuing of the Invoice.
-     * @param null|string &$typeCode __BT-X-99, From EXTENDED__ Type of the posting reference
+     * @param  null|string &$id       __BT-133, From EN 16931__ Posting reference of the byuer. If required, this reference shall be provided by the Buyer to the Seller prior to the issuing of the Invoice.
+     * @param  null|string &$typeCode __BT-X-99, From EXTENDED__ Type of the posting reference
      * @return ZugferdDocumentReader
      */
     public function getDocumentPositionReceivableSpecifiedTradeAccountingAccount(?string &$id, ?string &$typeCode): ZugferdDocumentReader

--- a/tests/assets/xml_issue_268.xml
+++ b/tests/assets/xml_issue_268.xml
@@ -114,6 +114,7 @@
 				</ram:AdditionalReferencedDocument>
 				<ram:ReceivableSpecifiedTradeAccountingAccount>
 					<ram:ID>567</ram:ID>
+                    <ram:TypeCode>1</ram:TypeCode>
 				</ram:ReceivableSpecifiedTradeAccountingAccount>
 			</ram:SpecifiedLineTradeSettlement>
 		</ram:IncludedSupplyChainTradeLineItem>
@@ -196,6 +197,7 @@
 				</ram:AdditionalReferencedDocument>
 				<ram:ReceivableSpecifiedTradeAccountingAccount>
 					<ram:ID>567</ram:ID>
+                    <ram:TypeCode>2</ram:TypeCode>
 				</ram:ReceivableSpecifiedTradeAccountingAccount>
 			</ram:SpecifiedLineTradeSettlement>
 		</ram:IncludedSupplyChainTradeLineItem>
@@ -278,6 +280,7 @@
 				</ram:AdditionalReferencedDocument>
 				<ram:ReceivableSpecifiedTradeAccountingAccount>
 					<ram:ID>740</ram:ID>
+                    <ram:TypeCode>3</ram:TypeCode>
 				</ram:ReceivableSpecifiedTradeAccountingAccount>
 			</ram:SpecifiedLineTradeSettlement>
 		</ram:IncludedSupplyChainTradeLineItem>
@@ -1322,6 +1325,14 @@
 				<ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
 				<ram:DuePayableAmount>1028.31</ram:DuePayableAmount>
 			</ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:ReceivableSpecifiedTradeAccountingAccount>
+                <ram:ID>567</ram:ID>
+                <ram:TypeCode>1</ram:TypeCode>
+            </ram:ReceivableSpecifiedTradeAccountingAccount>
+            <ram:ReceivableSpecifiedTradeAccountingAccount>
+                <ram:ID>740</ram:ID>
+                <ram:TypeCode>2</ram:TypeCode>
+            </ram:ReceivableSpecifiedTradeAccountingAccount>
 		</ram:ApplicableHeaderTradeSettlement>
 	</rsm:SupplyChainTradeTransaction>
 </rsm:CrossIndustryInvoice>

--- a/tests/assets/xml_issue_268_extended.xml
+++ b/tests/assets/xml_issue_268_extended.xml
@@ -114,6 +114,7 @@
 				</ram:AdditionalReferencedDocument>
 				<ram:ReceivableSpecifiedTradeAccountingAccount>
 					<ram:ID>567</ram:ID>
+                    <ram:TypeCode>1</ram:TypeCode>
 				</ram:ReceivableSpecifiedTradeAccountingAccount>
 			</ram:SpecifiedLineTradeSettlement>
 		</ram:IncludedSupplyChainTradeLineItem>
@@ -196,6 +197,7 @@
 				</ram:AdditionalReferencedDocument>
 				<ram:ReceivableSpecifiedTradeAccountingAccount>
 					<ram:ID>567</ram:ID>
+                    <ram:TypeCode>2</ram:TypeCode>
 				</ram:ReceivableSpecifiedTradeAccountingAccount>
 			</ram:SpecifiedLineTradeSettlement>
 		</ram:IncludedSupplyChainTradeLineItem>
@@ -278,6 +280,7 @@
 				</ram:AdditionalReferencedDocument>
 				<ram:ReceivableSpecifiedTradeAccountingAccount>
 					<ram:ID>740</ram:ID>
+                    <ram:TypeCode>3</ram:TypeCode>
 				</ram:ReceivableSpecifiedTradeAccountingAccount>
 			</ram:SpecifiedLineTradeSettlement>
 		</ram:IncludedSupplyChainTradeLineItem>
@@ -1322,6 +1325,14 @@
 				<ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
 				<ram:DuePayableAmount>1028.31</ram:DuePayableAmount>
 			</ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:ReceivableSpecifiedTradeAccountingAccount>
+                <ram:ID>567</ram:ID>
+                <ram:TypeCode>1</ram:TypeCode>
+            </ram:ReceivableSpecifiedTradeAccountingAccount>
+            <ram:ReceivableSpecifiedTradeAccountingAccount>
+                <ram:ID>740</ram:ID>
+                <ram:TypeCode>2</ram:TypeCode>
+            </ram:ReceivableSpecifiedTradeAccountingAccount>
 		</ram:ApplicableHeaderTradeSettlement>
 	</rsm:SupplyChainTradeTransaction>
 </rsm:CrossIndustryInvoice>

--- a/tests/testcases/BuilderEn16931Test.php
+++ b/tests/testcases/BuilderEn16931Test.php
@@ -1773,6 +1773,7 @@ class BuilderEn16931Test extends TestCase
         (self::$document)->setDocumentPositionBillingPeriod(new DateTime(), new DateTime());
         (self::$document)->addDocumentPositionAllowanceCharge(10.0, true, 19.0, 10.0, "reasoncode", "reason");
         (self::$document)->setDocumentPositionLineSummation(100);
+        (self::$document)->addDocumentPositionReceivableSpecifiedTradeAccountingAccount("accid2", "acctypecode2");
         (self::$document)->addDocumentPositionReceivableSpecifiedTradeAccountingAccount("accid", "acctypecode");
         (self::$document)->addDocumentPositionAdditionalReferencedDocument("1", "2", "3", "4", "name", "reftypecode", new DateTime());
         (self::$document)->addDocumentPositionUltimateCustomerOrderReferencedDocument("ORDER-0001", "1.1", new DateTime());

--- a/tests/testcases/BuilderExtendedTest.php
+++ b/tests/testcases/BuilderExtendedTest.php
@@ -1860,6 +1860,7 @@ class BuilderExtendedTest extends TestCase
         (self::$document)->setDocumentPositionBillingPeriod(new \DateTime(), new \DateTime());
         (self::$document)->addDocumentPositionAllowanceCharge(10.0, true, 19.0, 10.0, "reasoncode", "reason");
         (self::$document)->setDocumentPositionLineSummation(100);
+        (self::$document)->addDocumentPositionReceivableSpecifiedTradeAccountingAccount("accid2", "acctypecode2");
         (self::$document)->addDocumentPositionReceivableSpecifiedTradeAccountingAccount("accid", "acctypecode");
         (self::$document)->addDocumentPositionAdditionalReferencedDocument("1", "2", "3", "4", "name", "reftypecode", new \DateTime());
         (self::$document)->addDocumentPositionUltimateCustomerOrderReferencedDocument("ORDER-0001", "1.1", new \DateTime());

--- a/tests/testcases/BuilderMinimumTest.php
+++ b/tests/testcases/BuilderMinimumTest.php
@@ -1813,6 +1813,7 @@ class BuilderMinimumTest extends TestCase
         (self::$document)->setDocumentPositionBillingPeriod(new DateTime(), new DateTime());
         (self::$document)->addDocumentPositionAllowanceCharge(10.0, true, 19.0, 10.0, "reasoncode", "reason");
         (self::$document)->setDocumentPositionLineSummation(100);
+        (self::$document)->addDocumentPositionReceivableSpecifiedTradeAccountingAccount("accid2", "acctypecode2");
         (self::$document)->addDocumentPositionReceivableSpecifiedTradeAccountingAccount("accid", "acctypecode");
         (self::$document)->addDocumentPositionAdditionalReferencedDocument("1", "2", "3", "4", "name", "reftypecode", new DateTime());
         (self::$document)->addDocumentPositionUltimateCustomerOrderReferencedDocument("ORDER-0001", "1.1", new DateTime());

--- a/tests/testcases/PdfReaderEn16931AllowanceChargeTest.php
+++ b/tests/testcases/PdfReaderEn16931AllowanceChargeTest.php
@@ -970,6 +970,12 @@ class PdfReaderEn16931AllowanceChargeTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition());

--- a/tests/testcases/PdfReaderEn16931Test.php
+++ b/tests/testcases/PdfReaderEn16931Test.php
@@ -912,6 +912,12 @@ class PdfReaderEn16931Test extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition(), "has a first position");

--- a/tests/testcases/PdfReaderExtended2Test.php
+++ b/tests/testcases/PdfReaderExtended2Test.php
@@ -980,6 +980,18 @@ class PdfReaderExtended2Test extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertTrue(self::$document->firstDocumentTradeAccountingAccount());
+
+        self::$document->getDocumentReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("BUYER ACCOUNT REF", $accountId);
+        $this->assertSame("", $accountType);
+
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition());

--- a/tests/testcases/PdfReaderExtendedTest.php
+++ b/tests/testcases/PdfReaderExtendedTest.php
@@ -976,6 +976,12 @@ class PdfReaderExtendedTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition());

--- a/tests/testcases/PdfReaderMinimumTest.php
+++ b/tests/testcases/PdfReaderMinimumTest.php
@@ -847,6 +847,12 @@ class PdfReaderMinimumTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertFalse(self::$document->firstDocumentPosition(), "has a first position");

--- a/tests/testcases/PdfReaderXRechnungTest.php
+++ b/tests/testcases/PdfReaderXRechnungTest.php
@@ -928,6 +928,12 @@ class PdfReaderXRechnungTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition(), "has a first position");

--- a/tests/testcases/ReaderBasicTest.php
+++ b/tests/testcases/ReaderBasicTest.php
@@ -921,6 +921,12 @@ class ReaderBasicTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition(), "has a first position");

--- a/tests/testcases/ReaderEn16931AllowanceChargeTest.php
+++ b/tests/testcases/ReaderEn16931AllowanceChargeTest.php
@@ -985,6 +985,12 @@ class ReaderEn16931AllowanceChargeTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition());

--- a/tests/testcases/ReaderEn16931Test.php
+++ b/tests/testcases/ReaderEn16931Test.php
@@ -943,6 +943,12 @@ class ReaderEn16931Test extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition(), "has a first position");

--- a/tests/testcases/ReaderExtended2Test.php
+++ b/tests/testcases/ReaderExtended2Test.php
@@ -996,6 +996,18 @@ class ReaderExtended2Test extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertTrue(self::$document->firstDocumentTradeAccountingAccount());
+
+        self::$document->getDocumentReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("BUYER ACCOUNT REF", $accountId);
+        $this->assertSame("", $accountType);
+
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition());

--- a/tests/testcases/ReaderExtendedTest.php
+++ b/tests/testcases/ReaderExtendedTest.php
@@ -1054,6 +1054,12 @@ class ReaderExtendedTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition());

--- a/tests/testcases/ReaderXRechnungTest.php
+++ b/tests/testcases/ReaderXRechnungTest.php
@@ -944,6 +944,12 @@ class ReaderXRechnungTest extends TestCase
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }
 
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $this->assertFalse(self::$document->firstDocumentTradeAccountingAccount());
+        $this->assertFalse(self::$document->nextDocumentTradeAccountingAccount());
+    }
+
     public function testDocumentPositionLoop(): void
     {
         $this->assertTrue(self::$document->firstDocumentPosition(), "has a first position");

--- a/tests/testcases/issues/Issue270Test.php
+++ b/tests/testcases/issues/Issue270Test.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace horstoeko\zugferd\tests\testcases\issues;
+
+use horstoeko\zugferd\tests\TestCase;
+use horstoeko\zugferd\ZugferdDocumentReader;
+
+class Issue270Test extends TestCase
+{
+    public function testDocumentReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $document = ZugferdDocumentReader::readAndGuessFromFile(__DIR__ . '/../../assets/xml_issue_268.xml');
+
+        $this->assertTrue($document->firstDocumentTradeAccountingAccount());
+
+        $document->getDocumentReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("567", $accountId);
+        $this->assertSame("", $accountType);
+
+        $this->assertFalse($document->nextDocumentTradeAccountingAccount());
+    }
+
+    public function testDocumentPositionReceivableSpecifiedTradeAccountingAccount(): void
+    {
+        $document = ZugferdDocumentReader::readAndGuessFromFile(__DIR__ . '/../../assets/xml_issue_268.xml');
+
+        $this->assertTrue($document->firstDocumentPosition());
+
+        $document->getDocumentPositionReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("567", $accountId);
+        $this->assertSame("", $accountType);
+
+        $this->assertTrue($document->nextDocumentPosition());
+
+        $document->getDocumentPositionReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("567", $accountId);
+        $this->assertSame("", $accountType);
+
+        $this->assertTrue($document->nextDocumentPosition());
+
+        $document->getDocumentPositionReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("740", $accountId);
+        $this->assertSame("", $accountType);
+    }
+
+    public function testDocumentReceivableSpecifiedTradeAccountingAccountExtended(): void
+    {
+        $document = ZugferdDocumentReader::readAndGuessFromFile(__DIR__ . '/../../assets/xml_issue_268_extended.xml');
+
+        $this->assertTrue($document->firstDocumentTradeAccountingAccount());
+
+        $document->getDocumentReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("567", $accountId);
+        $this->assertSame("1", $accountType);
+
+        $this->assertTrue($document->nextDocumentTradeAccountingAccount());
+
+        $document->getDocumentReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("740", $accountId);
+        $this->assertSame("2", $accountType);
+
+        $this->assertFalse($document->nextDocumentTradeAccountingAccount());
+    }
+
+    public function testDocumentPositionReceivableSpecifiedTradeAccountingAccountExtended(): void
+    {
+        $document = ZugferdDocumentReader::readAndGuessFromFile(__DIR__ . '/../../assets/xml_issue_268_extended.xml');
+
+        $this->assertTrue($document->firstDocumentPosition());
+
+        $document->getDocumentPositionReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("567", $accountId);
+        $this->assertSame("1", $accountType);
+
+        $this->assertTrue($document->nextDocumentPosition());
+
+        $document->getDocumentPositionReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("567", $accountId);
+        $this->assertSame("2", $accountType);
+
+        $this->assertTrue($document->nextDocumentPosition());
+
+        $document->getDocumentPositionReceivableSpecifiedTradeAccountingAccount($accountId, $accountType);
+
+        $this->assertSame("740", $accountId);
+        $this->assertSame("3", $accountType);
+    }
+}


### PR DESCRIPTION
# Description

Added methods to read ReceivableSpecifiedTradeAccountingAccounts on document- and position-level

Fixes #270 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
