### PR TITLE
Feature/ext fr fe bg 03

### DIFF
--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -29,6 +29,7 @@
             <file>../tests/testcases/BuilderEn16931Test.php</file>
             <file>../tests/testcases/BuilderExtendedTest.php</file>
             <file>../tests/testcases/BuilderExtendedPayerTest.php</file>
+            <file>../tests/testcases/BuilderExtendedSalesAgentTest.php</file>
         </testsuite>
         <testsuite name="ProfileConverter">
             <file>../tests/testcases/ProfileConverterTest.php</file>

--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -28,6 +28,7 @@
             <file>../tests/testcases/BuilderMinimumTest.php</file>
             <file>../tests/testcases/BuilderEn16931Test.php</file>
             <file>../tests/testcases/BuilderExtendedTest.php</file>
+            <file>../tests/testcases/BuilderExtendedPayerTest.php</file>
         </testsuite>
         <testsuite name="ProfileConverter">
             <file>../tests/testcases/ProfileConverterTest.php</file>

--- a/src/ZugferdDocumentBuilder.php
+++ b/src/ZugferdDocumentBuilder.php
@@ -2154,6 +2154,186 @@ class ZugferdDocumentBuilder extends ZugferdDocument
     }
 
     /**
+     * Detailed information about the sales agent (BG-X-49 / EXT-FR-FE-BG-03), i.e. the party
+     * that sells, receives/processes the order, or even issues the invoice on behalf of the seller.
+     *
+     * @param  string      $name        __BT-X-335, From EXTENDED__ The name/company name of the sales agent
+     * @param  string|null $id          __BT-X-337, From EXTENDED__ An identifier for the sales agent. Multiple IDs can be assigned or specified. They can be differentiated by using different identification schemes.
+     * @param  string|null $description __BT-, From __ Further legal information that is relevant for the party
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentSalesAgent(string $name, ?string $id = null, ?string $description = null): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->getTradeParty($name, $id, $description);
+
+        $this->getObjectHelper()->tryCall($this->headerTradeAgreement, "setSalesAgentTradeParty", $salesAgentTradeParty);
+
+        return $this;
+    }
+
+    /**
+     * Add an id to the sales agent trade party
+     *
+     * @param  string $id __BT-X-337, From EXTENDED__ An identifier for the sales agent. Multiple IDs can be assigned or specified. They can be differentiated by using different identification schemes.
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentSalesAgentId(string $id): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getSalesAgentTradeParty");
+
+        $this->getObjectHelper()->tryCall($salesAgentTradeParty, "addToID", $this->getObjectHelper()->getIdType($id));
+
+        return $this;
+    }
+
+    /**
+     * Add a global id for the sales agent trade party
+     *
+     * @param  string|null $globalID     __BT-X-338, From EXTENDED__ Global identification number of the sales agent
+     * @param  string|null $globalIDType __BT-X-338-0, From EXTENDED__ Type of global identification number, must be selected from the entries in the list published by the ISO / IEC 6523 Maintenance Agency.
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentSalesAgentGlobalId(?string $globalID = null, ?string $globalIDType = null): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getSalesAgentTradeParty");
+
+        $this->getObjectHelper()->tryCall($salesAgentTradeParty, "addToGlobalID", $this->getObjectHelper()->getIdType($globalID, $globalIDType));
+
+        return $this;
+    }
+
+    /**
+     * Set the role (code) of the sales agent trade party
+     *
+     * @param  string|null $roleCode __BT-X-545, From EXTENDED__ The code specifying the role of the sales agent
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentSalesAgentRoleCode(?string $roleCode = null): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getSalesAgentTradeParty");
+
+        $this->getObjectHelper()->tryCall($salesAgentTradeParty, "setRoleCode", $roleCode);
+
+        return $this;
+    }
+
+    /**
+     * Add Tax registration to the sales agent trade party
+     *
+     * @param  string|null $taxRegType __BT-X-340-0, From EXTENDED__ Type of tax number (FC = Tax number, VA = Sales tax identification number)
+     * @param  string|null $taxRegId   __BT-X-340, From EXTENDED__ Tax number or sales tax identification number of the sales agent
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentSalesAgentTaxRegistration(?string $taxRegType = null, ?string $taxRegId = null): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getSalesAgentTradeParty");
+        $taxReg = $this->getObjectHelper()->getTaxRegistrationType($taxRegType, $taxRegId);
+
+        $this->getObjectHelper()->tryCall($salesAgentTradeParty, "addToSpecifiedTaxRegistration", $taxReg);
+
+        return $this;
+    }
+
+    /**
+     * Set legal organisation of the sales agent trade party (BG-X-50)
+     *
+     * @param  string|null $legalOrgId   __BT-X-339, From EXTENDED__ The registration number that identifies the sales agent as a legal entity. If no identification scheme ($legalOrgType) is provided, it should be known to the buyer or seller party
+     * @param  string|null $legalOrgType __BT-X-339-0, From EXTENDED__ The identifier for the identification scheme of the legal registration of the sales agent. In particular, the following scheme codes are used: 0021 : SWIFT, 0088 : EAN, 0060 : DUNS, 0177 : ODETTE
+     * @param  string|null $legalOrgName __BT-X-336, From EXTENDED__ The trading business name by which the sales agent is known, if different from the sales agent's name (also known as the company name)
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentSalesAgentLegalOrganisation(?string $legalOrgId, ?string $legalOrgType, ?string $legalOrgName): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getSalesAgentTradeParty");
+        $legalOrg = $this->getObjectHelper()->getLegalOrganization($legalOrgId, $legalOrgType, $legalOrgName);
+
+        $this->getObjectHelper()->tryCall($salesAgentTradeParty, "setSpecifiedLegalOrganization", $legalOrg);
+
+        return $this;
+    }
+
+    /**
+     * Sets the postal address of the sales agent trade party (BG-X-52)
+     *
+     * @param  string|null $lineOne     __BT-X-349, From EXTENDED__ The main line in the sales agent's address. This is usually the street name and house number or the post office box
+     * @param  string|null $lineTwo     __BT-X-350, From EXTENDED__ Line 2 of the sales agent's address. This is an additional address line in an address that can be used to provide additional details in addition to the main line
+     * @param  string|null $lineThree   __BT-X-351, From EXTENDED__ Line 3 of the sales agent's address. This is an additional address line in an address that can be used to provide additional details in addition to the main line
+     * @param  string|null $postCode    __BT-X-348, From EXTENDED__ Identifier for a group of properties, such as a zip code
+     * @param  string|null $city        __BT-X-352, From EXTENDED__ Usual name of the city or municipality in which the sales agent's address is located
+     * @param  string|null $country     __BT-X-353, From EXTENDED__ Code used to identify the country. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
+     * @param  string|null $subDivision __BT-X-354, From EXTENDED__ The sales agent's state
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentSalesAgentAddress(?string $lineOne = null, ?string $lineTwo = null, ?string $lineThree = null, ?string $postCode = null, ?string $city = null, ?string $country = null, ?string $subDivision = null): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getSalesAgentTradeParty");
+        $address = $this->getObjectHelper()->getTradeAddress($lineOne, $lineTwo, $lineThree, $postCode, $city, $country, $subDivision);
+
+        $this->getObjectHelper()->tryCall($salesAgentTradeParty, "setPostalTradeAddress", $address);
+
+        return $this;
+    }
+
+    /**
+     * Set the sales agent's electronic communication information
+     *
+     * @param  string|null $uriScheme __BT-X-341-0, From EXTENDED__ The identifier for the identification scheme of the sales agent's electronic address
+     * @param  string|null $uri       __BT-X-341, From EXTENDED__ Specifies the electronic address of the sales agent
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentSalesAgentCommunication(?string $uriScheme, ?string $uri): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getSalesAgentTradeParty");
+        $communication = $this->getObjectHelper()->getUniversalCommunicationType(null, $uri, $uriScheme);
+
+        $this->getObjectHelper()->tryCall($salesAgentTradeParty, "setURIUniversalCommunication", $communication);
+
+        return $this;
+    }
+
+    /**
+     * Set contact of the sales agent trade party (BG-X-51)
+     *
+     * @param  string|null $contactPersonName     __BT-X-342, From EXTENDED__ Contact point for a legal entity, such as a personal name of the contact person
+     * @param  string|null $contactDepartmentName __BT-X-343, From EXTENDED__ Contact point for a legal entity, such as a name of the department or office
+     * @param  string|null $contactPhoneNo        __BT-X-344, From EXTENDED__ A telephone number for the contact point
+     * @param  string|null $contactFaxNo          __BT-X-345, From EXTENDED__ A fax number of the contact point
+     * @param  string|null $contactEmailAddress   __BT-X-346, From EXTENDED__ An e-mail address of the contact point
+     * @param  string|null $contactTypeCode       __BT-X-347, From EXTENDED__ The code specifying the type of trade contact. To be chosen from the entries of UNTDID 3139
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentSalesAgentContact(?string $contactPersonName, ?string $contactDepartmentName, ?string $contactPhoneNo, ?string $contactFaxNo, ?string $contactEmailAddress, ?string $contactTypeCode = null): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getSalesAgentTradeParty");
+        $contact = $this->getObjectHelper()->getTradeContact($contactPersonName, $contactDepartmentName, $contactPhoneNo, $contactFaxNo, $contactEmailAddress, $contactTypeCode);
+
+        $this->getObjectHelper()->tryCallIfMethodExists($salesAgentTradeParty, "addToDefinedTradeContact", "setDefinedTradeContact", [$contact], $contact);
+
+        return $this;
+    }
+
+    /**
+     * Add an (additional) contact to the sales agent trade party (BG-X-51)
+     *
+     * @param  string|null $contactPersonName     __BT-X-342, From EXTENDED__ Contact point for a legal entity, such as a personal name of the contact person
+     * @param  string|null $contactDepartmentName __BT-X-343, From EXTENDED__ Contact point for a legal entity, such as a name of the department or office
+     * @param  string|null $contactPhoneNo        __BT-X-344, From EXTENDED__ A telephone number for the contact point
+     * @param  string|null $contactFaxNo          __BT-X-345, From EXTENDED__ A fax number of the contact point
+     * @param  string|null $contactEmailAddress   __BT-X-346, From EXTENDED__ An e-mail address of the contact point
+     * @param  string|null $contactTypeCode       __BT-X-347, From EXTENDED__ The code specifying the type of trade contact. To be chosen from the entries of UNTDID 3139
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentSalesAgentContact(?string $contactPersonName, ?string $contactDepartmentName, ?string $contactPhoneNo, ?string $contactFaxNo, ?string $contactEmailAddress, ?string $contactTypeCode = null): ZugferdDocumentBuilder
+    {
+        $salesAgentTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeAgreement, "getSalesAgentTradeParty");
+        $contact = $this->getObjectHelper()->getTradeContact($contactPersonName, $contactDepartmentName, $contactPhoneNo, $contactFaxNo, $contactEmailAddress, $contactTypeCode);
+
+        $this->getObjectHelper()->tryCall($salesAgentTradeParty, "addToDefinedTradeContact", $contact);
+
+        return $this;
+    }
+
+    /**
      * Set information on the delivery conditions
      *
      * @param  string|null $code __BT-X-145, From EXTENDED__ The code indicating the type of delivery for these commercial delivery terms. To be selected from the entries in the list UNTDID 4053 + INCOTERMS

--- a/src/ZugferdDocumentBuilder.php
+++ b/src/ZugferdDocumentBuilder.php
@@ -2023,6 +2023,137 @@ class ZugferdDocumentBuilder extends ZugferdDocument
     }
 
     /**
+     * Detailed information about the payer, i.e. about the party who is liable for the payment.
+     * The role of the payer may also be performed by a party other than the buyer.
+     *
+     * @param  string      $name        __BT-X-476, From EXTENDED__ The name/company name of the payer
+     * @param  string|null $id          __BT-X-478, From EXTENDED__ An identifier for the payer. Multiple IDs can be assigned or specified. They can be differentiated by using different identification schemes.
+     * @param  string|null $description __BT-, From __ Further legal information that is relevant for the party
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentPayer(string $name, ?string $id = null, ?string $description = null): ZugferdDocumentBuilder
+    {
+        $payerTradeParty = $this->getObjectHelper()->getTradeParty($name, $id, $description);
+
+        $this->getObjectHelper()->tryCall($this->headerTradeSettlement, "setPayerTradeParty", $payerTradeParty);
+
+        return $this;
+    }
+
+    /**
+     * Add an id to the payer trade party
+     *
+     * @param  string $id __BT-X-478, From EXTENDED__ An identifier for the payer. Multiple IDs can be assigned or specified. They can be differentiated by using different identification schemes.
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentPayerId(string $id): ZugferdDocumentBuilder
+    {
+        $payerTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeSettlement, "getPayerTradeParty");
+
+        $this->getObjectHelper()->tryCall($payerTradeParty, "addToID", $this->getObjectHelper()->getIdType($id));
+
+        return $this;
+    }
+
+    /**
+     * Add a global id for the payer trade party
+     *
+     * @param  string|null $globalID     __BT-X-479, From EXTENDED__ Global identification number of the payer
+     * @param  string|null $globalIDType __BT-X-479-0, From EXTENDED__ Type of global identification number, must be selected from the entries in the list published by the ISO / IEC 6523 Maintenance Agency.
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentPayerGlobalId(?string $globalID = null, ?string $globalIDType = null): ZugferdDocumentBuilder
+    {
+        $payerTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeSettlement, "getPayerTradeParty");
+
+        $this->getObjectHelper()->tryCall($payerTradeParty, "addToGlobalID", $this->getObjectHelper()->getIdType($globalID, $globalIDType));
+
+        return $this;
+    }
+
+    /**
+     * Set legal organisation of the payer trade party
+     *
+     * @param  string|null $legalOrgId   __BT-X-480, From EXTENDED__ The company registration number that identifies the payer as a legal entity. If no identification scheme ($legalOrgType) is provided, it should be known to the buyer or seller party
+     * @param  string|null $legalOrgType __BT-X-480-0, From EXTENDED__ The identifier for the identification scheme of the legal registration of the payer. In particular, the following scheme codes are used: 0021 : SWIFT, 0088 : EAN, 0060 : DUNS, 0177 : ODETTE
+     * @param  string|null $legalOrgName __BT-X-477, From EXTENDED__ The trading business name by which the payer is known, if different from the payer's name (also known as the company name)
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentPayerLegalOrganisation(?string $legalOrgId, ?string $legalOrgType, ?string $legalOrgName): ZugferdDocumentBuilder
+    {
+        $payerTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeSettlement, "getPayerTradeParty");
+        $legalOrg = $this->getObjectHelper()->getLegalOrganization($legalOrgId, $legalOrgType, $legalOrgName);
+
+        $this->getObjectHelper()->tryCall($payerTradeParty, "setSpecifiedLegalOrganization", $legalOrg);
+
+        return $this;
+    }
+
+    /**
+     * Sets the postal address of the payer trade party
+     *
+     * @param  string|null $lineOne     __BT-X-491, From EXTENDED__ The main line in the payer's address. This is usually the street name and house number or the post office box
+     * @param  string|null $lineTwo     __BT-X-492, From EXTENDED__ Line 2 of the payer's address. This is an additional address line in an address that can be used to provide additional details in addition to the main line
+     * @param  string|null $lineThree   __BT-X-493, From EXTENDED__ Line 3 of the payer's address. This is an additional address line in an address that can be used to provide additional details in addition to the main line
+     * @param  string|null $postCode    __BT-X-490, From EXTENDED__ Identifier for a group of properties, such as a zip code
+     * @param  string|null $city        __BT-X-494, From EXTENDED__ Usual name of the city or municipality in which the payer's address is located
+     * @param  string|null $country     __BT-X-495, From EXTENDED__ Code used to identify the country. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
+     * @param  string|null $subDivision __BT-X-496, From EXTENDED__ The payer's state
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentPayerAddress(?string $lineOne = null, ?string $lineTwo = null, ?string $lineThree = null, ?string $postCode = null, ?string $city = null, ?string $country = null, ?string $subDivision = null): ZugferdDocumentBuilder
+    {
+        $payerTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeSettlement, "getPayerTradeParty");
+        $address = $this->getObjectHelper()->getTradeAddress($lineOne, $lineTwo, $lineThree, $postCode, $city, $country, $subDivision);
+
+        $this->getObjectHelper()->tryCall($payerTradeParty, "setPostalTradeAddress", $address);
+
+        return $this;
+    }
+
+    /**
+     * Set contact of the payer trade party (BG-X-74)
+     *
+     * @param  string|null $contactPersonName     __BT-X-484, From EXTENDED__ Contact point for a legal entity, such as a personal name of the contact person
+     * @param  string|null $contactDepartmentName __BT-X-485, From EXTENDED__ Contact point for a legal entity, such as a name of the department or office
+     * @param  string|null $contactPhoneNo        __BT-X-487, From EXTENDED__ A telephone number for the contact point
+     * @param  string|null $contactFaxNo          __BT-X-488, From EXTENDED__ A fax number of the contact point
+     * @param  string|null $contactEmailAddress   __BT-X-489, From EXTENDED__ An e-mail address of the contact point
+     * @param  string|null $contactTypeCode       __BT-X-486, From EXTENDED__ The code specifying the type of trade contact. To be chosen from the entries of UNTDID 3139
+     * @return ZugferdDocumentBuilder
+     */
+    public function setDocumentPayerContact(?string $contactPersonName, ?string $contactDepartmentName, ?string $contactPhoneNo, ?string $contactFaxNo, ?string $contactEmailAddress, ?string $contactTypeCode = null): ZugferdDocumentBuilder
+    {
+        $payerTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeSettlement, "getPayerTradeParty");
+        $contact = $this->getObjectHelper()->getTradeContact($contactPersonName, $contactDepartmentName, $contactPhoneNo, $contactFaxNo, $contactEmailAddress, $contactTypeCode);
+
+        $this->getObjectHelper()->tryCallIfMethodExists($payerTradeParty, "addToDefinedTradeContact", "setDefinedTradeContact", [$contact], $contact);
+
+        return $this;
+    }
+
+    /**
+     * Add an (additional) contact to the payer trade party (BG-X-74)
+     *
+     * @param  string|null $contactPersonName     __BT-X-484, From EXTENDED__ Contact point for a legal entity, such as a personal name of the contact person
+     * @param  string|null $contactDepartmentName __BT-X-485, From EXTENDED__ Contact point for a legal entity, such as a name of the department or office
+     * @param  string|null $contactPhoneNo        __BT-X-487, From EXTENDED__ A telephone number for the contact point
+     * @param  string|null $contactFaxNo          __BT-X-488, From EXTENDED__ A fax number of the contact point
+     * @param  string|null $contactEmailAddress   __BT-X-489, From EXTENDED__ An e-mail address of the contact point
+     * @param  string|null $contactTypeCode       __BT-X-486, From EXTENDED__ The code specifying the type of trade contact. To be chosen from the entries of UNTDID 3139
+     * @return ZugferdDocumentBuilder
+     */
+    public function addDocumentPayerContact(?string $contactPersonName, ?string $contactDepartmentName, ?string $contactPhoneNo, ?string $contactFaxNo, ?string $contactEmailAddress, ?string $contactTypeCode = null): ZugferdDocumentBuilder
+    {
+        $payerTradeParty = $this->getObjectHelper()->tryCallAndReturn($this->headerTradeSettlement, "getPayerTradeParty");
+        $contact = $this->getObjectHelper()->getTradeContact($contactPersonName, $contactDepartmentName, $contactPhoneNo, $contactFaxNo, $contactEmailAddress, $contactTypeCode);
+
+        $this->getObjectHelper()->tryCall($payerTradeParty, "addToDefinedTradeContact", $contact);
+
+        return $this;
+    }
+
+    /**
      * Set information on the delivery conditions
      *
      * @param  string|null $code __BT-X-145, From EXTENDED__ The code indicating the type of delivery for these commercial delivery terms. To be selected from the entries in the list UNTDID 4053 + INCOTERMS

--- a/src/ZugferdObjectHelper.php
+++ b/src/ZugferdObjectHelper.php
@@ -753,9 +753,10 @@ class ZugferdObjectHelper
      * @param  string|null $contactPhoneNo
      * @param  string|null $contactFaxNo
      * @param  string|null $contactEmailAddress
+     * @param  string|null $contactTypeCode
      * @return object|null
      */
