### PR TITLE
feat: add MIME code and filename output parameters to `getDocumentAdditionalReferencedDocument`

### DIFF
--- a/src/ZugferdDocumentReader.php
+++ b/src/ZugferdDocumentReader.php
@@ -2051,10 +2051,12 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  array|null    $name               __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
      * @param  string|null   $refTypeCode        __BT-, From __ The identifier for the identification scheme of the identifier of the item invoiced. If it is not clear to the recipient which scheme is used for the identifier, an identifier of the scheme should be used, which must be selected from UNTDID 1153 in accordance with the code list entries.
      * @param  DateTime|null $issueDate          __BT-X-149, From EXTENDED__ Document date
-     * @param  string|null   $binaryDataFilename __BT-125, From EN 16931__ Contains a file name of an attachment document embedded as a binary object
+     * @param  string|null   $binaryDataFilename __BT-125, From EN 16931__ Contains the content located at the path $this->binarydatadirectory + filename of the embedded binary object Attachment
+     * @param  string|null   $binaryMimeCode     __BT-125-1 From _EN 16931__ Contains the mime code of the embedded binary object Attachment
+     * @param  string|null   $binaryFilename     __BT-125-2 From _EN 16931__ Contains the filename of the embedded binary object Attachment
      * @return ZugferdDocumentReader
      */
-    public function getDocumentAdditionalReferencedDocument(?string &$issuerAssignedId, ?string &$typeCode, ?string &$uriId, ?array &$name, ?string &$refTypeCode, ?DateTime &$issueDate, ?string &$binaryDataFilename): ZugferdDocumentReader
+    public function getDocumentAdditionalReferencedDocument(?string &$issuerAssignedId, ?string &$typeCode, ?string &$uriId, ?array &$name, ?string &$refTypeCode, ?DateTime &$issueDate, ?string &$binaryDataFilename, ?string &$binaryMimeCode = null, ?string &$binaryFilename = null): ZugferdDocumentReader
     {
         $addRefDoc = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getAdditionalReferencedDocument", []);
         $addRefDoc = $addRefDoc[$this->documentAddRefDocPointer];
@@ -2069,16 +2071,17 @@ class ZugferdDocumentReader extends ZugferdDocument
             $this->getInvoiceValueByPathFrom($addRefDoc, "getFormattedIssueDateTime.getDateTimeString.getFormat", "")
         );
 
-        $binaryDataFilename = $this->getInvoiceValueByPathFrom($addRefDoc, "getAttachmentBinaryObject.getFilename", "");
-        $binarydata = $this->getInvoiceValueByPathFrom($addRefDoc, "getAttachmentBinaryObject.value", "");
+        $binaryMimeCode = $this->getInvoiceValueByPathFrom($addRefDoc, "getAttachmentBinaryObject.getMimeCode", null);
+        $binaryFilename = $this->getInvoiceValueByPathFrom($addRefDoc, "getAttachmentBinaryObject.getFilename", null);
+        $binaryObject = $this->getInvoiceValueByPathFrom($addRefDoc, "getAttachmentBinaryObject.value", null);
 
         if (
-            StringUtils::stringIsNullOrEmpty($binaryDataFilename) === false
-            && StringUtils::stringIsNullOrEmpty($binarydata) === false
+            StringUtils::stringIsNullOrEmpty($binaryFilename) === false
+            && StringUtils::stringIsNullOrEmpty($binaryObject) === false
             && StringUtils::stringIsNullOrEmpty($this->binarydatadirectory) === false
         ) {
-            $binaryDataFilename = PathUtils::combinePathWithFile($this->binarydatadirectory, $binaryDataFilename);
-            FileUtils::base64ToFile($binarydata, $binaryDataFilename);
+            $binaryDataFilename = PathUtils::combinePathWithFile($this->binarydatadirectory, $binaryFilename);
+            FileUtils::base64ToFile($binaryObject, $binaryDataFilename);
         } else {
             $binaryDataFilename = "";
         }

