### PR TITLE
Allow XML documents with non-default namespace prefixes Issue

### DIFF
--- a/src/ZugferdProfileResolver.php
+++ b/src/ZugferdProfileResolver.php
@@ -42,6 +42,8 @@ class ZugferdProfileResolver
         try {
             libxml_clear_errors();
             $xmldocument = new SimpleXMLElement($xmlContent);
+            $xmldocument->registerXPathNamespace("rsm", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100");
+            $xmldocument->registerXPathNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
             $typeelement = $xmldocument->xpath('/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID');
             if (libxml_get_last_error()) {
                 throw new ZugferdUnknownXmlContentException();


### PR DESCRIPTION
# Description
Allow XML documents with non-default namespace prefixes. Although this is uncommon, validators such as the KoSIT Validator for XRechnung allow it. Online Version (German): https://erechnungsvalidator.service-bw.de/
Resolves #331 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Try parsing the attached file with non default namespaces. After the deserialization is performed, the default prefixes can be used internally. 
[non_default_namespaces.xml](https://github.com/user-attachments/files/23583743/non_default_namespaces.xml)