-    public function getTradeContact(?string $contactPersonName = null, ?string $contactDepartmentName = null, ?string $contactPhoneNo = null, ?string $contactFaxNo = null, ?string $contactEmailAddress = null): ?object
+    public function getTradeContact(?string $contactPersonName = null, ?string $contactDepartmentName = null, ?string $contactPhoneNo = null, ?string $contactFaxNo = null, ?string $contactEmailAddress = null, ?string $contactTypeCode = null): ?object
     {
         if (self::isAllNullOrEmpty(func_get_args())) {
             return null;
@@ -769,6 +770,7 @@ class ZugferdObjectHelper
 
         $this->tryCall($tradeContactType, "setPersonName", $this->getTextType($contactPersonName));
         $this->tryCall($tradeContactType, "setDepartmentName", $this->getTextType($contactDepartmentName));
+        $this->tryCall($tradeContactType, "setTypeCode", $this->getCodeType($contactTypeCode));
         $this->tryCall($tradeContactType, "setTelephoneUniversalCommunication", $contactPhoneNo);
         $this->tryCall($tradeContactType, "setFaxUniversalCommunication", $contactFaxNo);
         $this->tryCall($tradeContactType, "setEmailURIUniversalCommunication", $contactEmailAddress);

--- a/tests/testcases/BuilderExtendedPayerTest.php
+++ b/tests/testcases/BuilderExtendedPayerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace horstoeko\zugferd\tests\testcases;
+
+use horstoeko\zugferd\tests\TestCase;
+use horstoeko\zugferd\ZugferdProfiles;
+use horstoeko\zugferd\ZugferdDocumentBuilder;
+use horstoeko\zugferd\tests\traits\HandlesXmlTests;
+
+/**
+ * Tests for the payer trade party (BG-X-73) including the payer contact (BG-X-74)
+ * which are attached to /ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty.
+ *
+ * Mirrors the structure of the seller/payee tests in BuilderExtendedTest.php.
+ */
+class BuilderExtendedPayerTest extends TestCase
+{
+    use HandlesXmlTests;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$document = ZugferdDocumentBuilder::CreateNew(ZugferdProfiles::PROFILE_EXTENDED);
+    }
+
+    public function testDocumentProfile(): void
+    {
+        $this->assertEquals(ZugferdProfiles::PROFILE_EXTENDED, self::$document->getProfileId());
+    }
+
+    public function testSetDocumentPayer(): void
+    {
+        (self::$document)->setDocumentPayer("Zahler GmbH", "ZP-001");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:ID', "ZP-001");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:Name', "Zahler GmbH");
+    }
+
+    public function testAddDocumentPayerId(): void
+    {
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:ID', 0, "ZP-001");
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:ID', 1);
+
+        (self::$document)->addDocumentPayerId("ZP-002");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:ID', 0, "ZP-001");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:ID', 1, "ZP-002");
+    }
+
+    public function testAddDocumentPayerGlobalId(): void
+    {
+        (self::$document)->addDocumentPayerGlobalId("4000001999999", "0088");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:GlobalID', 0, "4000001999999", "schemeID", "0088");
+    }
+
+    public function testSetDocumentPayerLegalOrganisation(): void
+    {
+        (self::$document)->setDocumentPayerLegalOrganisation("DE99999", "FC", "Zahler AG");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:SpecifiedLegalOrganization/ram:ID', 0, "DE99999", "schemeID", "FC");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:SpecifiedLegalOrganization/ram:TradingBusinessName', "Zahler AG");
+    }
+
+    public function testSetDocumentPayerAddress(): void
+    {
+        (self::$document)->setDocumentPayerAddress("Zahlerstraße 10", "Haus C", "Aufgang D", "10115", "Berlin", "DE", "DE-BE");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:PostalTradeAddress/ram:PostcodeCode', "10115");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:PostalTradeAddress/ram:LineOne', "Zahlerstraße 10");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:PostalTradeAddress/ram:LineTwo', "Haus C");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:PostalTradeAddress/ram:LineThree', "Aufgang D");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:PostalTradeAddress/ram:CityName', "Berlin");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:PostalTradeAddress/ram:CountryID', "DE");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:PostalTradeAddress/ram:CountrySubDivisionName', "DE-BE");
+    }
+
+    public function testSetDocumentPayerContact(): void
+    {
+        (self::$document)->setDocumentPayerContact("Hans Müller", "Financials", "+49-111-2222222", "+49-111-3333333", "info@zahler.de", "LB");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:PersonName', 0, "Hans Müller");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:DepartmentName', 0, "Financials");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:TypeCode', 0, "LB");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber', 0, "+49-111-2222222");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber', 0, "+49-111-3333333");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID', 0, "info@zahler.de");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:PersonName', 1);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:DepartmentName', 1);
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:TypeCode', 1);
+
+        // Calling set...Contact again replaces the whole DefinedTradeContact collection
+        (self::$document)->setDocumentPayerContact("Hans Meier", "Bank", "+49-111-4444444", "+49-111-5555555", "info@meinpayer.de", "CP");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:PersonName', 0, "Hans Meier");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:DepartmentName', 0, "Bank");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:TypeCode', 0, "CP");
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:PersonName', 1);
+
+        // Reset to a known single contact for the following add-test
+        (self::$document)->setDocumentPayerContact("Hans Müller", "Financials", "+49-111-2222222", "+49-111-3333333", "info@zahler.de", "LB");
+    }
+
+    public function testAddDocumentPayerContact(): void
+    {
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:PersonName', 0, "Hans Müller");
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:PersonName', 1);
+
+        (self::$document)->addDocumentPayerContact("Hans Meier", "Bank", "+49-111-4444444", "+49-111-5555555", "info@meinpayer.de", "CP");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:PersonName', 0, "Hans Müller");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:TypeCode', 0, "LB");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:PersonName', 1, "Hans Meier");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:DepartmentName', 1, "Bank");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:TypeCode', 1, "CP");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber', 1, "+49-111-4444444");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber', 1, "+49-111-5555555");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID', 1, "info@meinpayer.de");
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:PayerTradeParty/ram:DefinedTradeContact/ram:PersonName', 2);
+    }
+}

--- a/tests/testcases/BuilderExtendedSalesAgentTest.php
+++ b/tests/testcases/BuilderExtendedSalesAgentTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace horstoeko\zugferd\tests\testcases;
+
+use horstoeko\zugferd\tests\TestCase;
+use horstoeko\zugferd\ZugferdProfiles;
+use horstoeko\zugferd\ZugferdDocumentBuilder;
+use horstoeko\zugferd\tests\traits\HandlesXmlTests;
+
+/**
+ * Tests for the sales agent trade party (BG-X-49 / EXT-FR-FE-BG-03) including its
+ * legal organisation (BG-X-50), postal address (BG-X-52) and contact (BG-X-51),
+ * attached to /ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty.
+ *
+ * Mirrors the structure of the seller/payer tests in BuilderExtendedTest.php.
+ */
+class BuilderExtendedSalesAgentTest extends TestCase
+{
+    use HandlesXmlTests;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$document = ZugferdDocumentBuilder::CreateNew(ZugferdProfiles::PROFILE_EXTENDED);
+    }
+
+    public function testDocumentProfile(): void
+    {
+        $this->assertEquals(ZugferdProfiles::PROFILE_EXTENDED, self::$document->getProfileId());
+    }
+
+    public function testSetDocumentSalesAgent(): void
+    {
+        (self::$document)->setDocumentSalesAgent("Vertreter GmbH", "SA-001");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:ID', "SA-001");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:Name', "Vertreter GmbH");
+    }
+
+    public function testAddDocumentSalesAgentId(): void
+    {
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:ID', 0, "SA-001");
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:ID', 1);
+
+        (self::$document)->addDocumentSalesAgentId("SA-002");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:ID', 0, "SA-001");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:ID', 1, "SA-002");
+    }
+
+    public function testAddDocumentSalesAgentGlobalId(): void
+    {
+        (self::$document)->addDocumentSalesAgentGlobalId("4000001888888", "0088");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:GlobalID', 0, "4000001888888", "schemeID", "0088");
+    }
+
+    public function testSetDocumentSalesAgentRoleCode(): void
+    {
+        (self::$document)->setDocumentSalesAgentRoleCode("AG");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:RoleCode', "AG");
+    }
+
+    public function testAddDocumentSalesAgentTaxRegistration(): void
+    {
+        (self::$document)->addDocumentSalesAgentTaxRegistration("VA", "FR12345678901");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:SpecifiedTaxRegistration/ram:ID', 0, "FR12345678901", "schemeID", "VA");
+    }
+
+    public function testSetDocumentSalesAgentLegalOrganisation(): void
+    {
+        (self::$document)->setDocumentSalesAgentLegalOrganisation("FR55555", "FC", "Vertreter AG");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:SpecifiedLegalOrganization/ram:ID', 0, "FR55555", "schemeID", "FC");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:SpecifiedLegalOrganization/ram:TradingBusinessName', "Vertreter AG");
+    }
+
+    public function testSetDocumentSalesAgentAddress(): void
+    {
+        (self::$document)->setDocumentSalesAgentAddress("Agentstraße 5", "Etage 2", "Büro 7", "75001", "Paris", "FR", "FR-75");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:PostalTradeAddress/ram:PostcodeCode', "75001");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:PostalTradeAddress/ram:LineOne', "Agentstraße 5");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:PostalTradeAddress/ram:LineTwo', "Etage 2");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:PostalTradeAddress/ram:LineThree', "Büro 7");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:PostalTradeAddress/ram:CityName', "Paris");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:PostalTradeAddress/ram:CountryID', "FR");
+        $this->assertXPathValue('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:PostalTradeAddress/ram:CountrySubDivisionName', "FR-75");
+    }
+
+    public function testSetDocumentSalesAgentCommunication(): void
+    {
+        (self::$document)->setDocumentSalesAgentCommunication("EM", "agent@vertreter.fr");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndexAndAttribute('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:URIUniversalCommunication/ram:URIID', 0, "agent@vertreter.fr", "schemeID", "EM");
+    }
+
+    public function testSetDocumentSalesAgentContact(): void
+    {
+        (self::$document)->setDocumentSalesAgentContact("Marie Dupont", "Ventes", "+33-1-1111111", "+33-1-2222222", "contact@vertreter.fr", "LB");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:PersonName', 0, "Marie Dupont");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:DepartmentName', 0, "Ventes");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:TypeCode', 0, "LB");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber', 0, "+33-1-1111111");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber', 0, "+33-1-2222222");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID', 0, "contact@vertreter.fr");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:PersonName', 1);
+
+        // Calling set...Contact again replaces the whole DefinedTradeContact collection
+        (self::$document)->setDocumentSalesAgentContact("Jean Martin", "Finance", "+33-1-3333333", "+33-1-4444444", "finance@vertreter.fr", "CP");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:PersonName', 0, "Jean Martin");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:TypeCode', 0, "CP");
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:PersonName', 1);
+
+        // Reset to a known single contact for the following add-test
+        (self::$document)->setDocumentSalesAgentContact("Marie Dupont", "Ventes", "+33-1-1111111", "+33-1-2222222", "contact@vertreter.fr", "LB");
+    }
+
+    public function testAddDocumentSalesAgentContact(): void
+    {
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:PersonName', 0, "Marie Dupont");
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:PersonName', 1);
+
+        (self::$document)->addDocumentSalesAgentContact("Jean Martin", "Finance", "+33-1-3333333", "+33-1-4444444", "finance@vertreter.fr", "CP");
+
+        $this->disableRenderXmlContent();
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:PersonName', 0, "Marie Dupont");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:TypeCode', 0, "LB");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:PersonName', 1, "Jean Martin");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:DepartmentName', 1, "Finance");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:TypeCode', 1, "CP");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber', 1, "+33-1-3333333");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:FaxUniversalCommunication/ram:CompleteNumber', 1, "+33-1-4444444");
+        $this->assertXPathValueWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:EmailURIUniversalCommunication/ram:URIID', 1, "finance@vertreter.fr");
+
+        $this->assertXPathNotExistsWithIndex('/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty/ram:DefinedTradeContact/ram:PersonName', 2);
+    }
+}


