### PR TITLE
Fix handling of already truncated 4 digit credit card numbers

### DIFF
--- a/src/ZugferdObjectHelper.php
+++ b/src/ZugferdObjectHelper.php
@@ -857,7 +857,7 @@ class ZugferdObjectHelper
         // At the moment PCI Security Standards Council has defined that the first 6 digits and
         // last 4 digits are the maximum number of digits to be shown.
 
-        $id = substr($id, 0, 6) . substr($id, -4);
+        $id = strlen($id) > 4 ? substr($id, 0, 6) . substr($id, -4) : $id;
 
         $tradeSettlementFinancialCardType = $this->createClassInstance('ram\TradeSettlementFinancialCardType');
 

--- a/tests/testcases/ObjectHelperEn16931Test.php
+++ b/tests/testcases/ObjectHelperEn16931Test.php
@@ -906,6 +906,17 @@ class ObjectHelperEn16931Test extends TestCase
         $this->assertEquals("name", $fincard->getCardholderName());
     }
 
+    public function testGetTradeSettlementFinancialCardType4DigitValue(): void
+    {
+        /**
+         * @var \horstoeko\zugferd\entities\en16931\ram\TradeSettlementFinancialCardType
+         */
+        $fincard = self::$objectHelper->getTradeSettlementFinancialCardType("type", "8453", "name");
+        $this->assertEquals("type", $fincard->getID()->getSchemeID());
+        $this->assertEquals("8453", $fincard->getID());
+        $this->assertEquals("name", $fincard->getCardholderName());
+    }
+
     public function testGetTradeSettlementFinancialCardTypeAllNull(): void
     {
         /**

--- a/tests/testcases/ObjectHelperExtendedTest.php
+++ b/tests/testcases/ObjectHelperExtendedTest.php
@@ -908,6 +908,17 @@ class ObjectHelperExtendedTest extends TestCase
         $this->assertEquals("name", $fincard->getCardholderName());
     }
 
+    public function testGetTradeSettlementFinancialCardType4DigitValue(): void
+    {
+        /**
+         * @var \horstoeko\zugferd\entities\en16931\ram\TradeSettlementFinancialCardType
+         */
+        $fincard = self::$objectHelper->getTradeSettlementFinancialCardType("type", "8453", "name");
+        $this->assertEquals("type", $fincard->getID()->getSchemeID());
+        $this->assertEquals("8453", $fincard->getID());
+        $this->assertEquals("name", $fincard->getCardholderName());
+    }
+
     public function testGetTradeSettlementFinancialCardTypeAllNull(): void
     {
         /**


### PR DESCRIPTION
# Description

This pull request updates the logic for masking financial card IDs in the `getTradeSettlementFinancialCardType` method to handle short values correctly, and adds new tests to ensure this behavior is covered.

Logic update for card ID masking:

* Updated `getTradeSettlementFinancialCardType` in `ZugferdObjectHelper.php` to only mask card IDs longer than 4 digits; if the ID is 4 digits or fewer, it is left unchanged.
* Previous an already truncated credit card number like `1234` resulted in `12341234`.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added `testGetTradeSettlementFinancialCardType4DigitValue` to both `ObjectHelperEn16931Test.php` and `ObjectHelperExtendedTest.php` to verify that 4-digit card IDs are not masked and are returned as-is. [[1]](diffhunk://#diff-61a1809cd554a5e6b2d5942dedc7e818560f0053fc7ce8a43d1dbe853b8ede03R909-R919) [[2]](diffhunk://#diff-7ebeba44d9edaa008ee56120e1ba912a8b1927d79afb0b881b06bb51b5d43e8cR911-R921)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas => I would say that is not relevant here.
- [ ] I have made corresponding changes to the documentation => I am not sure about this.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules => None