### PR TITLE
#299 ZugferdDocumentReader::getDocumentDeliveryTerms uses the wrong path

### DIFF
--- a/src/ZugferdDocumentReader.php
+++ b/src/ZugferdDocumentReader.php
@@ -1920,7 +1920,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      */
     public function getDocumentDeliveryTerms(?string &$code): ZugferdDocumentReader
     {
-        $code = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getApplicableTradeDeliveryTerms.setDeliveryTypeCode.value", "");
+        $code = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getApplicableTradeDeliveryTerms.getDeliveryTypeCode.value", "");
 
         return $this;
     }


### PR DESCRIPTION
# Description

DocumentReader uses a wrong path to extract BT-X-145

Fixes #299 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