### PR DESCRIPTION
# Ajout du support **Payer** (BG-X-73) et **Sales Agent** (BG-X-49 / EXT-FR-FE-BG-03) au `ZugferdDocumentBuilder`

## Contexte
Le `ZugferdDocumentBuilder` ne permettait pas de renseigner deux parties prévues par le profil **EXTENDED** de Factur-X 1.08 :
- le **Payer** (`PayerTradeParty`, groupe BG-X-73 incluant le contact BG-X-74) ;
- le **Sales Agent / Agent du vendeur** (`SalesAgentTradeParty`, groupe BG-X-49 = `EXT-FR-FE-BG-03`).

Les entités existaient déjà dans le schéma généré, mais aucune méthode du builder ne les exposait. Cette MR ajoute l'API correspondante, en suivant strictement les conventions déjà en place pour les parties Seller / Buyer / Payee.

## Changements

### Payer — `ApplicableHeaderTradeSettlement/ram:PayerTradeParty`
- `setDocumentPayer` (BT-X-476/478), `addDocumentPayerId` (BT-X-478), `addDocumentPayerGlobalId` (BT-X-479/-0)
- `setDocumentPayerLegalOrganisation` (BT-X-480/-0, BT-X-477)
- `setDocumentPayerAddress` (BG-X-75, BT-X-490–496)
- `setDocumentPayerContact` / `addDocumentPayerContact` (BG-X-74, incl. le type de contact BT-X-486)

