### PR TITLE
feat: add BuyerTaxRepresentative, BusinessProcess/ForeignCurrency reader, UltimateCustomerOrder

### DIFF
--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -22,6 +22,7 @@
             <file>../tests/testcases/ReaderExtended2Test.php</file>
             <file>../tests/testcases/ReaderXRechnungTest.php</file>
             <file>../tests/testcases/ReaderXRechnungAttachedBinaryObjectTest.php</file>
+            <file>../tests/testcases/ReaderExtendedBuyerTaxRepresentativeTest.php</file>
         </testsuite>
         <testsuite name="Builder">
             <file>../tests/testcases/BuilderMinimumTest.php</file>

--- a/src/ZugferdDocumentBuilder.php
+++ b/src/ZugferdDocumentBuilder.php
@@ -892,6 +892,136 @@ class ZugferdDocumentBuilder extends ZugferdDocument
     }
 
     /**
+     * Sets the information about the buyer's tax representative party (BG-X-54, EXTENDED Profile)
+     *
+     * @param  string      $name        __BT-X-362, From EXTENDED__ The full name of the buyer's tax representative
+     * @param  string|null $id          __BT-X-364, From EXTENDED__ An identifier of the buyer's tax representative
+     * @param  string|null $description __BT-, From __ Further legal information that is relevant for the buyer's tax representative
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentBuyerTaxRepresentativeTradeParty(string $name, ?string $id = null, ?string $description = null): ZugferdDocumentBuilder
+    {
+        $buyerTaxRepresentativeTradeParty = $this->getObjectHelper()->getTradeParty($name, $id, $description);
+
+        $this->getObjectHelper()->tryCall($this->headerTradeAgreement, "setBuyerTaxRepresentativeTradeParty", $buyerTaxRepresentativeTradeParty);
+
+        return $this;
+    }
+
+    /**
+     * Add a global id for the buyer's tax representative party
+     *
+     * @param  string|null $globalID     __BT-X-365, From EXTENDED__ The buyer's tax representative identifier identification scheme is an identifier uniquely assigned to a party by a global registration organization.
+     * @param  string|null $globalIDType __BT-X-365-0, From EXTENDED__ If the identifier is used for the identification scheme, it must be selected from the entries in the list published by the ISO / IEC 6523 Maintenance Agency.
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentBuyerTaxRepresentativeGlobalId(?string $globalID = null, ?string $globalIDType = null): ZugferdDocumentBuilder
+    {
+        $taxrepresentativeTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getBuyerTaxRepresentativeTradeParty");
+
+        $this->getObjectHelper()->tryCall($taxrepresentativeTradeParty, "addToGlobalID", $this->getObjectHelper()->getIdType($globalID, $globalIDType));
+
+        return $this;
+    }
+
+    /**
+     * Add tax registration to buyer's tax representative party
+     *
+     * @param  string|null $taxRegType __BT-X-367-0, From EXTENDED__ Type of tax number (FC = Tax number, VA = Sales tax identification number)
+     * @param  string|null $taxRegId   __BT-X-367, From EXTENDED__ Tax number or sales tax identification number
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentBuyerTaxRepresentativeTaxRegistration(?string $taxRegType = null, ?string $taxRegId = null): ZugferdDocumentBuilder
+    {
+        $taxrepresentativeTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getBuyerTaxRepresentativeTradeParty");
+        $taxReg = $this->getObjectHelper()->getTaxRegistrationType($taxRegType, $taxRegId);
+
+        $this->getObjectHelper()->tryCall($taxrepresentativeTradeParty, "addToSpecifiedTaxRegistration", $taxReg);
+
+        return $this;
+    }
+
+    /**
+     * Sets the postal address of the buyer's tax representative party
+     *
+     * @param  string|null $lineOne     __BT-X-383, From EXTENDED__ The main line in the buyer's tax representative address
+     * @param  string|null $lineTwo     __BT-X-384, From EXTENDED__ Line 2 of the buyer's tax representative address
+     * @param  string|null $lineThree   __BT-X-385, From EXTENDED__ Line 3 of the buyer's tax representative address
+     * @param  string|null $postCode    __BT-X-382, From EXTENDED__ Identifier for a group of properties, such as a zip code
+     * @param  string|null $city        __BT-X-386, From EXTENDED__ Usual name of the city or municipality in which the buyer's tax representative address is located
+     * @param  string|null $country     __BT-X-387, From EXTENDED__ Code used to identify the country. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency "Codes for the representation of names of countries and their subdivisions"
+     * @param  string|null $subDivision __BT-X-388, From EXTENDED__ The buyer's tax representative state
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentBuyerTaxRepresentativeAddress(?string $lineOne = null, ?string $lineTwo = null, ?string $lineThree = null, ?string $postCode = null, ?string $city = null, ?string $country = null, ?string $subDivision = null): ZugferdDocumentBuilder
+    {
+        $taxrepresentativeTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getBuyerTaxRepresentativeTradeParty");
+        $address = $this->getObjectHelper()->getTradeAddress($lineOne, $lineTwo, $lineThree, $postCode, $city, $country, $subDivision);
+
+        $this->getObjectHelper()->tryCall($taxrepresentativeTradeParty, "setPostalTradeAddress", $address);
+
+        return $this;
+    }
+
+    /**
+     * Set legal organisation of the buyer's tax representative party
+     *
+     * @param  string|null $legalOrgId   __BT-, From __ An identifier issued by an official registrar that identifies the buyer's tax representative as a legal entity or legal person.
+     * @param  string|null $legalOrgType __BT-, From __ The identifier for the identification scheme of the legal registration of the buyer's tax representative. If the identification scheme is used, it must be selected from ISO/IEC 6523 list
+     * @param  string|null $legalOrgName __BT-, From __ A name by which the buyer's tax representative is known, if different from the buyer's tax representative name (also known as the company name)
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentBuyerTaxRepresentativeLegalOrganisation(?string $legalOrgId, ?string $legalOrgType, ?string $legalOrgName): ZugferdDocumentBuilder
+    {
+        $taxrepresentativeTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getBuyerTaxRepresentativeTradeParty");
+        $legalOrg = $this->getObjectHelper()->getLegalOrganization($legalOrgId, $legalOrgType, $legalOrgName);
+
+        $this->getObjectHelper()->tryCall($taxrepresentativeTradeParty, "setSpecifiedLegalOrganization", $legalOrg);
+
+        return $this;
+    }
+
+    /**
+     * Set detailed information on the buyer's tax representative party contact person BG-X-55
+     *
+     * @param  string|null $contactPersonName     __BT-X-369, From EXTENDED__ Such as personal name, name of contact person or department or office
+     * @param  string|null $contactDepartmentName __BT-X-370, From EXTENDED__ If a contact person is specified, either the name or the department must be transmitted.
+     * @param  string|null $contactPhoneNo        __BT-X-372, From EXTENDED__ A telephone number for the contact point
+     * @param  string|null $contactFaxNo          __BT-X-373, From EXTENDED__ A fax number of the contact point
+     * @param  string|null $contactEmailAddress   __BT-X-374, From EXTENDED__ An e-mail address of the contact point
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentBuyerTaxRepresentativeContact(?string $contactPersonName, ?string $contactDepartmentName, ?string $contactPhoneNo, ?string $contactFaxNo, ?string $contactEmailAddress): ZugferdDocumentBuilder
+    {
+        $taxrepresentativeTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getBuyerTaxRepresentativeTradeParty");
+        $contact = $this->getObjectHelper()->getTradeContact($contactPersonName, $contactDepartmentName, $contactPhoneNo, $contactFaxNo, $contactEmailAddress);
+
+        $this->getObjectHelper()->tryCallIfMethodExists($taxrepresentativeTradeParty, "addToDefinedTradeContact", "setDefinedTradeContact", [$contact], $contact);
+
+        return $this;
+    }
+
+    /**
+     * Add an (additional) contact to the buyer's tax representative party (EXTENDED Profile only)
+     *
+     * @param  string|null $contactPersonName     __BT-X-369, From EXTENDED__ Such as personal name, name of contact person or department or office
+     * @param  string|null $contactDepartmentName __BT-X-370, From EXTENDED__ If a contact person is specified, either the name or the department must be transmitted.
+     * @param  string|null $contactPhoneNo        __BT-X-372, From EXTENDED__ A telephone number for the contact point
+     * @param  string|null $contactFaxNo          __BT-X-373, From EXTENDED__ A fax number of the contact point
+     * @param  string|null $contactEmailAddress   __BT-X-374, From EXTENDED__ An e-mail address of the contact point
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentBuyerTaxRepresentativeContact(?string $contactPersonName, ?string $contactDepartmentName, ?string $contactPhoneNo, ?string $contactFaxNo, ?string $contactEmailAddress): ZugferdDocumentBuilder
+    {
+        $taxrepresentativeTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getBuyerTaxRepresentativeTradeParty");
+        $contact = $this->getObjectHelper()->getTradeContact($contactPersonName, $contactDepartmentName, $contactPhoneNo, $contactFaxNo, $contactEmailAddress);
+
+        $this->getObjectHelper()->tryCall($taxrepresentativeTradeParty, "addToDefinedTradeContact", $contact);
+
+        return $this;
+    }
+
+    /**
      * Detailed information on the deviating end user (general informaton)
      *
      * @param  string      $name        __BT-X-128, From EXTENDED__ Name/company name of the end user

--- a/src/ZugferdDocumentReader.php
+++ b/src/ZugferdDocumentReader.php
@@ -99,6 +99,13 @@ class ZugferdDocumentReader extends ZugferdDocument
     private $documentBuyerContactPointer = 0;
 
     /**
+     * Internal pointer for buyer tax representative party contacts
+     *
+     * @var integer
+     */
+    private $documentBuyerTaxRepresentativeContactPointer = 0;
+
+    /**
      * Internal pointer for seller tax representativ party contacts
      *
      * @var integer
@@ -239,6 +246,13 @@ class ZugferdDocumentReader extends ZugferdDocument
     private $positionReferencedProductPointer = 0;
 
     /**
+     * Internal pointer for the position ultimate customer order referenced documents
+     *
+     * @var integer
+     */
+    private $positionUltimateCustomerOrderReferencedDocumentPointer = 0;
+
+    /**
      * @var string
      */
     private $binarydatadirectory = "";
