### PR TITLE
#286 Changed PDF Conformancelevel for Profile XRechnung to "XRECHNUNG"

### DIFF
--- a/src/ZugferdProfiles.php
+++ b/src/ZugferdProfiles.php
@@ -146,7 +146,7 @@ class ZugferdProfiles
             'alternativecontextparameters' => [],
             'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
-            'xmpname' => 'EN 16931',
+            'xmpname' => 'XRECHNUNG',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
             'schematronfilename' => 'FACTUR-X_EN16931.sch',
             'xsltfilename' => "FACTUR-X_EN16931.xslt"
@@ -161,7 +161,7 @@ class ZugferdProfiles
             'alternativecontextparameters' => [],
             'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
-            'xmpname' => 'EN 16931',
+            'xmpname' => 'XRECHNUNG',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
             'schematronfilename' => 'FACTUR-X_EN16931.sch',
             'xsltfilename' => "FACTUR-X_EN16931.xslt"
@@ -176,7 +176,7 @@ class ZugferdProfiles
             'alternativecontextparameters' => [],
             'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
-            'xmpname' => 'EN 16931',
+            'xmpname' => 'XRECHNUNG',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
             'schematronfilename' => 'FACTUR-X_EN16931.sch',
             'xsltfilename' => "FACTUR-X_EN16931.xslt"
@@ -191,7 +191,7 @@ class ZugferdProfiles
             'alternativecontextparameters' => [],
             'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
-            'xmpname' => 'EN 16931',
+            'xmpname' => 'XRECHNUNG',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
             'schematronfilename' => 'FACTUR-X_EN16931.sch',
             'xsltfilename' => "FACTUR-X_EN16931.xslt"
@@ -220,7 +220,7 @@ class ZugferdProfiles
             'alternativecontextparameters' => [],
             'businessprocess' => null,
             'attachmentfilename' => 'xrechnung.xml',
-            'xmpname' => 'EN 16931',
+            'xmpname' => 'XRECHNUNG',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
             'schematronfilename' => 'FACTUR-X_EN16931.sch',
             'xsltfilename' => "FACTUR-X_EN16931.xslt"
@@ -235,7 +235,7 @@ class ZugferdProfiles
             'alternativecontextparameters' => [],
             'businessprocess' => 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
             'attachmentfilename' => 'xrechnung.xml',
-            'xmpname' => 'EN 16931',
+            'xmpname' => 'XRECHNUNG',
             'xsdfilename' => 'FACTUR-X_EN16931.xsd',
             'schematronfilename' => 'FACTUR-X_EN16931.sch',
             'xsltfilename' => "FACTUR-X_EN16931.xslt"

--- a/tests/testcases/ReaderXRechnungAttachedBinaryObjectTest.php
+++ b/tests/testcases/ReaderXRechnungAttachedBinaryObjectTest.php
@@ -41,7 +41,7 @@ class ReaderXRechnungAttachedBinaryObjectTest extends TestCase
         $this->assertEquals('XRECHNUNG', self::$document->getProfileDefinitionParameter('altname'));
         $this->assertEquals('urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.0', self::$document->getProfileDefinitionParameter('contextparameter'));
         $this->assertEquals('xrechnung.xml', self::$document->getProfileDefinitionParameter('attachmentfilename'));
-        $this->assertEquals('EN 16931', self::$document->getProfileDefinitionParameter('xmpname'));
+        $this->assertEquals('XRECHNUNG', self::$document->getProfileDefinitionParameter('xmpname'));
         $this->expectNoticeOrWarningExt(
             function () {
                 self::$document->getProfileDefinitionParameter('unknownparameter');

--- a/tests/testcases/ReaderXRechnungTest.php
+++ b/tests/testcases/ReaderXRechnungTest.php
@@ -40,7 +40,7 @@ class ReaderXRechnungTest extends TestCase
         $this->assertEquals('XRECHNUNG', self::$document->getProfileDefinitionParameter('altname'));
         $this->assertEquals('urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_1.2', self::$document->getProfileDefinitionParameter('contextparameter'));
         $this->assertEquals('xrechnung.xml', self::$document->getProfileDefinitionParameter('attachmentfilename'));
-        $this->assertEquals('EN 16931', self::$document->getProfileDefinitionParameter('xmpname'));
+        $this->assertEquals('XRECHNUNG', self::$document->getProfileDefinitionParameter('xmpname'));
         $this->expectNoticeOrWarningExt(
             function () {
                 self::$document->getProfileDefinitionParameter('unknownparameter');


### PR DESCRIPTION
# Description

Changed PDF Conformancelevel for Profile XRechnung to "XRECHNUNG"

Fixes #286 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)