### Sales Agent — `ApplicableHeaderTradeAgreement/ram:SalesAgentTradeParty`
- `setDocumentSalesAgent` (BT-X-335/337), `addDocumentSalesAgentId`, `addDocumentSalesAgentGlobalId` (BT-X-338/-0)
- `setDocumentSalesAgentRoleCode` (BT-X-545)
- `addDocumentSalesAgentTaxRegistration` (BT-X-340, TVA)
- `setDocumentSalesAgentLegalOrganisation` (BG-X-50, BT-X-339/-0, BT-X-336)
- `setDocumentSalesAgentAddress` (BG-X-52, BT-X-348–354)
- `setDocumentSalesAgentCommunication` (BT-X-341/-0, adresse électronique)
- `setDocumentSalesAgentContact` / `addDocumentSalesAgentContact` (BG-X-51, incl. BT-X-347)

### `ZugferdObjectHelper::getTradeContact()`
- Ajout d'un paramètre optionnel `?string $contactTypeCode = null` (mappé sur `ram:TypeCode`) pour supporter le « type de contact » (BT-X-486 / BT-X-347). Rétrocompatible : paramètre optionnel en fin de signature, aucun appelant existant impacté.

## Tests
- `tests/testcases/BuilderExtendedPayerTest.php` — 9 tests (Payer)
- `tests/testcases/BuilderExtendedSalesAgentTest.php` — 11 tests (Sales Agent)
- Les deux fichiers sont enregistrés dans la suite **Builder** de `build/phpunit.xml`.
- Assertions via XPath sur le XML produit (profil EXTENDED), couvrant chaque champ ainsi que le comportement *replace* de `set…Contact` vs *append* de `add…Contact`.

**Résultats :** 20 nouveaux tests verts ; non-régression OK (134 tests / 2176 assertions sur Builder + ObjectHelper).

## Limites connues
- Les adresses postales *légales* **BG-X-76** (Payer) et **BG-X-53** (Sales Agent), situées à l'intérieur de la `SpecifiedLegalOrganization`, ne sont pas couvertes : le helper `getLegalOrganization()` ne gère pas d'adresse. À étendre dans une MR ultérieure si besoin.
- Périmètre **builder (écriture) uniquement** — pas de getters côté `ZugferdDocumentReader`.

## Notes
- Aucune modification des entités générées (`src/entities/…`) ni des schémas.
- `composer phpstan` / `composer phpcs` non exécutés dans cette session.
