### PR TITLE
#279 Add support for ApplicableTradePaymentPenaltyTerms (BG-X-43)

### DIFF
--- a/src/ZugferdDocumentBuilder.php
+++ b/src/ZugferdDocumentBuilder.php
@@ -2603,6 +2603,26 @@ class ZugferdDocumentBuilder extends ZugferdDocument
     }
 
     /**
+     * Add penalty Terms to last added payment term
+     *
+     * @param  float|null    $calculationPercent         __BT-X-280, From EXTENDED__ Percentage of the payment surcharge
+     * @param  DateTime|null $basisDateTime              __BT-X-276, From EXTENDED__ Due date reference date
+     * @param  float|null    $basisPeriodMeasureValue    __BT-X-277, From EXTENDED__ Maturity period (basis)
+     * @param  string|null   $basisPeriodMeasureUnitCode __BT-X-277, From EXTENDED__ Maturity period (unit)
+     * @param  float|null    $basisAmount                __BT-X-279, From EXTENDED__ Basic amount of the payment surcharge
+     * @param  float|null    $actualPenaltyAmount        __BT-X-281, From EXTENDED__ Amount of the payment surcharge
+     * @return ZugferdDocumentBuilder
+     */
+    public function addPenaltyTermsToPaymentTerms(?float $calculationPercent = null, ?DateTime $basisDateTime = null, ?float $basisPeriodMeasureValue = null, ?string $basisPeriodMeasureUnitCode = null, ?float $basisAmount = null, ?float $actualPenaltyAmount = null): ZugferdDocumentBuilder
+    {
+        $penaltyTerms = $this->getObjectHelper()->getTradePaymentPenaltyTermsType($basisDateTime, $basisPeriodMeasureValue, $basisPeriodMeasureUnitCode, $basisAmount, $calculationPercent, $actualPenaltyAmount);
+
+        $this->getObjectHelper()->tryCall($this->currentPaymentTerms, "setApplicableTradePaymentPenaltyTerms", $penaltyTerms);
+
+        return $this;
+    }
+
+    /**
      * Add a payment term in XRechnung-Style (in the Form #SKONTO#TAGE=14#PROZENT=1.00#BASISBETRAG=2.53#)
      *
      * @param  string        $description                __BT-20, From _EN 16931 XRECHNUNG__ Text to add

--- a/src/ZugferdDocumentReader.php
+++ b/src/ZugferdDocumentReader.php
@@ -2784,6 +2784,35 @@ class ZugferdDocumentReader extends ZugferdDocument
     }
 
     /**
+     * Get detailed information on payment penalties.
+     *
+     * @param  float|null    $calculationPercent         __BT-X-280, From EXTENDED__ Percentage of the payment surcharge
+     * @param  DateTime|null $basisDateTime              __BT-X-276, From EXTENDED__ Due date reference date
+     * @param  float|null    $basisPeriodMeasureValue    __BT-X-277, From EXTENDED__ Maturity period (basis)
+     * @param  string|null   $basisPeriodMeasureUnitCode __BT-X-277, From EXTENDED__ Maturity period (unit)
+     * @param  float|null    $basisAmount                __BT-X-279, From EXTENDED__ Basic amount of the payment surcharge
+     * @param  float|null    $actualPenaltyAmount        __BT-X-281, From EXTENDED__ Amount of the payment surcharge
+     * @return ZugferdDocumentReader
+     */
+    public function getPenaltyTermsFromPaymentTerm(?float &$calculationPercent, ?DateTime &$basisDateTime, ?float &$basisPeriodMeasureValue, ?string &$basisPeriodMeasureUnitCode, ?float &$basisAmount, ?float &$actualPenaltyAmount): ZugferdDocumentReader
+    {
+        $paymentTerms = $this->getObjectHelper()->ensureArray($this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeSettlement.getSpecifiedTradePaymentTerms", []));
+        $paymentTerms = $paymentTerms[$this->documentPaymentTermsPointer];
+
+        $calculationPercent = $this->getInvoiceValueByPathFrom($paymentTerms, "getApplicableTradePaymentPenaltyTerms.getCalculationPercent.value", 0.0);
+        $basisDateTime = $this->getObjectHelper()->toDateTime(
+            $this->getObjectHelper()->tryCallByPathAndReturn($paymentTerms, "getApplicableTradePaymentPenaltyTerms.getBasisDateTime.getDateTimeString.value"),
+            $this->getObjectHelper()->tryCallByPathAndReturn($paymentTerms, "getApplicableTradePaymentPenaltyTerms.getBasisDateTime.getDateTimeString.getFormat")
+        );
+        $basisPeriodMeasureValue = $this->getInvoiceValueByPathFrom($paymentTerms, "getApplicableTradePaymentPenaltyTerms.getBasisPeriodMeasure.value", 0.0);
+        $basisPeriodMeasureUnitCode = $this->getInvoiceValueByPathFrom($paymentTerms, "getApplicableTradePaymentPenaltyTerms.getBasisPeriodMeasure.getUnitCode", "");
+        $basisAmount = $this->getInvoiceValueByPathFrom($paymentTerms, "getApplicableTradePaymentPenaltyTerms.getBasisAmount.value", 0.0);
+        $actualPenaltyAmount = $this->getInvoiceValueByPathFrom($paymentTerms, "getApplicableTradePaymentPenaltyTerms.getActualPenaltyAmount.value", 0.0);
+
+        return $this;
+    }
+
+    /**
      * Seek to the first trade accounting account of the document. Returns true if a first account is available, otherwise false.
      * You may use this together with ZugferdDocumentReader::getDocumentSellerContact.
      *

--- a/src/ZugferdObjectHelper.php
+++ b/src/ZugferdObjectHelper.php
@@ -1002,6 +1002,34 @@ class ZugferdObjectHelper
     }
 
     /**
+     * Get instance of TradePaymentPenaltyTermsType
+     *
+     * @param  DateTime|null $basisDateTime
+     * @param  float|null    $basisPeriodMeasureValue
+     * @param  string|null   $basisPeriodMeasureUnitCode
+     * @param  float|null    $basisAmount
+     * @param  float|null    $calculationPercent
+     * @param  float|null    $actualPenaltyAmount
+     * @return object|null
+     */
+    public function getTradePaymentPenaltyTermsType(?DateTime $basisDateTime = null, ?float $basisPeriodMeasureValue = null, ?string $basisPeriodMeasureUnitCode = null, ?float $basisAmount = null, ?float $calculationPercent = null, ?float $actualPenaltyAmount = null): ?object
+    {
+        if (self::isAllNullOrEmpty(func_get_args())) {
+            return null;
+        }
+
+        $tradePaymentDiscountTermsType = $this->createClassInstance('ram\TradePaymentPenaltyTermsType');
+
+        $this->tryCall($tradePaymentDiscountTermsType, "setBasisDateTime", $this->getDateTimeType($basisDateTime));
+        $this->tryCall($tradePaymentDiscountTermsType, "setBasisPeriodMeasure", $this->getMeasureType($basisPeriodMeasureValue, $basisPeriodMeasureUnitCode));
+        $this->tryCall($tradePaymentDiscountTermsType, "setBasisAmount", $this->getAmountType($basisAmount));
+        $this->tryCall($tradePaymentDiscountTermsType, "setCalculationPercent", $this->getPercentType($calculationPercent));
+        $this->tryCall($tradePaymentDiscountTermsType, "setActualPenaltyAmount", $this->getAmountType($actualPenaltyAmount));
+
+        return $tradePaymentDiscountTermsType;
+    }
+
+    /**
      * Get instance of TradeTaxType
      * Sales tax breakdown, Umsatzsteueraufschlüsselung
      *

--- a/tests/assets/xml_extended_1.xml
+++ b/tests/assets/xml_extended_1.xml
@@ -338,8 +338,16 @@
                 <ram:Description>Skontovereinbarung: 2% bei Zahlung innerhalb 10 Tagen nach Rechnungsdatum</ram:Description>
                 <ram:ApplicableTradePaymentDiscountTerms>
                     <ram:BasisPeriodMeasure unitCode="DAY">10</ram:BasisPeriodMeasure>
+                    <ram:BasisAmount>480.22</ram:BasisAmount>
                     <ram:CalculationPercent>2.00</ram:CalculationPercent>
+                    <ram:ActualDiscountAmount>9.60</ram:ActualDiscountAmount>
                 </ram:ApplicableTradePaymentDiscountTerms>
+                <ram:ApplicableTradePaymentPenaltyTerms>
+                    <ram:BasisPeriodMeasure unitCode="DAY">30</ram:BasisPeriodMeasure>
+                    <ram:BasisAmount>480.22</ram:BasisAmount>
+                    <ram:CalculationPercent>5.00</ram:CalculationPercent>
+                    <ram:ActualPenaltyAmount>24.01</ram:ActualPenaltyAmount>
+                </ram:ApplicableTradePaymentPenaltyTerms>
             </ram:SpecifiedTradePaymentTerms>
             <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
                 <ram:LineTotalAmount>410.10</ram:LineTotalAmount>

--- a/tests/testcases/BuilderEn16931Test.php
+++ b/tests/testcases/BuilderEn16931Test.php
@@ -1657,6 +1657,28 @@ class BuilderEn16931Test extends TestCase
         $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1);
     }
 
+    public function testAddDocumentPaymentTermAndPenalty(): void
+    {
+        (self::$document)->addDocumentPaymentTerm("Payment", new DateTime(), "mandate");
+        (self::$document)->addPenaltyTermsToPaymentTerms(10.0, new DateTime(), 1, "DAY", 20.0, 2.0);
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 0, "Payment");
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 0, (new DateTime())->format("Ymd"), "format", "102");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 0, "mandate");
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:ActualPenaltyAmount', 0);
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 1);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 1);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1);
+    }
+
     public function testAddDocumentPaymentTermXRechnung(): void
     {
         (self::$document)->addDocumentPaymentTermXRechnung("", [14], [2], [100], new DateTime(), "mandate");

--- a/tests/testcases/BuilderExtendedTest.php
+++ b/tests/testcases/BuilderExtendedTest.php
@@ -1712,6 +1712,32 @@ class BuilderExtendedTest extends TestCase
         $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1);
     }
 
+    public function testAddDocumentPaymentTermAndPenalty(): void
+    {
+        (self::$document)->addDocumentPaymentTerm("Payment", new DateTime(), "mandate");
+        (self::$document)->addPenaltyTermsToPaymentTerms(10.0, new DateTime(), 1, "DAY", 20.0, 2.0);
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 0, "Payment");
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 0, (new DateTime())->format("Ymd"), "format", "102");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 0, "mandate");
+
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 1, "Payment");
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 1, (new DateTime())->format("Ymd"), "format", "102");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1, "mandate");
+
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString', 0, (new \DateTime())->format("Ymd"), "format", "102");
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure', 0, "1.0", "unitCode", "DAY");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount', 0, "20.0");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent', 0, "10.0");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:ActualPenaltyAmount', 0, "2.0");
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 2);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 2);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 2);
+    }
+
     public function testAddDocumentPaymentTermXRechnung(): void
     {
         (self::$document)->addDocumentPaymentTermXRechnung("", [14], [2], [100], new DateTime(), "mandate");
@@ -1722,9 +1748,13 @@ class BuilderExtendedTest extends TestCase
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 0, (new \DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 0, "mandate");
 
-        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 1);
-        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 1);
-        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1);
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 1, "Payment");
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 1, (new DateTime())->format("Ymd"), "format", "102");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1, "mandate");
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 2);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 2);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 2);
 
         (self::$document)->addDocumentPaymentTermXRechnung("Payment", [], [], [], new DateTime(), "mandate");
 
@@ -1738,6 +1768,14 @@ class BuilderExtendedTest extends TestCase
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 1, (new DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1, "mandate");
 
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 2, "Payment");
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 2, (new DateTime())->format("Ymd"), "format", "102");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 2, "mandate");
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 3);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 3);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 3);
+
         (self::$document)->addDocumentPaymentTermXRechnung("Payment", [14], [2], [100], new DateTime(), "mandate");
 
         $this->disableRenderXmlContent();
@@ -1750,9 +1788,13 @@ class BuilderExtendedTest extends TestCase
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 1, (new DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1, "mandate");
 
-        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 2, "#SKONTO#TAGE=14#PROZENT=2.00#BASISBETRAG=100.00#\nPayment");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 2, "Payment");
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 2, (new DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 2, "mandate");
+
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 3, "#SKONTO#TAGE=14#PROZENT=2.00#BASISBETRAG=100.00#\nPayment");
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 3, (new DateTime())->format("Ymd"), "format", "102");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 3, "mandate");
 
         (self::$document)->addDocumentPaymentTermXRechnung("Payment", [14], [2], [], new DateTime(), "mandate");
 
@@ -1766,13 +1808,17 @@ class BuilderExtendedTest extends TestCase
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 1, (new DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1, "mandate");
 
-        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 2, "#SKONTO#TAGE=14#PROZENT=2.00#BASISBETRAG=100.00#\nPayment");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 2, "Payment");
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 2, (new DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 2, "mandate");
 
-        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 3, "#SKONTO#TAGE=14#PROZENT=2.00#\nPayment");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 3, "#SKONTO#TAGE=14#PROZENT=2.00#BASISBETRAG=100.00#\nPayment");
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 3, (new DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 3, "mandate");
+
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 4, "#SKONTO#TAGE=14#PROZENT=2.00#\nPayment");
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 4, (new DateTime())->format("Ymd"), "format", "102");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 4, "mandate");
     }
 
     public function testAddDocumentPaymenTermAndhPartialPaymentAmount(): void
@@ -1789,17 +1835,21 @@ class BuilderExtendedTest extends TestCase
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 1, (new DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1, "mandate");
 
-        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 2, "#SKONTO#TAGE=14#PROZENT=2.00#BASISBETRAG=100.00#\nPayment");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 2, "Payment");
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 2, (new DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 2, "mandate");
 
-        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 3, "#SKONTO#TAGE=14#PROZENT=2.00#\nPayment");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 3, "#SKONTO#TAGE=14#PROZENT=2.00#BASISBETRAG=100.00#\nPayment");
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 3, (new DateTime())->format("Ymd"), "format", "102");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 3, "mandate");
 
-        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 4, "Payment with partial payment amount");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 4, "#SKONTO#TAGE=14#PROZENT=2.00#\nPayment");
         $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 4, (new DateTime())->format("Ymd"), "format", "102");
-        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 4, "mandate with partial payment amount");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 4, "mandate");
+
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 5, "Payment with partial payment amount");
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 5, (new DateTime())->format("Ymd"), "format", "102");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 5, "mandate with partial payment amount");
         $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:PartialPaymentAmount', 0, 100.0);
         $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:PartialPaymentAmount', 1);
     }

--- a/tests/testcases/BuilderMinimumTest.php
+++ b/tests/testcases/BuilderMinimumTest.php
@@ -1697,6 +1697,28 @@ class BuilderMinimumTest extends TestCase
         $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1);
     }
 
+    public function testAddDocumentPaymentTermAndPenalty(): void
+    {
+        (self::$document)->addDocumentPaymentTerm("Payment", new DateTime(), "mandate");
+        (self::$document)->addPenaltyTermsToPaymentTerms(10.0, new DateTime(), 1, "DAY", 20.0, 2.0);
+
+        $this->disableRenderXmlContent();
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 0);
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent', 0);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:ApplicableTradePaymentPenaltyTerms/ram:ActualPenaltyAmount', 0);
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:Description', 1);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime/udt:DateTimeString', 1);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID', 1);
+    }
+
     public function testAddDocumentPaymentTermXRechnung(): void
     {
         (self::$document)->addDocumentPaymentTermXRechnung("", [14], [2], [100], new DateTime(), "mandate");

--- a/tests/testcases/ObjectHelperEn16931Test.php
+++ b/tests/testcases/ObjectHelperEn16931Test.php
@@ -1026,6 +1026,24 @@ class ObjectHelperEn16931Test extends TestCase
         $this->assertNull($discountterms);
     }
 
+    public function testGetTradePaymentPenaltyTermsTypeAllValues(): void
+    {
+        /**
+         * @var \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType
+         */
+        $penaltyterms = self::$objectHelper->getTradePaymentPenaltyTermsType(new \DateTime(), 2, "DAY", 1, 1, 1);
+        $this->assertNull($penaltyterms);
+    }
+
+    public function testGetTradePaymentPenaltyTermsTypeAllNull(): void
+    {
+        /**
+         * @var \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType
+         */
+        $penaltyterms = self::$objectHelper->getTradePaymentPenaltyTermsType(null, null, null, null, null, null);
+        $this->assertNull($penaltyterms);
+    }
+
     public function testGetTradeTaxTypeAllValues(): void
     {
         /**

--- a/tests/testcases/ObjectHelperExtendedTest.php
+++ b/tests/testcases/ObjectHelperExtendedTest.php
@@ -1040,6 +1040,36 @@ class ObjectHelperExtendedTest extends TestCase
         $this->assertNull($discountterms);
     }
 
+    public function testGetTradePaymentPenaltyTermsTypeAllValues(): void
+    {
+        /**
+         * @var \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType
+         */
+        $penaltyterms = self::$objectHelper->getTradePaymentPenaltyTermsType(new \DateTime(), 2, "DAY", 1, 1, 1);
+
+        /**
+         * @var \horstoeko\zugferd\entities\extended\udt\PercentType
+         */
+        $calculationpercent = $penaltyterms->getCalculationPercent();
+
+        $this->assertEquals((new \DateTime())->format("Ymd"), $penaltyterms->getBasisDateTime()->getDateTimeString());
+        $this->assertEquals("102", $penaltyterms->getBasisDateTime()->getDateTimeString()->getFormat());
+        $this->assertEquals(2, $penaltyterms->getBasisPeriodMeasure()->value());
+        $this->assertEquals("DAY", $penaltyterms->getBasisPeriodMeasure()->getUnitCode());
+        $this->assertEquals(1, $penaltyterms->getBasisAmount()->value());
+        $this->assertEquals(1, $calculationpercent->value());
+        $this->assertEquals(1, $penaltyterms->getActualPenaltyAmount()->value());
+    }
+
+    public function testGetTradePaymentPenaltyTermsTypeAllNull(): void
+    {
+        /**
+         * @var \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType
+         */
+        $penaltyterms = self::$objectHelper->getTradePaymentPenaltyTermsType(null, null, null, null, null, null);
+        $this->assertNull($penaltyterms);
+    }
+
     public function testGetTradeTaxTypeAllValues(): void
     {
         /**

--- a/tests/testcases/PdfReaderEn16931AllowanceChargeTest.php
+++ b/tests/testcases/PdfReaderEn16931AllowanceChargeTest.php
@@ -956,6 +956,7 @@ class PdfReaderEn16931AllowanceChargeTest extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("Zahlbar innerhalb 30 Tagen netto bis 04.07.2018, 3% Skonto innerhalb 10 Tagen bis 15.06.2018", $termdescription);
         $this->assertNotInstanceOf(\DateTime::class, $termduedate);
@@ -966,6 +967,11 @@ class PdfReaderEn16931AllowanceChargeTest extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/PdfReaderEn16931Test.php
+++ b/tests/testcases/PdfReaderEn16931Test.php
@@ -898,6 +898,7 @@ class PdfReaderEn16931Test extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018", $termdescription);
         $this->assertNotInstanceOf(\DateTime::class, $termduedate);
@@ -908,6 +909,11 @@ class PdfReaderEn16931Test extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/PdfReaderExtended2Test.php
+++ b/tests/testcases/PdfReaderExtended2Test.php
@@ -965,6 +965,7 @@ class PdfReaderExtended2Test extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("", $termdescription);
         $this->assertInstanceOf("DateTime", $termduedate);
@@ -976,6 +977,11 @@ class PdfReaderExtended2Test extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/PdfReaderExtendedTest.php
+++ b/tests/testcases/PdfReaderExtendedTest.php
@@ -962,6 +962,7 @@ class PdfReaderExtendedTest extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("Skontovereinbarung: 2% bei Zahlung innerhalb 10 Tagen nach Rechnungsdatum", $termdescription);
         $this->assertNotInstanceOf(\DateTime::class, $termduedate);
@@ -972,6 +973,11 @@ class PdfReaderExtendedTest extends TestCase
         $this->assertSame("DAY", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/PdfReaderXRechnungTest.php
+++ b/tests/testcases/PdfReaderXRechnungTest.php
@@ -914,6 +914,7 @@ class PdfReaderXRechnungTest extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018", $termdescription);
         $this->assertNotInstanceOf(\DateTime::class, $termduedate);
@@ -924,6 +925,11 @@ class PdfReaderXRechnungTest extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/ReaderBasicTest.php
+++ b/tests/testcases/ReaderBasicTest.php
@@ -907,6 +907,7 @@ class ReaderBasicTest extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("", $termdescription);
         $this->assertInstanceOf(\DateTime::class, $termduedate);
@@ -917,6 +918,11 @@ class ReaderBasicTest extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/ReaderEn16931AllowanceChargeTest.php
+++ b/tests/testcases/ReaderEn16931AllowanceChargeTest.php
@@ -971,6 +971,7 @@ class ReaderEn16931AllowanceChargeTest extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("Zahlbar innerhalb 30 Tagen netto bis 04.07.2018, 3% Skonto innerhalb 10 Tagen bis 15.06.2018", $termdescription);
         $this->assertNotInstanceOf(\DateTime::class, $termduedate);
@@ -981,6 +982,11 @@ class ReaderEn16931AllowanceChargeTest extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/ReaderEn16931Bank1Test.php
+++ b/tests/testcases/ReaderEn16931Bank1Test.php
@@ -102,6 +102,7 @@ class ReaderEn16931Bank1Test extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", $termdescription);
         $this->assertNotInstanceOf(\DateTime::class, $termduedate);
@@ -112,6 +113,11 @@ class ReaderEn16931Bank1Test extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/ReaderEn16931Bank2Test.php
+++ b/tests/testcases/ReaderEn16931Bank2Test.php
@@ -84,6 +84,7 @@ class ReaderEn16931Bank2Test extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("", $termdescription);
         $this->assertEquals((\DateTime::createFromFormat('Ymd', '20200215'))->format('Ymd'), $termduedate->format('Ymd'));
@@ -94,6 +95,11 @@ class ReaderEn16931Bank2Test extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/ReaderEn16931Test.php
+++ b/tests/testcases/ReaderEn16931Test.php
@@ -929,6 +929,7 @@ class ReaderEn16931Test extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018", $termdescription);
         $this->assertNotInstanceOf(\DateTime::class, $termduedate);
@@ -939,6 +940,11 @@ class ReaderEn16931Test extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/ReaderExtended2Test.php
+++ b/tests/testcases/ReaderExtended2Test.php
@@ -981,6 +981,7 @@ class ReaderExtended2Test extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("", $termdescription);
         $this->assertInstanceOf("DateTime", $termduedate);
@@ -992,6 +993,11 @@ class ReaderExtended2Test extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/ReaderExtendedTest.php
+++ b/tests/testcases/ReaderExtendedTest.php
@@ -1040,6 +1040,7 @@ class ReaderExtendedTest extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("Skontovereinbarung: 2% bei Zahlung innerhalb 10 Tagen nach Rechnungsdatum", $termdescription);
         $this->assertNotInstanceOf(\DateTime::class, $termduedate);
@@ -1048,8 +1049,13 @@ class ReaderExtendedTest extends TestCase
         $this->assertNotInstanceOf(\DateTime::class, $discbasedatetime);
         $this->assertEquals(10, $discmeasureval);
         $this->assertSame("DAY", $discmeasureunit);
-        $this->assertEquals(0, $discbaseamount);
-        $this->assertEquals(0, $discamount);
+        $this->assertEquals(480.22, $discbaseamount);
+        $this->assertEquals(9.60, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(30, $penaltymeasureval);
+        $this->assertSame("DAY", $penaltymeasureunit);
+        $this->assertEquals(480.22, $penaltybaseamount);
+        $this->assertEquals(24.01, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }

--- a/tests/testcases/ReaderXRechnungTest.php
+++ b/tests/testcases/ReaderXRechnungTest.php
@@ -930,6 +930,7 @@ class ReaderXRechnungTest extends TestCase
         $this->assertTrue(self::$document->firstDocumentPaymentTerms());
         self::$document->getDocumentPaymentTerm($termdescription, $termduedate, $termmandate);
         self::$document->getDiscountTermsFromPaymentTerm($dispercent, $discbasedatetime, $discmeasureval, $discmeasureunit, $discbaseamount, $discamount);
+        self::$document->getPenaltyTermsFromPaymentTerm($penaltypercent, $penaltybasedatetime, $penaltymeasureval, $penaltymeasureunit, $penaltybaseamount, $penaltyamount);
 
         $this->assertSame("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018", $termdescription);
         $this->assertNotInstanceOf(\DateTime::class, $termduedate);
@@ -940,6 +941,11 @@ class ReaderXRechnungTest extends TestCase
         $this->assertSame("", $discmeasureunit);
         $this->assertEquals(0, $discbaseamount);
         $this->assertEquals(0, $discamount);
+        $this->assertNotInstanceOf(\DateTime::class, $penaltybasedatetime);
+        $this->assertEquals(0, $penaltymeasureval);
+        $this->assertSame("", $penaltymeasureunit);
+        $this->assertEquals(0, $penaltybaseamount);
+        $this->assertEquals(0, $penaltyamount);
 
         $this->assertFalse(self::$document->nextDocumentPaymentTerms());
     }


### PR DESCRIPTION
# Description

Addes support for ApplicableTradePaymentPenaltyTerms (BG-X-43). This includes all attributes for ApplicableTradePaymentPenaltyTerms

Fixes #279 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

All Unit Tests for ``ZugferdDocumentBuilder`` and ``ZugferdDocumentReader``