--- a/tests/testcases/PdfReaderExtended2Test.php
+++ b/tests/testcases/PdfReaderExtended2Test.php
@@ -848,7 +848,7 @@ class PdfReaderExtended2Test extends TestCase
     public function testGetDocumentAdditionalReferencedDocument(): void
     {
         $this->assertTrue(self::$document->firstDocumentAdditionalReferencedDocument());
-        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename);
+        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename, $binarymimecode, $binaryfilename);
         $this->assertSame("SUPPort doc", $issuerassignedid);
         $this->assertSame("916", $typecode);
         $this->assertSame("url:gffter", $uriid);
@@ -859,6 +859,8 @@ class PdfReaderExtended2Test extends TestCase
         $this->assertSame("", $reftypecode);
         $this->assertNotInstanceOf(\DateTime::class, $issueddate);
         $this->assertSame("", $binarydatafilename);
+        $this->assertNull($binarymimecode);
+        $this->assertNull($binaryfilename);
     }
 
     public function testDocumentUltimateCustomerOrderReferencedDocumentLoop(): void

--- a/tests/testcases/PdfReaderExtendedTest.php
+++ b/tests/testcases/PdfReaderExtendedTest.php
@@ -859,7 +859,7 @@ class PdfReaderExtendedTest extends TestCase
     public function testGetDocumentAdditionalReferencedDocument(): void
     {
         $this->assertTrue(self::$document->firstDocumentAdditionalReferencedDocument());
-        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename);
+        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename, $binarymimecode, $binaryfilename);
         $this->assertSame("A777123", $issuerassignedid);
         $this->assertSame("130", $typecode);
         $this->assertSame("", $uriid);
@@ -868,6 +868,8 @@ class PdfReaderExtendedTest extends TestCase
         $this->assertSame("", $reftypecode);
         $this->assertNotInstanceOf(\DateTime::class, $issueddate);
         $this->assertSame("", $binarydatafilename);
+        $this->assertNull($binarymimecode);
+        $this->assertNull($binaryfilename);
     }
 
     public function testDocumentUltimateCustomerOrderReferencedDocumentLoop(): void

--- a/tests/testcases/ReaderExtended2Test.php
+++ b/tests/testcases/ReaderExtended2Test.php
@@ -865,7 +865,7 @@ class ReaderExtended2Test extends TestCase
     public function testGetDocumentAdditionalReferencedDocument(): void
     {
         $this->assertTrue(self::$document->firstDocumentAdditionalReferencedDocument());
-        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename);
+        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename, $binarymimecode, $binaryfilename);
         $this->assertSame("SUPPort doc", $issuerassignedid);
         $this->assertSame("916", $typecode);
         $this->assertSame("url:gffter", $uriid);
@@ -876,6 +876,8 @@ class ReaderExtended2Test extends TestCase
         $this->assertSame("", $reftypecode);
         $this->assertNotInstanceOf(\DateTime::class, $issueddate);
         $this->assertSame("", $binarydatafilename);
+        $this->assertNull($binarymimecode);
+        $this->assertNull($binaryfilename);
     }
 
     public function testDocumentUltimateCustomerOrderReferencedDocumentLoop(): void

--- a/tests/testcases/ReaderExtendedTest.php
+++ b/tests/testcases/ReaderExtendedTest.php
@@ -902,7 +902,7 @@ class ReaderExtendedTest extends TestCase
     public function testGetDocumentAdditionalReferencedDocument(): void
     {
         $this->assertTrue(self::$document->firstDocumentAdditionalReferencedDocument());
-        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename);
+        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename, $binarymimecode, $binaryfilename);
         $this->assertSame("A777123", $issuerassignedid);
         $this->assertSame("130", $typecode);
         $this->assertSame("", $uriid);
@@ -911,6 +911,8 @@ class ReaderExtendedTest extends TestCase
         $this->assertSame("", $reftypecode);
         $this->assertNotInstanceOf(\DateTime::class, $issueddate);
         $this->assertSame("", $binarydatafilename);
+        $this->assertNull($binarymimecode);
+        $this->assertNull($binaryfilename);
     }
 
     public function testDocumentInvoiceReferencedDocumentLoop(): void