@@ -347,6 +361,51 @@ class ZugferdDocumentReader extends ZugferdDocument
             $this->getInvoiceValueByPath("getExchangedDocument.getEffectiveSpecifiedPeriod.getDateTimeString", ""),
             $this->getInvoiceValueByPath("getExchangedDocument.getEffectiveSpecifiedPeriod.getDateTimeString.getFormat", "")
         );
+
+        return $this;
+    }
+
+    /**
+     * Get the business process specified in the document context.
+     *
+     * @param  string|null $businessProcess __BT-23, From BASIC WL__ Identifies the business process context in which the transaction appears
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentBusinessProcess(?string &$businessProcess): ZugferdDocumentReader
+    {
+        $businessProcess = $this->getInvoiceValueByPath("getExchangedDocumentContext.getBusinessProcessSpecifiedDocumentContextParameter.getID.value", "");
+
+        return $this;
+    }
+
+    /**
+     * Get information about the foreign currency used in the document.
+     * This is the counterpart to ZugferdDocumentBuilder::setForeignCurrency.
+     *
+     * @param  string|null $foreignCurrencyCode __BT-6, From BASIC WL__ Foreign currency code
+     * @param  float|null  $foreignTaxAmount    __BT-X-260, From EXTENDED__ Tax total amount in the foreign currency
+     * @param  float|null  $exchangeRate        __BT-X-260, From EXTENDED__ Exchange rate from invoice currency to foreign currency
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentForeignCurrency(?string &$foreignCurrencyCode, ?float &$foreignTaxAmount, ?float &$exchangeRate): ZugferdDocumentReader
+    {
+        $foreignCurrencyCode = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeSettlement.getTaxCurrencyCode.value", "");
+        $foreignTaxAmount = 0.0;
+        $exchangeRate = 0.0;
+
+        if ($foreignCurrencyCode !== '') {
+            $taxTotalAmountElements = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeSettlement.getSpecifiedTradeSettlementHeaderMonetarySummation.getTaxTotalAmount", []);
+
+            foreach ($taxTotalAmountElements as $taxTotalAmountElement) {
+                $currencyId = $this->getObjectHelper()->tryCallAndReturn($taxTotalAmountElement, "getCurrencyID") ?? '';
+                if ($currencyId === $foreignCurrencyCode) {
+                    $foreignTaxAmount = $this->getObjectHelper()->tryCallAndReturn($taxTotalAmountElement, "value") ?? 0.0;
+                    break;
+                }
+            }
+
+            $exchangeRate = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeSettlement.getTaxApplicableTradeCurrencyExchange.getConversionRate.value", 0.0);
+        }
 
         return $this;
     }
@@ -891,6 +950,150 @@ class ZugferdDocumentReader extends ZugferdDocument
         $contacts = $this->getObjectHelper()->ensureArray($this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getSellerTaxRepresentativeTradeParty.getDefinedTradeContact", []));
 
         $contact = $contacts[$this->documentSellerTaxRepresentativeContactPointer];
+
+        $contactPersonName = $this->getInvoiceValueByPathFrom($contact, "getPersonName.value", "");
+        $contactDepartmentName = $this->getInvoiceValueByPathFrom($contact, "getDepartmentName.value", "");
+        $contactPhoneNo = $this->getInvoiceValueByPathFrom($contact, "getTelephoneUniversalCommunication.getCompleteNumber.value", "");
+        $contactFaxNo = $this->getInvoiceValueByPathFrom($contact, "getFaxUniversalCommunication.getCompleteNumber.value", "");
+        $contactEmailAddress = $this->getInvoiceValueByPathFrom($contact, "getEmailURIUniversalCommunication.getURIID.value", "");
+
+        return $this;
+    }
+
+    /**
+     * Get information about the buyer's tax representative party BG-X-54.
+     *
+     * @param  string|null $name        __BT-X-362, From EXTENDED__ The full name of the buyer's tax representative
+     * @param  array|null  $id          __BT-X-364, From EXTENDED__ An array of identifiers of the buyer's tax representative
+     * @param  string|null $description __BT-, From __ Further legal information that is relevant for the buyer's tax representative
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentBuyerTaxRepresentative(?string &$name, ?array &$id, ?string &$description): ZugferdDocumentReader
+    {
+        $name = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getName.value", "");
+        $id = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getID", []);
+        $description = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getDescription.value", "");
+
+        $id = $this->convertToArray($id, ["id" => "value"]);
+
+        return $this;
+    }
+
+    /**
+     * Get document buyer tax representative global ids.
+     *
+     * @param  array|null $globalID __BT-X-365/BT-X-365-0, From EXTENDED__ Returns an array of the buyer's tax representative identifiers indexed by the identification scheme.
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentBuyerTaxRepresentativeGlobalId(?array &$globalID): ZugferdDocumentReader
+    {
+        $globalID = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getGlobalID", []);
+        $globalID = $this->convertToAssociativeArray($globalID, "getSchemeID", "value");
+
+        return $this;
+    }
+
+    /**
+     * Get detailed information on the buyer's tax representative tax information.
+     *
+     * @param  array|null $taxReg __BT-X-367/BT-X-367-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentBuyerTaxRepresentativeTaxRegistration(?array &$taxReg): ZugferdDocumentReader
+    {
+        $taxReg = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getSpecifiedTaxRegistration", []);
+        $taxReg = $this->convertToAssociativeArray($taxReg, "getID.getSchemeID", "getID.value");
+
+        return $this;
+    }
+
+    /**
+     * Get the address of the buyer's tax representative.
+     *
+     * @param  string|null $lineOne     __BT-X-383, From EXTENDED__ The main line in the buyer's tax representative address
+     * @param  string|null $lineTwo     __BT-X-384, From EXTENDED__ Line 2 of the buyer's tax representative address
+     * @param  string|null $lineThree   __BT-X-385, From EXTENDED__ Line 3 of the buyer's tax representative address
+     * @param  string|null $postCode    __BT-X-382, From EXTENDED__ Identifier for a group of properties, such as a zip code
+     * @param  string|null $city        __BT-X-386, From EXTENDED__ Usual name of the city or municipality in which the buyer's tax representative address is located
+     * @param  string|null $country     __BT-X-387, From EXTENDED__ Code used to identify the country. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency "Codes for the representation of names of countries and their subdivisions"
+     * @param  array|null  $subDivision __BT-X-388, From EXTENDED__ The buyer's tax representative state
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentBuyerTaxRepresentativeAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
+    {
+        $lineOne = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getPostalTradeAddress.getLineOne.value", "");
+        $lineTwo = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getPostalTradeAddress.getLineTwo.value", "");
+        $lineThree = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getPostalTradeAddress.getLineThree.value", "");
+        $postCode = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getPostalTradeAddress.getPostcodeCode.value", "");
+        $city = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getPostalTradeAddress.getCityName.value", "");
+        $country = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getPostalTradeAddress.getCountryID.value", "");
+        $subDivision = $this->convertToArray($this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getPostalTradeAddress.getCountrySubDivisionName", []), ["value"]);
+
+        return $this;
+    }
+
+    /**
+     * Get the legal organisation of the buyer's tax representative.
+     *
+     * @param  string|null $legalOrgId   __BT-, From __ An identifier issued by an official registrar that identifies the buyer's tax representative as a legal entity or legal person.
+     * @param  string|null $legalOrgType __BT-, From __ The identifier for the identification scheme of the legal registration of the buyer's tax representative. If the identification scheme is used, it must be selected from ISO/IEC 6523 list
+     * @param  string|null $legalOrgName __BT-, From __ A name by which the buyer's tax representative is known, if different from the buyer's tax representative name (also known as the company name)
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentBuyerTaxRepresentativeLegalOrganisation(?string &$legalOrgId, ?string &$legalOrgType, ?string &$legalOrgName): ZugferdDocumentReader
+    {
+        $legalOrgId = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getSpecifiedLegalOrganization.getID.value", "");
+        $legalOrgType = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getSpecifiedLegalOrganization.getID.getSchemeID", "");
+        $legalOrgName = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getSpecifiedLegalOrganization.getTradingBusinessName.value", "");
+
+        return $this;
+    }
+
+    /**
+     * Seek to the first buyer tax representative contact of the document. Returns true if a first contact is available, otherwise false.
+     * You may use this together with ZugferdDocumentReader::getDocumentBuyerTaxRepresentativeContact.
+     *
+     * @return boolean
+     */
+    public function firstDocumentBuyerTaxRepresentativeContact(): bool
+    {
+        $this->documentBuyerTaxRepresentativeContactPointer = 0;
+
+        $contacts = $this->getObjectHelper()->ensureArray($this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getDefinedTradeContact", []));
+
+        return isset($contacts[$this->documentBuyerTaxRepresentativeContactPointer]);
+    }
+
+    /**
+     * Seek to the next available buyer tax representative contact of the document. Returns true if another contact is available, otherwise false.
+     * You may use this together with ZugferdDocumentReader::getDocumentBuyerTaxRepresentativeContact.
+     *
+     * @return boolean
+     */
+    public function nextDocumentBuyerTaxRepresentativeContact(): bool
+    {
+        $this->documentBuyerTaxRepresentativeContactPointer++;
+
+        $contacts = $this->getObjectHelper()->ensureArray($this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getDefinedTradeContact", []));
+
+        return isset($contacts[$this->documentBuyerTaxRepresentativeContactPointer]);
+    }
+
+    /**
+     * Get contact information of the buyer's tax representative.
+     *
+     * @param  string|null $contactPersonName     __BT-X-369, From EXTENDED__ Such as personal name, name of contact person or department or office
+     * @param  string|null $contactDepartmentName __BT-X-370, From EXTENDED__ If a contact person is specified, either the name or the department must be transmitted.
+     * @param  string|null $contactPhoneNo        __BT-X-372, From EXTENDED__ A telephone number for the contact point
+     * @param  string|null $contactFaxNo          __BT-X-373, From EXTENDED__ A fax number of the contact point
+     * @param  string|null $contactEmailAddress   __BT-X-374, From EXTENDED__ An e-mail address of the contact point
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentBuyerTaxRepresentativeContact(?string &$contactPersonName, ?string &$contactDepartmentName, ?string &$contactPhoneNo, ?string &$contactFaxNo, ?string &$contactEmailAddress): ZugferdDocumentReader
+    {
+        $contacts = $this->getObjectHelper()->ensureArray($this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getBuyerTaxRepresentativeTradeParty.getDefinedTradeContact", []));
+
+        $contact = $contacts[$this->documentBuyerTaxRepresentativeContactPointer];
 
         $contactPersonName = $this->getInvoiceValueByPathFrom($contact, "getPersonName.value", "");
         $contactDepartmentName = $this->getInvoiceValueByPathFrom($contact, "getDepartmentName.value", "");
@@ -2252,13 +2455,27 @@ class ZugferdDocumentReader extends ZugferdDocument
     }
 
     /**
-     * Details of the ultimate customer order.
+     * Get all ultimate customer order referenced documents as an array.
      *
+     * @param  array|null $refdocs Returns an array of referenced documents, each containing keys: _issuerAssignedId_ and _issueDate_
      * @return ZugferdDocumentReader
      */
-    public function getDocumentUltimateCustomerOrderReferencedDocuments(/*?array $refdocs*/): ZugferdDocumentReader
+    public function getDocumentUltimateCustomerOrderReferencedDocuments(?array &$refdocs): ZugferdDocumentReader
     {
-        // TODO: Implemente method getDocumentUltimateCustomerOrderReferencedDocuments
+        $refdocs = [];
+        $allRefDocs = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeAgreement.getUltimateCustomerOrderReferencedDocument", []);
+        $allRefDocs = $this->getObjectHelper()->ensureArray($allRefDocs);
+
+        foreach ($allRefDocs as $refDoc) {
+            $refdocs[] = [
+                'issuerAssignedId' => $this->getInvoiceValueByPathFrom($refDoc, "getIssuerAssignedID.value", ""),
+                'issueDate' => $this->getObjectHelper()->toDateTime(
+                    $this->getInvoiceValueByPathFrom($refDoc, "getFormattedIssueDateTime.getDateTimeString.value", ""),
+                    $this->getInvoiceValueByPathFrom($refDoc, "getFormattedIssueDateTime.getDateTimeString.getFormat", "")
+                ),
+            ];
+        }
+
         return $this;
     }
 
@@ -3488,7 +3705,67 @@ class ZugferdDocumentReader extends ZugferdDocument
         return $this;
     }
 
-    //TODO: DocumentPositionUltimateCustomerOrderReferencedDocument
+    /**
+     * Seek to the first ultimate customer order referenced document at position level. Returns true if the first position is available, otherwise false.
+     * You may use it together with ZugferdDocumentReader::getDocumentPositionUltimateCustomerOrderReferencedDocument.
+     *
+     * @return boolean
+     */
+    public function firstDocumentPositionUltimateCustomerOrderReferencedDocument(): bool
+    {
+        $this->positionUltimateCustomerOrderReferencedDocumentPointer = 0;
+
+        $tradeLineItem = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getIncludedSupplyChainTradeLineItem", []);
+        $tradeLineItem = $tradeLineItem[$this->positionPointer];
+
+        $addRefDoc = $this->getObjectHelper()->ensureArray($this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeAgreement.getUltimateCustomerOrderReferencedDocument", []));
+
+        return isset($addRefDoc[$this->positionUltimateCustomerOrderReferencedDocumentPointer]);
+    }
+
+    /**
+     * Seek to the next ultimate customer order referenced document at position level. Returns true if another position is available, otherwise false.
+     * You may use it together with ZugferdDocumentReader::getDocumentPositionUltimateCustomerOrderReferencedDocument.
+     *
+     * @return boolean
+     */
+    public function nextDocumentPositionUltimateCustomerOrderReferencedDocument(): bool
+    {
+        $this->positionUltimateCustomerOrderReferencedDocumentPointer++;
+
+        $tradeLineItem = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getIncludedSupplyChainTradeLineItem", []);
+        $tradeLineItem = $tradeLineItem[$this->positionPointer];
+
+        $addRefDoc = $this->getObjectHelper()->ensureArray($this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeAgreement.getUltimateCustomerOrderReferencedDocument", []));
+
+        return isset($addRefDoc[$this->positionUltimateCustomerOrderReferencedDocumentPointer]);
+    }
+
+    /**
+     * Get details of the ultimate customer order referenced document at position level.
+     *
+     * @param  string|null   $issuerAssignedId __BT-X-43, From EXTENDED__ Order number of the end customer
+     * @param  string|null   $lineId           __BT-X-44, From EXTENDED__ Order item (end customer)
+     * @param  DateTime|null $issueDate        __BT-X-45, From EXTENDED__ Document date of end customer order
+     * @return ZugferdDocumentReader
+     */
+    public function getDocumentPositionUltimateCustomerOrderReferencedDocument(?string &$issuerAssignedId, ?string &$lineId, ?DateTime &$issueDate): ZugferdDocumentReader
+    {
+        $tradeLineItem = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getIncludedSupplyChainTradeLineItem", []);
+        $tradeLineItem = $tradeLineItem[$this->positionPointer];
+
+        $addRefDoc = $this->getObjectHelper()->ensureArray($this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeAgreement.getUltimateCustomerOrderReferencedDocument", []));
+        $addRefDoc = $addRefDoc[$this->positionUltimateCustomerOrderReferencedDocumentPointer];
+
+        $issuerAssignedId = $this->getInvoiceValueByPathFrom($addRefDoc, "getIssuerAssignedID.value", "");
+        $lineId = $this->getInvoiceValueByPathFrom($addRefDoc, "getLineID.value", "");
+        $issueDate = $this->getObjectHelper()->toDateTime(
+            $this->getInvoiceValueByPathFrom($addRefDoc, "getFormattedIssueDateTime.getDateTimeString.value", ""),
+            $this->getInvoiceValueByPathFrom($addRefDoc, "getFormattedIssueDateTime.getDateTimeString.getFormat", "")
+        );
+
+        return $this;
+    }
 
     /**
      * Get the unit price excluding sales tax before deduction of the discount on the item price.

--- a/src/schema/catalog.xml
+++ b/src/schema/catalog.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  XML Catalog for Factur-X / ZUGFeRD / XRechnung namespace resolution.
+
+  Maps the UN/CEFACT URN namespaces to the local Factur-X EXTENDED profile XSD files,
+  which contain the most complete set of elements across all profiles.
+
+  The original UN/CEFACT schemas for namespace version :100 (D16B+) were never published
+  as individual XSD files on unece.org. The Factur-X XSD files distributed by FNFE-MPE
+  (Forum National de la Facture Electronique) are the authoritative local representations.
+
+  Source of XSD files: Factur-X 1.0 Technical Specification Package
+  Original distribution: https://fnfe-mpe.org/factur-x/ (FNFE-MPE / FeRD)
+  Specification: https://www.ferd-net.de/standards/zugferd/index.html
+
+  Usage:
+  - PHPStorm: Settings > Languages & Frameworks > Schemas and DTDs > XML Catalog
+    Add this file as an XML Catalog.
+  - Other XML tools: Pass this catalog via XML_CATALOG_FILES environment variable
+    or tool-specific catalog configuration.
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <!-- CrossIndustryInvoice (CII) root schema -->
+    <uri name="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+         uri="FACTUR-X_EXTENDED.xsd"/>
+
+    <!-- Qualified Data Type definitions -->
+    <uri name="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
+         uri="FACTUR-X_EXTENDED_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
+
+    <!-- Reusable Aggregate Business Information Entity definitions -->
+    <uri name="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+         uri="FACTUR-X_EXTENDED_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd"/>
+
+    <!-- Unqualified Data Type definitions -->
+    <uri name="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+         uri="FACTUR-X_EXTENDED_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
+</catalog>

--- a/tests/testcases/ReaderExtendedBuyerTaxRepresentativeTest.php
+++ b/tests/testcases/ReaderExtendedBuyerTaxRepresentativeTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace horstoeko\zugferd\tests\testcases;
+
+use horstoeko\zugferd\tests\TestCase;
+use horstoeko\zugferd\ZugferdProfiles;
+use horstoeko\zugferd\ZugferdDocumentBuilder;
+use horstoeko\zugferd\ZugferdDocumentReader;
+
+/**
+ * Round-trip test for new fork features in the EXTENDED profile:
+ * BuyerTaxRepresentativeParty (BG-X-54), getDocumentBusinessProcess, getDocumentForeignCurrency.
+ * Builds a document with these features, then reads it back and verifies all values.
+ */
+class ReaderExtendedBuyerTaxRepresentativeTest extends TestCase
+{
+    /**
+     * The document instance
+     *
+     * @var ZugferdDocumentReader
+     */
+    protected static $document;
+
+    public static function setUpBeforeClass(): void
+    {
+        $builder = ZugferdDocumentBuilder::createNew(ZugferdProfiles::PROFILE_EXTENDED);
+
+        $builder
+            ->setDocumentInformation("BTRTST-001", "380", \DateTime::createFromFormat("Ymd", "20250601"), "EUR")
+            ->setDocumentBusinessProcess("urn:fdc:peppol.eu:2017:poacc:billing:01:1.0")
+            ->addDocumentNote("Test document for BuyerTaxRepresentative")
+            ->setDocumentSeller("Seller Corp", "SELL-01")
+            ->setDocumentSellerAddress("Seller Street 1", "", "", "10115", "Berlin", "DE")
+            ->addDocumentSellerTaxRegistration("VA", "DE123456789")
+            ->setDocumentBuyer("Buyer Corp", "BUY-01")
+            ->setDocumentBuyerAddress("Buyer Lane 5", "", "", "80331", "München", "DE")
+            ->setDocumentBuyerTaxRepresentativeTradeParty("Tax Rep GmbH", "TAXREP-01")
+            ->addDocumentBuyerTaxRepresentativeGlobalId("4000001123452", "0088")
+            ->addDocumentBuyerTaxRepresentativeTaxRegistration("VA", "DE999888777")
+            ->setDocumentBuyerTaxRepresentativeAddress("Steuerstr. 42", "Gebäude B", "3. OG", "50667", "Köln", "DE", "NRW")
+            ->setDocumentBuyerTaxRepresentativeLegalOrganisation("REG-12345", "0002", "Tax Rep Trading")
+            ->setDocumentBuyerTaxRepresentativeContact("Max Steuer", "Steuerabteilung", "+49 221 555 0001", "+49 221 555 0002", "max@taxrep.de")
+            ->addDocumentBuyerTaxRepresentativeContact("Lisa Abgabe", "Buchhaltung", "+49 221 555 0003", "+49 221 555 0004", "lisa@taxrep.de")
+            ->addNewPosition("1")
+            ->setDocumentPositionProductDetails("Test Product")
+            ->setDocumentPositionNetPrice(100.00)
+            ->setDocumentPositionQuantity(1, "C62")
+            ->addDocumentPositionTax("S", "VAT", 19.0)
+            ->setDocumentPositionLineSummation(100.00)
+            ->setDocumentSummation(119.00, 119.00, 100.00, 0.0, 0.0, 100.00, 19.00)
+            ->addDocumentTax("S", "VAT", 100.00, 19.00, 19.0)
+            ->setForeignCurrency("USD", 22.61, 1.19);
+
+        $xml = $builder->getContent();
+        self::$document = ZugferdDocumentReader::readAndGuessFromContent($xml);
+    }
+
+    public function testGetDocumentBusinessProcess(): void
+    {
+        self::$document->getDocumentBusinessProcess($businessProcess);
+
+        self::assertSame("urn:fdc:peppol.eu:2017:poacc:billing:01:1.0", $businessProcess);
+    }
+
+    public function testGetDocumentForeignCurrency(): void
+    {
+        self::$document->getDocumentForeignCurrency($foreignCurrencyCode, $foreignTaxAmount, $exchangeRate);
+
+        self::assertSame("USD", $foreignCurrencyCode);
+        self::assertEqualsWithDelta(22.61, $foreignTaxAmount, 0.01);
+        self::assertEqualsWithDelta(1.19, $exchangeRate, 0.01);
+    }
+
+    public function testGetDocumentForeignCurrencyEmptyWhenNotSet(): void
+    {
+        $emptyBuilder = ZugferdDocumentBuilder::createNew(ZugferdProfiles::PROFILE_EXTENDED);
+        $emptyBuilder
+            ->setDocumentInformation("EMPTY-001", "380", \DateTime::createFromFormat("Ymd", "20250601"), "EUR")
+            ->setDocumentSeller("Seller Corp")
+            ->setDocumentSellerAddress("Street", "", "", "10115", "Berlin", "DE")
+            ->addDocumentSellerTaxRegistration("VA", "DE123456789")
+            ->setDocumentBuyer("Buyer Corp")
+            ->addNewPosition("1")
+            ->setDocumentPositionProductDetails("Test")
+            ->setDocumentPositionNetPrice(100.00)
+            ->setDocumentPositionQuantity(1, "C62")
+            ->addDocumentPositionTax("S", "VAT", 19.0)
+            ->setDocumentPositionLineSummation(100.00)
+            ->setDocumentSummation(119.00, 119.00, 100.00, 0.0, 0.0, 100.00, 19.00)
+            ->addDocumentTax("S", "VAT", 100.00, 19.00, 19.0);
+
+        $reader = ZugferdDocumentReader::readAndGuessFromContent($emptyBuilder->getContent());
+        $reader->getDocumentForeignCurrency($code, $amount, $rate);
+
+        self::assertSame("", $code);
+        self::assertEqualsWithDelta(0.0, $amount, 0.01);
+        self::assertEqualsWithDelta(0.0, $rate, 0.01);
+    }
+
+    public function testGetDocumentBuyerTaxRepresentative(): void
+    {
+        self::$document->getDocumentBuyerTaxRepresentative($name, $id, $description);
+
+        self::assertEquals("Tax Rep GmbH", $name);
+        self::assertIsArray($id);
+        self::assertNotEmpty($id);
+        self::assertEquals("TAXREP-01", $id[0]);
+        self::assertEquals("", $description);
+    }
+
+    public function testGetDocumentBuyerTaxRepresentativeGlobalId(): void
+    {
+        self::$document->getDocumentBuyerTaxRepresentativeGlobalId($globalID);
+
+        self::assertIsArray($globalID);
+        self::assertArrayHasKey("0088", $globalID);
+        self::assertEquals("4000001123452", $globalID["0088"]);
+    }
+
+    public function testGetDocumentBuyerTaxRepresentativeTaxRegistration(): void
+    {
+        self::$document->getDocumentBuyerTaxRepresentativeTaxRegistration($taxReg);
+
+        self::assertIsArray($taxReg);
+        self::assertArrayHasKey("VA", $taxReg);
+        self::assertEquals("DE999888777", $taxReg["VA"]);
+    }
+
+    public function testGetDocumentBuyerTaxRepresentativeAddress(): void
+    {
+        self::$document->getDocumentBuyerTaxRepresentativeAddress($lineOne, $lineTwo, $lineThree, $postCode, $city, $country, $subDivision);
+
+        self::assertEquals("Steuerstr. 42", $lineOne);
+        self::assertEquals("Gebäude B", $lineTwo);
+        self::assertEquals("3. OG", $lineThree);
+        self::assertEquals("50667", $postCode);
+        self::assertEquals("Köln", $city);
+        self::assertEquals("DE", $country);
+        self::assertIsArray($subDivision);
+        self::assertContains("NRW", $subDivision);
+    }
+
+    public function testGetDocumentBuyerTaxRepresentativeLegalOrganisation(): void
+    {
+        self::$document->getDocumentBuyerTaxRepresentativeLegalOrganisation($legalOrgId, $legalOrgType, $legalOrgName);
+
+        self::assertEquals("REG-12345", $legalOrgId);
+        self::assertEquals("0002", $legalOrgType);
+        self::assertEquals("Tax Rep Trading", $legalOrgName);
+    }
+
+    public function testFirstDocumentBuyerTaxRepresentativeContact(): void
+    {
+        self::assertTrue(self::$document->firstDocumentBuyerTaxRepresentativeContact());
+    }
+
+    public function testGetDocumentBuyerTaxRepresentativeContactFirst(): void
+    {
+        self::$document->firstDocumentBuyerTaxRepresentativeContact();
+        self::$document->getDocumentBuyerTaxRepresentativeContact($personName, $deptName, $phone, $fax, $email);
+
+        self::assertEquals("Max Steuer", $personName);
+        self::assertEquals("Steuerabteilung", $deptName);
+        self::assertEquals("+49 221 555 0001", $phone);
+        self::assertEquals("+49 221 555 0002", $fax);
+        self::assertEquals("max@taxrep.de", $email);
+    }
+
+    public function testNextDocumentBuyerTaxRepresentativeContact(): void
+    {
+        self::$document->firstDocumentBuyerTaxRepresentativeContact();
+        self::assertTrue(self::$document->nextDocumentBuyerTaxRepresentativeContact());
+    }
+
+    public function testGetDocumentBuyerTaxRepresentativeContactSecond(): void
+    {
+        self::$document->firstDocumentBuyerTaxRepresentativeContact();
+        self::$document->nextDocumentBuyerTaxRepresentativeContact();
+        self::$document->getDocumentBuyerTaxRepresentativeContact($personName, $deptName, $phone, $fax, $email);
+
+        self::assertEquals("Lisa Abgabe", $personName);
+        self::assertEquals("Buchhaltung", $deptName);
+        self::assertEquals("+49 221 555 0003", $phone);
+        self::assertEquals("+49 221 555 0004", $fax);
+        self::assertEquals("lisa@taxrep.de", $email);
+    }
+
+    public function testNoThirdContact(): void
+    {
+        self::$document->firstDocumentBuyerTaxRepresentativeContact();
+        self::$document->nextDocumentBuyerTaxRepresentativeContact();
+        self::assertFalse(self::$document->nextDocumentBuyerTaxRepresentativeContact());
+    }
+}

--- a/tests/testcases/ReaderExtendedBuyerTaxRepresentativeTest.php
+++ b/tests/testcases/ReaderExtendedBuyerTaxRepresentativeTest.php
@@ -49,7 +49,10 @@ class ReaderExtendedBuyerTaxRepresentativeTest extends TestCase
             ->setDocumentPositionLineSummation(100.00)
             ->setDocumentSummation(119.00, 119.00, 100.00, 0.0, 0.0, 100.00, 19.00)
             ->addDocumentTax("S", "VAT", 100.00, 19.00, 19.0)
-            ->setForeignCurrency("USD", 22.61, 1.19);
+            ->setForeignCurrency("USD", 22.61, 1.19)
+            ->addDocumentUltimateCustomerOrderReferencedDocument("UCO-001", \DateTime::createFromFormat("Ymd", "20250501"))
+            ->addDocumentUltimateCustomerOrderReferencedDocument("UCO-002", \DateTime::createFromFormat("Ymd", "20250515"))
+            ->addDocumentPositionUltimateCustomerOrderReferencedDocument("POS-UCO-001", "10", \DateTime::createFromFormat("Ymd", "20250520"));
 
         $xml = $builder->getContent();
         self::$document = ZugferdDocumentReader::readAndGuessFromContent($xml);
@@ -59,16 +62,16 @@ class ReaderExtendedBuyerTaxRepresentativeTest extends TestCase
     {
         self::$document->getDocumentBusinessProcess($businessProcess);
 
-        self::assertSame("urn:fdc:peppol.eu:2017:poacc:billing:01:1.0", $businessProcess);
+        $this->assertSame("urn:fdc:peppol.eu:2017:poacc:billing:01:1.0", $businessProcess);
     }
 
     public function testGetDocumentForeignCurrency(): void
     {
         self::$document->getDocumentForeignCurrency($foreignCurrencyCode, $foreignTaxAmount, $exchangeRate);
 
-        self::assertSame("USD", $foreignCurrencyCode);
-        self::assertEqualsWithDelta(22.61, $foreignTaxAmount, 0.01);
-        self::assertEqualsWithDelta(1.19, $exchangeRate, 0.01);
+        $this->assertSame("USD", $foreignCurrencyCode);
+        $this->assertEqualsWithDelta(22.61, $foreignTaxAmount, 0.01);
+        $this->assertEqualsWithDelta(1.19, $exchangeRate, 0.01);
     }
 
     public function testGetDocumentForeignCurrencyEmptyWhenNotSet(): void
@@ -92,66 +95,66 @@ class ReaderExtendedBuyerTaxRepresentativeTest extends TestCase
         $reader = ZugferdDocumentReader::readAndGuessFromContent($emptyBuilder->getContent());
         $reader->getDocumentForeignCurrency($code, $amount, $rate);
 
-        self::assertSame("", $code);
-        self::assertEqualsWithDelta(0.0, $amount, 0.01);
-        self::assertEqualsWithDelta(0.0, $rate, 0.01);
+        $this->assertSame("", $code);
+        $this->assertEqualsWithDelta(0.0, $amount, 0.01);
+        $this->assertEqualsWithDelta(0.0, $rate, 0.01);
     }
 
     public function testGetDocumentBuyerTaxRepresentative(): void
     {
         self::$document->getDocumentBuyerTaxRepresentative($name, $id, $description);
 
-        self::assertEquals("Tax Rep GmbH", $name);
-        self::assertIsArray($id);
-        self::assertNotEmpty($id);
-        self::assertEquals("TAXREP-01", $id[0]);
-        self::assertEquals("", $description);
+        $this->assertEquals("Tax Rep GmbH", $name);
+        $this->assertIsArray($id);
+        $this->assertNotEmpty($id);
+        $this->assertEquals("TAXREP-01", $id[0]);
+        $this->assertEquals("", $description);
     }
 
     public function testGetDocumentBuyerTaxRepresentativeGlobalId(): void
     {
         self::$document->getDocumentBuyerTaxRepresentativeGlobalId($globalID);
 
-        self::assertIsArray($globalID);
-        self::assertArrayHasKey("0088", $globalID);
-        self::assertEquals("4000001123452", $globalID["0088"]);
+        $this->assertIsArray($globalID);
+        $this->assertArrayHasKey("0088", $globalID);
+        $this->assertEquals("4000001123452", $globalID["0088"]);
     }
 
     public function testGetDocumentBuyerTaxRepresentativeTaxRegistration(): void
     {
         self::$document->getDocumentBuyerTaxRepresentativeTaxRegistration($taxReg);
 
-        self::assertIsArray($taxReg);
-        self::assertArrayHasKey("VA", $taxReg);
-        self::assertEquals("DE999888777", $taxReg["VA"]);
+        $this->assertIsArray($taxReg);
+        $this->assertArrayHasKey("VA", $taxReg);
+        $this->assertEquals("DE999888777", $taxReg["VA"]);
     }
 
     public function testGetDocumentBuyerTaxRepresentativeAddress(): void
     {
         self::$document->getDocumentBuyerTaxRepresentativeAddress($lineOne, $lineTwo, $lineThree, $postCode, $city, $country, $subDivision);
 
-        self::assertEquals("Steuerstr. 42", $lineOne);
-        self::assertEquals("Gebäude B", $lineTwo);
-        self::assertEquals("3. OG", $lineThree);
-        self::assertEquals("50667", $postCode);
-        self::assertEquals("Köln", $city);
-        self::assertEquals("DE", $country);
-        self::assertIsArray($subDivision);
-        self::assertContains("NRW", $subDivision);
+        $this->assertEquals("Steuerstr. 42", $lineOne);
+        $this->assertEquals("Gebäude B", $lineTwo);
+        $this->assertEquals("3. OG", $lineThree);
+        $this->assertEquals("50667", $postCode);
+        $this->assertEquals("Köln", $city);
+        $this->assertEquals("DE", $country);
+        $this->assertIsArray($subDivision);
+        $this->assertContains("NRW", $subDivision);
     }
 
     public function testGetDocumentBuyerTaxRepresentativeLegalOrganisation(): void
     {
         self::$document->getDocumentBuyerTaxRepresentativeLegalOrganisation($legalOrgId, $legalOrgType, $legalOrgName);
 
-        self::assertEquals("REG-12345", $legalOrgId);
-        self::assertEquals("0002", $legalOrgType);
-        self::assertEquals("Tax Rep Trading", $legalOrgName);
+        $this->assertEquals("REG-12345", $legalOrgId);
+        $this->assertEquals("0002", $legalOrgType);
+        $this->assertEquals("Tax Rep Trading", $legalOrgName);
     }
 
     public function testFirstDocumentBuyerTaxRepresentativeContact(): void
     {
-        self::assertTrue(self::$document->firstDocumentBuyerTaxRepresentativeContact());
+        $this->assertTrue(self::$document->firstDocumentBuyerTaxRepresentativeContact());
     }
 
     public function testGetDocumentBuyerTaxRepresentativeContactFirst(): void
@@ -159,17 +162,17 @@ class ReaderExtendedBuyerTaxRepresentativeTest extends TestCase
         self::$document->firstDocumentBuyerTaxRepresentativeContact();
         self::$document->getDocumentBuyerTaxRepresentativeContact($personName, $deptName, $phone, $fax, $email);
 
-        self::assertEquals("Max Steuer", $personName);
-        self::assertEquals("Steuerabteilung", $deptName);
-        self::assertEquals("+49 221 555 0001", $phone);
-        self::assertEquals("+49 221 555 0002", $fax);
-        self::assertEquals("max@taxrep.de", $email);
+        $this->assertEquals("Max Steuer", $personName);
+        $this->assertEquals("Steuerabteilung", $deptName);
+        $this->assertEquals("+49 221 555 0001", $phone);
+        $this->assertEquals("+49 221 555 0002", $fax);
+        $this->assertEquals("max@taxrep.de", $email);
     }
 
     public function testNextDocumentBuyerTaxRepresentativeContact(): void
     {
         self::$document->firstDocumentBuyerTaxRepresentativeContact();
-        self::assertTrue(self::$document->nextDocumentBuyerTaxRepresentativeContact());
+        $this->assertTrue(self::$document->nextDocumentBuyerTaxRepresentativeContact());
     }
 
     public function testGetDocumentBuyerTaxRepresentativeContactSecond(): void
@@ -178,17 +181,85 @@ class ReaderExtendedBuyerTaxRepresentativeTest extends TestCase
         self::$document->nextDocumentBuyerTaxRepresentativeContact();
         self::$document->getDocumentBuyerTaxRepresentativeContact($personName, $deptName, $phone, $fax, $email);
 
-        self::assertEquals("Lisa Abgabe", $personName);
-        self::assertEquals("Buchhaltung", $deptName);
-        self::assertEquals("+49 221 555 0003", $phone);
-        self::assertEquals("+49 221 555 0004", $fax);
-        self::assertEquals("lisa@taxrep.de", $email);
+        $this->assertEquals("Lisa Abgabe", $personName);
+        $this->assertEquals("Buchhaltung", $deptName);
+        $this->assertEquals("+49 221 555 0003", $phone);
+        $this->assertEquals("+49 221 555 0004", $fax);
+        $this->assertEquals("lisa@taxrep.de", $email);
     }
 
     public function testNoThirdContact(): void
     {
         self::$document->firstDocumentBuyerTaxRepresentativeContact();
         self::$document->nextDocumentBuyerTaxRepresentativeContact();
-        self::assertFalse(self::$document->nextDocumentBuyerTaxRepresentativeContact());
+        $this->assertFalse(self::$document->nextDocumentBuyerTaxRepresentativeContact());
+    }
+
+    public function testGetDocumentUltimateCustomerOrderReferencedDocuments(): void
+    {
+        self::$document->getDocumentUltimateCustomerOrderReferencedDocuments($refdocs);
+
+        $this->assertIsArray($refdocs);
+        $this->assertCount(2, $refdocs);
+        $this->assertEquals("UCO-001", $refdocs[0]['issuerAssignedId']);
+        $this->assertEquals("UCO-002", $refdocs[1]['issuerAssignedId']);
+    }
+
+    public function testFirstDocumentUltimateCustomerOrderReferencedDocument(): void
+    {
+        $this->assertTrue(self::$document->firstDocumentUltimateCustomerOrderReferencedDocument());
+    }
+
+    public function testGetDocumentUltimateCustomerOrderReferencedDocumentFirst(): void
+    {
+        self::$document->firstDocumentUltimateCustomerOrderReferencedDocument();
+        self::$document->getDocumentUltimateCustomerOrderReferencedDocument($issuerAssignedId, $issueDate);
+
+        $this->assertEquals("UCO-001", $issuerAssignedId);
+        $this->assertInstanceOf(\DateTime::class, $issueDate);
+        $this->assertEquals("20250501", $issueDate->format("Ymd"));
+    }
+
+    public function testNextDocumentUltimateCustomerOrderReferencedDocument(): void
+    {
+        self::$document->firstDocumentUltimateCustomerOrderReferencedDocument();
+        $this->assertTrue(self::$document->nextDocumentUltimateCustomerOrderReferencedDocument());
+
+        self::$document->getDocumentUltimateCustomerOrderReferencedDocument($issuerAssignedId, $issueDate);
+
+        $this->assertEquals("UCO-002", $issuerAssignedId);
+        $this->assertEquals("20250515", $issueDate->format("Ymd"));
+    }
+
+    public function testNoThirdDocumentUltimateCustomerOrderReferencedDocument(): void
+    {
+        self::$document->firstDocumentUltimateCustomerOrderReferencedDocument();
+        self::$document->nextDocumentUltimateCustomerOrderReferencedDocument();
+        $this->assertFalse(self::$document->nextDocumentUltimateCustomerOrderReferencedDocument());
+    }
+
+    public function testFirstDocumentPositionUltimateCustomerOrderReferencedDocument(): void
+    {
+        self::$document->firstDocumentPosition();
+        $this->assertTrue(self::$document->firstDocumentPositionUltimateCustomerOrderReferencedDocument());
+    }
+
+    public function testGetDocumentPositionUltimateCustomerOrderReferencedDocument(): void
+    {
+        self::$document->firstDocumentPosition();
+        self::$document->firstDocumentPositionUltimateCustomerOrderReferencedDocument();
+        self::$document->getDocumentPositionUltimateCustomerOrderReferencedDocument($issuerAssignedId, $lineId, $issueDate);
+
+        $this->assertEquals("POS-UCO-001", $issuerAssignedId);
+        $this->assertEquals("10", $lineId);
+        $this->assertInstanceOf(\DateTime::class, $issueDate);
+        $this->assertEquals("20250520", $issueDate->format("Ymd"));
+    }
+
+    public function testNoSecondDocumentPositionUltimateCustomerOrderReferencedDocument(): void
+    {
+        self::$document->firstDocumentPosition();
+        self::$document->firstDocumentPositionUltimateCustomerOrderReferencedDocument();
+        $this->assertFalse(self::$document->nextDocumentPositionUltimateCustomerOrderReferencedDocument());
     }
 }


