### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,10 @@
         "setasign/fpdf": "^1",
         "setasign/fpdi": "^2",
         "smalot/pdfparser": "^0|^2",
-        "symfony/finder": "^5|^6|^7",
-        "symfony/process": "^5|^6|^7",
-        "symfony/validator": "^5|^6|^7",
-        "symfony/yaml": "^5|^6|^7"
+        "symfony/finder": "^5|^6|^7|^8",
+        "symfony/process": "^5|^6|^7|^8",
+        "symfony/validator": "^5|^6|^7|^8",
+        "symfony/yaml": "^5|^6|^7|^8"
     },
     "require-dev": {
         "goetas-webservices/xsd2php": "^0",


### PR DESCRIPTION
Extend symfony to version 8.x

Fixes #336 

Known Problems:
goetas-webservices/xsd2php also uses Symfony 7.x component. 