--- a/tests/testcases/ReaderXRechnungAttachedBinaryObjectTest.php
+++ b/tests/testcases/ReaderXRechnungAttachedBinaryObjectTest.php
@@ -71,7 +71,7 @@ class ReaderXRechnungAttachedBinaryObjectTest extends TestCase
 
     public function testGetDocumentAdditionalReferencedDocumentNoDirectorySet(): void
     {
-        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename);
+        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename, $binarymimecode, $binaryfilename);
         $this->assertSame("01_15_Anhang_01.pdf", $issuerassignedid);
         $this->assertSame("916", $typecode);
         $this->assertArrayHasKey(0, $name);
@@ -79,12 +79,14 @@ class ReaderXRechnungAttachedBinaryObjectTest extends TestCase
         $this->assertEquals("Aufschlüsselung der einzelnen Leistungspositionen", $name[0]);
         $this->assertSame("", $binarydatafilename);
         $this->assertFileDoesNotExist($binarydatafilename);
+        $this->assertSame("application/pdf", $binarymimecode);
+        $this->assertSame("01_15_Anhang_01.pdf", $binaryfilename);
     }
 
     public function testGetDocumentAdditionalReferencedDocument(): void
     {
         self::$document->setBinaryDataDirectory(__DIR__);
-        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename);
+        self::$document->getDocumentAdditionalReferencedDocument($issuerassignedid, $typecode, $uriid, $name, $reftypecode, $issueddate, $binarydatafilename, $binarymimecode, $binaryfilename);
         $this->assertSame("01_15_Anhang_01.pdf", $issuerassignedid);
         $this->assertSame("916", $typecode);
         $this->assertArrayHasKey(0, $name);
@@ -95,6 +97,8 @@ class ReaderXRechnungAttachedBinaryObjectTest extends TestCase
         $this->assertFileExists($binarydatafilename);
         $this->assertSame(150128, filesize($binarydatafilename));
         $this->assertSame("%PDF", substr(file_get_contents($binarydatafilename), 0, 4));
+        $this->assertSame("application/pdf", $binarymimecode);
+        $this->assertSame("01_15_Anhang_01.pdf", $binaryfilename);
         @unlink($binarydatafilename);
     }
 


### PR DESCRIPTION
## Summary

Extends `getDocumentAdditionalReferencedDocument` with two new optional output parameters to expose the MIME type and original filename of an embedded binary attachment:

- `$binaryMimeCode` — reads `AttachmentBinaryObject/@mimeCode` (e.g. `application/pdf`)
- `$binaryFilename` — reads `AttachmentBinaryObject/@filename` (e.g. `01_15_Anhang_01.pdf`)

## Background

Previously, the method only returned the resolved file path of a written binary attachment via `$binaryDataFilename`. The raw MIME type and original filename from the XML were silently discarded, making it impossible for callers to determine the attachment's content type or source filename without additional XML parsing.

Both new parameters are optional and default to `null`, so the change is fully backwards compatible.

## Changes

- `src/ZugferdDocumentReader.php`: Added `$binaryMimeCode` and `$binaryFilename` as optional by-reference parameters. Internally renamed `$binarydata` to `$binaryObject` for clarity. The `$binaryDataFilename` parameter retains its existing behaviour (resolved output path when a binary data directory is set, empty string otherwise).
- `tests/testcases/ReaderXRechnungAttachedBinaryObjectTest.php`: Assertions added for `$binaryMimeCode` (`application/pdf`) and `$binaryFilename` (`01_15_Anhang_01.pdf`) in both the no-directory and directory-set scenarios.
- `tests/testcases/ReaderExtendedTest.php`, `PdfReaderExtendedTest.php`, `ReaderExtended2Test.php`, `PdfReaderExtended2Test.php`: Assertions added for empty strings on documents that carry no binary attachment.

## Test Plan

- [x] Run the full PHPUnit test suite.
- [x] Confirm that `$binaryMimeCode` and `$binaryFilename` are populated correctly when reading an XRechnung with an embedded PDF attachment.
- [x] Confirm that both parameters return an empty string for documents without a binary attachment.
- [x] Confirm that existing callers that omit the new parameters continue to work without modification.