### PR DESCRIPTION
## Summary

- **BuyerTaxRepresentativeParty (BG-X-54, EXTENDED profile):** Full Builder + Reader implementation with 7 builder methods and 10 reader methods, including pointer-based contact iteration. Based on the work by [NicedriverMX](https://github.com/NicedriverMX/zugferd).
- **`getDocumentBusinessProcess()`:** Reader counterpart to `setDocumentBusinessProcess()` (BT-23)
- **`getDocumentForeignCurrency()`:** Reader counterpart to `setForeignCurrency()` (BT-6, BT-X-260), returns currency code, tax amount, and exchange rate
- **`getDocumentUltimateCustomerOrderReferencedDocuments()`:** Previously a TODO stub, now fully implemented with batch getter and pointer-based iteration (first/next/get)
- **Position-level `UltimateCustomerOrderReferencedDocument`:** New `firstDocumentPositionUltimateCustomerOrderReferencedDocument()`, `nextDocumentPositionUltimateCustomerOrderReferencedDocument()`, `getDocumentPositionUltimateCustomerOrderReferencedDocument()` matching the existing builder method
- **XML Catalog** for Factur-X / UN/CEFACT namespace resolution (IDE/tooling helper, not used at runtime)

## New Builder methods

| Method | Profile | Description |
|--------|---------|-------------|
| `setDocumentBuyerTaxRepresentativeTradeParty()` | EXTENDED | Set name and ID |
| `addDocumentBuyerTaxRepresentativeGlobalId()` | EXTENDED | Add global identifier |
| `addDocumentBuyerTaxRepresentativeTaxRegistration()` | EXTENDED | Add tax registration |
| `setDocumentBuyerTaxRepresentativeAddress()` | EXTENDED | Set postal address |
| `setDocumentBuyerTaxRepresentativeLegalOrganisation()` | EXTENDED | Set legal organisation |
| `setDocumentBuyerTaxRepresentativeContact()` | EXTENDED | Set/replace contact |
| `addDocumentBuyerTaxRepresentativeContact()` | EXTENDED | Add additional contact |

## New Reader methods

| Method | Description |
|--------|-------------|
| `getDocumentBusinessProcess()` | BT-23 business process context |
| `getDocumentForeignCurrency()` | BT-6/BT-X-260 foreign currency + exchange rate |
| `getDocumentBuyerTaxRepresentative()` | Name, ID, description |
| `getDocumentBuyerTaxRepresentativeGlobalId()` | Global identifiers |
| `getDocumentBuyerTaxRepresentativeTaxRegistration()` | Tax registrations |
| `getDocumentBuyerTaxRepresentativeAddress()` | Postal address |
| `getDocumentBuyerTaxRepresentativeLegalOrganisation()` | Legal organisation |
| `first/next/getDocumentBuyerTaxRepresentativeContact()` | Contact iteration |
| `getDocumentUltimateCustomerOrderReferencedDocuments()` | Batch getter (was TODO stub) |
| `first/next/getDocumentUltimateCustomerOrderReferencedDocument()` | Pointer iteration |
| `first/next/getDocumentPositionUltimateCustomerOrderReferencedDocument()` | Position-level pointer iteration |

## Files changed (5)

| File | Change |
|------|--------|
| `src/ZugferdDocumentBuilder.php` | +130 lines: 7 BuyerTaxRepresentative builder methods |
| `src/ZugferdDocumentReader.php` | +285 lines: All new reader methods listed above |
| `tests/testcases/ReaderExtendedBuyerTaxRepresentativeTest.php` | New: 21 round-trip tests (60 assertions) |
| `src/schema/catalog.xml` | New: XML Catalog for IDE namespace resolution |
| `build/phpunit.xml` | Register new test suite |

## Test plan

- [x] All 21 new tests pass (60 assertions)
- [x] Full test suite passes (2072 tests, 14139 assertions)
- [x] No new failures introduced
- [x] Round-trip verified: build with Builder → read with Reader → values match
- [x] Edge case: `getDocumentForeignCurrency()` returns defaults when not set
- [x] Contact iteration: first, next, boundary (no third contact)
- [x] UltimateCustomerOrder: document-level batch + pointer, position-level pointer, boundaries
- [ ] Verify BuyerTaxRepresentativeParty serializes correctly against EXTENDED profile XSD

**Tested on:** PHP 8.5.6, PHPUnit 11.5.55, openSUSE Tumbleweed

Co-Authored-By: NicedriverMX (BuyerTaxRepresentativeParty concept)