### PR TITLE
Raise PHPStan to level 6 and fix the two bugs it surfaced

### DIFF
--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
     paths:
         - ../src
         - ../tests
-    level: 3
+    level: 4
     treatPhpDocTypesAsCertain: false
     excludePaths:
         - ../src/entities/*

--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
     paths:
         - ../src
         - ../tests
-    level: 4
+    level: 6
     treatPhpDocTypesAsCertain: false
     excludePaths:
         - ../src/entities/*

--- a/src/ZugferdDocument.php
+++ b/src/ZugferdDocument.php
@@ -16,6 +16,7 @@ use horstoeko\zugferd\exception\ZugferdUnknownProfileIdException;
 use horstoeko\zugferd\exception\ZugferdUnknownProfileParameterException;
 use horstoeko\zugferd\jms\ZugferdTypesHandler;
 use horstoeko\zugferd\ZugferdObjectHelper;
+use horstoeko\zugferd\ZugferdProfiles;
 use horstoeko\zugferd\ZugferdProfileResolver;
 use JMS\Serializer\Exception\InvalidArgumentException;
 use JMS\Serializer\Exception\RuntimeException;
@@ -31,6 +32,8 @@ use JMS\Serializer\SerializerInterface;
  * @author   D. Erling <horstoeko@erling.com.de>
  * @license  https://opensource.org/licenses/MIT MIT
  * @link     https://github.com/horstoeko/zugferd
+ *
+ * @phpstan-import-type ZugferdProfileDefinition from ZugferdProfiles
  */
 class ZugferdDocument
 {
@@ -40,7 +43,7 @@ class ZugferdDocument
     private $profileId = -1;
 
     /**
-     * @var array $profileDefinition Internal profile definition
+     * @var ZugferdProfileDefinition|array{} $profileDefinition Internal profile definition
      */
     private $profileDefinition = [];
 
@@ -136,7 +139,7 @@ class ZugferdDocument
     /**
      * Returns the profile definition
      *
-     * @return array
+     * @return ZugferdProfileDefinition|array{}
      */
     public function getProfileDefinition(): array
     {

--- a/src/ZugferdDocumentBuilder.php
+++ b/src/ZugferdDocumentBuilder.php
@@ -2119,7 +2119,7 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      *                                                    to reference an identifier for an object specified by the seller.
      * @param  string|null            $uriId              __BT-124, From EN 16931__ A means of locating the resource, including the primary access method intended for it, e.g. http:// or ftp://. The storage location of the external document must be used if the buyer requires further information as
      *                                                    supporting documents for the invoiced amounts. External documents are not part of the invoice. Invoice processing should be possible without access to external documents. Access to external documents can entail certain risks.
-     * @param  string|array|null      $name               __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
+     * @param  string|array<int, string>|null $name               __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
      * @param  string|null            $refTypeCode        __BT-18-1, From ENN 16931__ The identifier for the identification scheme of the identifier of the item invoiced. If it is not clear to the recipient which scheme is used for the identifier, an identifier of the scheme should be used, which must be selected from UNTDID 1153 in accordance with the code list entries.
      * @param  DateTimeInterface|null $issueDate          __BT-X-149, From EXTENDED__ Document date
      * @param  string|null            $binaryDataFilename __BT-125, From EN 16931__ Contains a file name of an attachment document embedded as a binary object
@@ -2143,7 +2143,7 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      *
      * @param  string            $issuerAssignedId __BT-122, From EN 16931__ Identification of the document supporting the invoice
      * @param  string            $uriId            __BT-124, From EN 16931__ A means of locating the resource, including the primary access method intended for it, e.g. http:// or ftp://. The storage location of the external document must be used if the buyer requires further information as
-     * @param  string|array|null $name             __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
+     * @param  string|array<int, string>|null $name             __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentInvoiceSupportingDocumentWithUri(string $issuerAssignedId, string $uriId, $name = null): ZugferdDocumentBuilder
@@ -2157,7 +2157,7 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      *
      * @param  string            $issuerAssignedId   __BT-122, From EN 16931__ Identification of the document supporting the invoice
      * @param  string            $binaryDataFilename __BT-125, From EN 16931__ Contains a file name of an attachment document embedded as a binary object
-     * @param  string|array|null $name               __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
+     * @param  string|array<int, string>|null $name               __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
      * @return ZugferdDocumentBuilder
      * @throws ZugferdUnsupportedMimetype
      */
@@ -2196,7 +2196,7 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * @param  string            $issuerAssignedId   __BT-122, From EN 16931__ Identification of the document supporting the invoice
      * @param  string            $attachmentFilename __BT-125, From EN 16931__ Contains a file name of an attachment document embedded as a binary object
      * @param  string            $base64EncodedData  __BT-125, From EN 16931__ Contains BASE64-Encoded data an attachment document embedded as a binary object. You must provide $binaryDataFilename
-     * @param  string|array|null $name               __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
+     * @param  string|array<int, string>|null $name               __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
      * @return ZugferdDocumentBuilder
      * @throws ZugferdUnsupportedMimetype
      */
@@ -2686,9 +2686,9 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      *
      * @param  string     $description            __BT-X-271, From EXTENDED__ Identification of the service fee
      * @param  float      $appliedAmount          __BT-X-272, From EXTENDED__ Amount of the service fee
-     * @param  array|null $taxTypeCodes           __BT-X-273-0, From EXTENDED__ Code of the Tax type. Note: Fixed value = "VAT"
-     * @param  array|null $taxCategoryCodes       __BT-X-273, From EXTENDED__ Code of the VAT category
-     * @param  array|null $rateApplicablePercents __BT-X-274, From EXTENDED__ The sales tax rate, expressed as the percentage applicable to the sales tax category in question. Note: The code of the sales tax category and the category-specific sales tax rate must correspond to one another. The value to be given is the percentage. For example, the value 20 is given for 20% (and not 0.2)
+     * @param  array<int, string>|null $taxTypeCodes           __BT-X-273-0, From EXTENDED__ Code of the Tax type. Note: Fixed value = "VAT"
+     * @param  array<int, string>|null $taxCategoryCodes       __BT-X-273, From EXTENDED__ Code of the VAT category
+     * @param  array<int, float>|null $rateApplicablePercents __BT-X-274, From EXTENDED__ The sales tax rate, expressed as the percentage applicable to the sales tax category in question. Note: The code of the sales tax category and the category-specific sales tax rate must correspond to one another. The value to be given is the percentage. For example, the value 20 is given for 20% (and not 0.2)
      * @return ZugferdDocumentBuilder
      */
     public function addDocumentLogisticsServiceCharge(string $description, float $appliedAmount, ?array $taxTypeCodes = null, ?array $taxCategoryCodes = null, ?array $rateApplicablePercents = null): ZugferdDocumentBuilder

--- a/src/ZugferdDocumentPdfBuilderAbstract.php
+++ b/src/ZugferdDocumentPdfBuilderAbstract.php
@@ -93,7 +93,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
     /**
      * List of files which should be additionally attached to PDF
      *
-     * @var array
+     * @var array<int, array{PdfStreamReader, string, string, string, string}>
      */
     private $additionalFilesToAttach = [];
 
@@ -737,7 +737,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
     /**
      * Prepare PDF Metadata informations from FacturX/ZUGFeRD XML.
      *
-     * @return array
+     * @return array{author: string, keywords: string, title: string, subject: string, createdDate: string, modifiedDate: string}
      */
     private function preparePdfMetadata(): array
     {
@@ -763,7 +763,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
     /**
      * Extract major invoice information from FacturX/ZUGFeRD XML.
      *
-     * @return array
+     * @return array{invoiceId: string|null, docTypeName: string, seller: string|null, date: string}
      */
     protected function extractInvoiceInformations(): array
     {
@@ -823,7 +823,7 @@ abstract class ZugferdDocumentPdfBuilderAbstract
      *
      * @param  string $which
      * @param  string $default
-     * @param  array  $invoiceInformation
+     * @param  array{invoiceId: string|null, docTypeName: string, seller: string|null, date: string} $invoiceInformation
      * @return string
      */
     private function buildMetadataField(string $which, string $default, array $invoiceInformation): string

--- a/src/ZugferdDocumentPdfMerger.php
+++ b/src/ZugferdDocumentPdfMerger.php
@@ -10,6 +10,7 @@
 namespace horstoeko\zugferd;
 
 use Throwable;
+use horstoeko\zugferd\ZugferdProfiles;
 use horstoeko\zugferd\ZugferdProfileResolver;
 use horstoeko\zugferd\ZugferdDocumentPdfBuilderAbstract;
 use horstoeko\zugferd\exception\ZugferdUnknownProfileException;
@@ -26,6 +27,8 @@ use horstoeko\zugferd\exception\ZugferdUnknownProfileParameterException;
  * @author   D. Erling <horstoeko@erling.com.de>
  * @license  https://opensource.org/licenses/MIT MIT
  * @link     https://github.com/horstoeko/zugferd
+ *
+ * @phpstan-import-type ZugferdProfileDefinition from ZugferdProfiles
  */
 class ZugferdDocumentPdfMerger extends ZugferdDocumentPdfBuilderAbstract
 {
@@ -125,7 +128,7 @@ class ZugferdDocumentPdfMerger extends ZugferdDocumentPdfBuilderAbstract
     /**
      * Guess the profile type of the readden xml document
      *
-     * @return array
+     * @return ZugferdProfileDefinition
      * @throws ZugferdFileNotReadableException
      * @throws ZugferdUnknownXmlContentException
      * @throws ZugferdUnknownProfileException

--- a/src/ZugferdDocumentReader.php
+++ b/src/ZugferdDocumentReader.php
@@ -480,7 +480,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Retrieve document notes.
      *
-     * @param  array|null $notes __BT-22, From BASIC WL__, __BT-X-5, From EXTENDED__, __BT-21, From BASIC WL__ Returns an array with all document notes. Each array element contains an assiociative array containing the following keys: _contentcode_, _subjectcode_ and _content_
+     * @param  array<int, mixed>|null $notes __BT-22, From BASIC WL__, __BT-X-5, From EXTENDED__, __BT-21, From BASIC WL__ Returns an array with all document notes. Each array element contains an assiociative array containing the following keys: _contentcode_, _subjectcode_ and _content_
      * @return ZugferdDocumentReader
      */
     public function getDocumentNotes(?array &$notes): ZugferdDocumentReader
@@ -502,7 +502,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information about the seller (=service provider).
      *
      * @param  string|null $name        __BT-27, From MINIMUM__ The full formal name under which the seller is registered in the National Register of Legal Entities, Taxable Person or otherwise acting as person(s)
-     * @param  array|null  $id          __BT-29, From BASIC WL__ An array of identifiers of the seller. In many systems, seller identification is key information. Multiple seller IDs can be assigned or specified. They can be differentiated by using different identification schemes. If no scheme is given, it should be known to the buyer and seller, e.g. a previously exchanged, buyer-assigned identifier of the seller
+     * @param  array<int, mixed>|null $id          __BT-29, From BASIC WL__ An array of identifiers of the seller. In many systems, seller identification is key information. Multiple seller IDs can be assigned or specified. They can be differentiated by using different identification schemes. If no scheme is given, it should be known to the buyer and seller, e.g. a previously exchanged, buyer-assigned identifier of the seller
      * @param  string|null $description __BT-33, From EN 16931__ Further legal information that is relevant for the seller
      * @return ZugferdDocumentReader
      */
@@ -520,7 +520,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get global identifiers of the seller.
      *
-     * @param  array|null $globalID __BT-29/BT-29-0/BT-29-1, From BASIC WL__ Array of the sellers global ids indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-29/BT-29-0/BT-29-1, From BASIC WL__ Array of the sellers global ids indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentSellerGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -534,7 +534,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on the seller's tax information.
      *
-     * @param  array|null $taxReg _BT-31/32, From MINIMUM/EN 16931__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg _BT-31/32, From MINIMUM/EN 16931__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentSellerTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -554,7 +554,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $postCode    __BT-38, From BASIC WL__ Identifier for a group of properties, such as a zip code
      * @param  string|null $city        __BT-37, From BASIC WL__ Usual name of the city or municipality in which the seller's address is located
      * @param  string|null $country     __BT-40, From MINIMUM__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
-     * @param  array|null  $subDivision __BT-39, From BASIC WL__ The sellers state
+     * @param  array<int, mixed>|null $subDivision __BT-39, From BASIC WL__ The sellers state
      * @return ZugferdDocumentReader
      */
     public function getDocumentSellerAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -661,7 +661,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information about the buyer (service recipient).
      *
      * @param  string|null $name        __BT-44, From MINIMUM__ The full name of the buyer
-     * @param  array|null  $id          __BT-46, From BASIC WL__ An identifier of the buyer. In many systems, buyer identification is key information. Multiple buyer IDs can be assigned or specified. They can be differentiated by using different identification schemes. If no scheme is given, it should be known to the buyer and buyer, e.g. a previously exchanged, seller-assigned identifier of the buyer
+     * @param  array<int, mixed>|null $id          __BT-46, From BASIC WL__ An identifier of the buyer. In many systems, buyer identification is key information. Multiple buyer IDs can be assigned or specified. They can be differentiated by using different identification schemes. If no scheme is given, it should be known to the buyer and buyer, e.g. a previously exchanged, seller-assigned identifier of the buyer
      * @param  string|null $description __BT-X-334, From EXTENDED__ Further legal information about the buyer
      * @return ZugferdDocumentReader
      */
@@ -679,7 +679,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get global identifiers of the buyer.
      *
-     * @param  array|null $globalID __BT-46-0, BT-46-1, From BASIC WL__ Array of the buyers global ids indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-46-0, BT-46-1, From BASIC WL__ Array of the buyers global ids indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentBuyerGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -693,7 +693,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on the buyer's tax information.
      *
-     * @param  array|null $taxReg _BT-48, From MINIMUM/EN 16931__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg _BT-48, From MINIMUM/EN 16931__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentBuyerTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -713,7 +713,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $postCode    __BT-53, From BASIC WL__ Identifier for a group of properties, such as a zip code
      * @param  string|null $city        __BT-52, From BASIC WL__ Usual name of the city or municipality in which the buyers address is located
      * @param  string|null $country     __BT-55, From BASIC WL__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
-     * @param  array|null  $subDivision __BT-54, From BASIC WL__ The buyers state
+     * @param  array<int, mixed>|null $subDivision __BT-54, From BASIC WL__ The buyers state
      * @return ZugferdDocumentReader
      */
     public function getDocumentBuyerAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -820,7 +820,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information about the seller's tax agent.
      *
      * @param  string|null $name        __BT-62, From BASIC WL__ The full name of the seller's tax agent
-     * @param  array|null  $id          __BT-X-116, From EXTENDED__ An array of identifiers of the sellers tax agent.
+     * @param  array<int, mixed>|null $id          __BT-X-116, From EXTENDED__ An array of identifiers of the sellers tax agent.
      * @param  string|null $description __BT-, From __ Further legal information that is relevant for the sellers tax agent
      * @return ZugferdDocumentReader
      */
@@ -838,7 +838,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get document seller tax agent global ids.
      *
-     * @param  array|null $globalID __BT-X-117/BT-X-117-1, From EXTENDED__ Returns an array of the seller's tax agent identifiers indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-X-117/BT-X-117-1, From EXTENDED__ Returns an array of the seller's tax agent identifiers indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentSellerTaxRepresentativeGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -852,7 +852,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on the seller's tax agent tax information.
      *
-     * @param  array|null $taxReg __BT-63/BT-63-0, From BASIC WL__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg __BT-63/BT-63-0, From BASIC WL__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentSellerTaxRepresentativeTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -872,7 +872,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $postCode    __BT-67, From BASIC WL__ Identifier for a group of properties, such as a zip code
      * @param  string|null $city        __BT-66, From BASIC WL__ Usual name of the city or municipality in which the sellers tax agent address is located
      * @param  string|null $country     __BT-69, From BASIC WL__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
-     * @param  array|null  $subDivision __BT-68, From BASIC WL__ The sellers tax agent state
+     * @param  array<int, mixed>|null $subDivision __BT-68, From BASIC WL__ The sellers tax agent state
      * @return ZugferdDocumentReader
      */
     public function getDocumentSellerTaxRepresentativeAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -964,7 +964,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get information about the buyer's tax representative party BG-X-54.
      *
      * @param  string|null $name        __BT-X-362, From EXTENDED__ The full name of the buyer's tax representative
-     * @param  array|null  $id          __BT-X-364, From EXTENDED__ An array of identifiers of the buyer's tax representative
+     * @param  array<int, mixed>|null $id          __BT-X-364, From EXTENDED__ An array of identifiers of the buyer's tax representative
      * @param  string|null $description __BT-, From __ Further legal information that is relevant for the buyer's tax representative
      * @return ZugferdDocumentReader
      */
@@ -982,7 +982,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get document buyer tax representative global ids.
      *
-     * @param  array|null $globalID __BT-X-365/BT-X-365-0, From EXTENDED__ Returns an array of the buyer's tax representative identifiers indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-X-365/BT-X-365-0, From EXTENDED__ Returns an array of the buyer's tax representative identifiers indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentBuyerTaxRepresentativeGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -996,7 +996,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on the buyer's tax representative tax information.
      *
-     * @param  array|null $taxReg __BT-X-367/BT-X-367-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg __BT-X-367/BT-X-367-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentBuyerTaxRepresentativeTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -1016,7 +1016,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $postCode    __BT-X-382, From EXTENDED__ Identifier for a group of properties, such as a zip code
      * @param  string|null $city        __BT-X-386, From EXTENDED__ Usual name of the city or municipality in which the buyer's tax representative address is located
      * @param  string|null $country     __BT-X-387, From EXTENDED__ Code used to identify the country. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency "Codes for the representation of names of countries and their subdivisions"
-     * @param  array|null  $subDivision __BT-X-388, From EXTENDED__ The buyer's tax representative state
+     * @param  array<int, mixed>|null $subDivision __BT-X-388, From EXTENDED__ The buyer's tax representative state
      * @return ZugferdDocumentReader
      */
     public function getDocumentBuyerTaxRepresentativeAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -1108,7 +1108,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information on the product end user (general information).
      *
      * @param  string      $name        __BT-X-128, From EXTENDED__ Name/company name of the end user
-     * @param  array|null  $id          __BT-X-126, From EXTENDED__ An array of identifiers of the product end user
+     * @param  array<int, mixed>|null $id          __BT-X-126, From EXTENDED__ An array of identifiers of the product end user
      * @param  string|null $description __BT-, From __ Further legal information that is relevant for the product end user
      * @return ZugferdDocumentReader
      */
@@ -1126,7 +1126,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get global identifier of the product end user.
      *
-     * @param  array|null $globalID __BT-X-127/BT-X-127-0, From EXTENDED__ Array of the product end users global ids indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-X-127/BT-X-127-0, From EXTENDED__ Array of the product end users global ids indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentProductEndUserGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -1140,7 +1140,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on the tax number of the product end user.
      *
-     * @param  array|null $taxReg __BT-, From __ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg __BT-, From __ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentProductEndUserTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -1160,7 +1160,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $postCode    __BT-X-396, From EXTENDED__ Identifier for a group of properties, such as a zip code
      * @param  string|null $city        __BT-X-400, From EXTENDED__ Usual name of the city or municipality in which the product end users address is located
      * @param  string|null $country     __BT-X-401, From EXTENDED__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
-     * @param  array|null  $subDivision __BT-X-402, From EXTENDED__ The product end users state
+     * @param  array<int, mixed>|null $subDivision __BT-X-402, From EXTENDED__ The product end users state
      * @return ZugferdDocumentReader
      */
     public function getDocumentProductEndUserAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -1252,7 +1252,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information on the Ship-To party.
      *
      * @param  string|null $name        __BT-70, From BASIC WL__ The name of the party to whom the goods are being delivered or for whom the services are being performed. Must be used if the recipient of the goods or services is not the same as the buyer.
-     * @param  array|null  $id          __BT-71, From BASIC WL__ An array of identifiers
+     * @param  array<int, mixed>|null $id          __BT-71, From BASIC WL__ An array of identifiers
      * @param  string|null $description __BT-, From __ Further legal information that is relevant for the party
      * @return ZugferdDocumentReader
      */
@@ -1270,7 +1270,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get global identifier for the Ship-To party.
      *
-     * @param  array|null $globalID __BT-71-0/BT-71-1, From BASIC WL__ Array of global ids indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-71-0/BT-71-1, From BASIC WL__ Array of global ids indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentShipToGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -1284,7 +1284,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on tax details of the Ship-To party.
      *
-     * @param  array|null $taxReg __BT-X-161/BT-X-161-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg __BT-X-161/BT-X-161-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentShipToTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -1304,7 +1304,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $postCode    __BT-78, From BASIC WL__ Identifier for a group of properties, such as a zip code
      * @param  string|null $city        __BT-77, From BASIC WL__ Usual name of the city or municipality in which the party's address is located
      * @param  string|null $country     __BT-80, From BASIC WL__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
-     * @param  array|null  $subDivision __BT-79, From BASIC WL__ The party's state
+     * @param  array<int, mixed>|null $subDivision __BT-79, From BASIC WL__ The party's state
      * @return ZugferdDocumentReader
      */
     public function getDocumentShipToAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -1396,7 +1396,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information on the different end recipient.
      *
      * @param  string|null $name        __BT-X-164, From EXTENDED__ Name or company name of the different end recipient
-     * @param  array|null  $id          __BT-X-162, From EXTENDED__ An array of identifiers
+     * @param  array<int, mixed>|null $id          __BT-X-162, From EXTENDED__ An array of identifiers
      * @param  string|null $description __BT-, From __ Further legal information that is relevant for the different end recipient
      * @return ZugferdDocumentReader
      */
@@ -1414,7 +1414,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get global identifiers of the different end recipient party.
      *
-     * @param  array|null $globalID __BT-X-163/BT-X-163-0, From EXTENDED__ Array of global ids indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-X-163/BT-X-163-0, From EXTENDED__ Array of global ids indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentUltimateShipToGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -1428,7 +1428,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on tax details of the different end recipient party.
      *
-     * @param  array|null $taxReg __BT-X-180/BT-X-180-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg __BT-X-180/BT-X-180-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentUltimateShipToTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -1448,7 +1448,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $postCode    __BT-X-172, From EXTENDED__ Identifier for a group of properties, such as a zip code
      * @param  string|null $city        __BT-X-176, From EXTENDED__ Usual name of the city or municipality in which the party's address is located
      * @param  string|null $country     __BT-X-177, From EXTENDED__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
-     * @param  array|null  $subDivision __BT-X-178, From EXTENDED__ The party's state
+     * @param  array<int, mixed>|null $subDivision __BT-X-178, From EXTENDED__ The party's state
      * @return ZugferdDocumentReader
      */
     public function getDocumentUltimateShipToAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -1540,7 +1540,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information of the deviating consignor party.
      *
      * @param  string|null $name        __BT-X-183, From EXTENDED__ The name of the party
-     * @param  array|null  $id          __BT-X-181, From EXTENDED__ An array of identifiers
+     * @param  array<int, mixed>|null $id          __BT-X-181, From EXTENDED__ An array of identifiers
      * @param  string|null $description __BT-, From __ Further legal information that is relevant for the party
      * @return ZugferdDocumentReader
      */
@@ -1558,7 +1558,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get global identifier of the deviating consignor party.
      *
-     * @param  array|null $globalID __BT-X-182/BT-X-182-0, From EXTENDED__ Array of global ids indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-X-182/BT-X-182-0, From EXTENDED__ Array of global ids indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentShipFromGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -1572,7 +1572,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on tax details of the deviating consignor party.
      *
-     * @param  array|null $taxReg __BT-, From __ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg __BT-, From __ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentShipFromTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -1592,7 +1592,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $postCode    __BT-X-191, From EXTENDED__ Identifier for a group of properties, such as a zip code
      * @param  string|null $city        __BT-X-195, From EXTENDED__ Usual name of the city or municipality in which the party's address is located
      * @param  string|null $country     __BT-X-196, From EXTENDED__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
-     * @param  array|null  $subDivision __BT-X-197, From EXTENDED__ The party's state
+     * @param  array<int, mixed>|null $subDivision __BT-X-197, From EXTENDED__ The party's state
      * @return ZugferdDocumentReader
      */
     public function getDocumentShipFromAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -1684,7 +1684,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information of the invoicer party.
      *
      * @param  string      $name        __BT-X-207, From EXTENDED__ The name of the party
-     * @param  array|null  $id          __BT-X-205, From EXTENDED__ An array of identifiers
+     * @param  array<int, mixed>|null $id          __BT-X-205, From EXTENDED__ An array of identifiers
      * @param  string|null $description __BT-, From __ Further legal information that is relevant for the party
      * @return ZugferdDocumentReader
      */
@@ -1702,7 +1702,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get global identifier of the invoicer party.
      *
-     * @param  array|null $globalID __BT-X-206/BT-X-206-0, From EXTENDED__ Array of global ids indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-X-206/BT-X-206-0, From EXTENDED__ Array of global ids indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentInvoicerGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -1716,7 +1716,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on tax details of the invoicer party.
      *
-     * @param  array|null $taxReg __BT-, From __ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg __BT-, From __ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentInvoicerTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -1736,7 +1736,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $postCode    __BT-X-215, From EXTENDED__ Identifier for a group of properties, such as a zip code
      * @param  string|null $city        __BT-X-219, From EXTENDED__ Usual name of the city or municipality in which the party's address is located
      * @param  string|null $country     __BT-X-220, From EXTENDED__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their subdivisions”
-     * @param  array|null  $subDivision __BT-X-221, From EXTENDED__ The party's state
+     * @param  array<int, mixed>|null $subDivision __BT-X-221, From EXTENDED__ The party's state
      * @return ZugferdDocumentReader
      */
     public function getDocumentInvoicerAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -1828,7 +1828,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Get detailed information on the different invoice recipient party.
      *
      * @param  string      $name        __BT-X-226, From EXTENDED__ The name of the party
-     * @param  array|null  $id          __BT-X-224, From EXTENDED__ An array of identifiers
+     * @param  array<int, mixed>|null $id          __BT-X-224, From EXTENDED__ An array of identifiers
      * @param  string|null $description __BT-, From __ Further legal information that is relevant for the party
      * @return ZugferdDocumentReader
      */
@@ -1846,7 +1846,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get global identifier of the different invoice recipient party.
      *
-     * @param  array|null $globalID __BT-X-225/BT-X-225-0, From EXTENDED__ Array of global ids indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-X-225/BT-X-225-0, From EXTENDED__ Array of global ids indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentInvoiceeGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -1860,7 +1860,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on tax details of the different invoice recipient party.
      *
-     * @param  array|null $taxReg __BT-X-242/BT-X-242-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg __BT-X-242/BT-X-242-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentInvoiceeTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -1881,7 +1881,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $city        __BT-X-238, From EXTENDED__ Usual name of the city or municipality in which the party's address is located
      * @param  string|null $country     __BT-X-239, From EXTENDED__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their
      *                                  subdivisions”
-     * @param  array|null  $subDivision __BT-X-240, From EXTENDED__ The party's state
+     * @param  array<int, mixed>|null $subDivision __BT-X-240, From EXTENDED__ The party's state
      * @return ZugferdDocumentReader
      */
     public function getDocumentInvoiceeAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -1974,7 +1974,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * The role of the payee may also be performed by a party other than the seller, e.g. by a factoring service.
      *
      * @param  string      $name        __BT-59, From BASIC WL__ The name of the party. Must be used if the payee is not the same as the seller. However, the name of the payee may match the name of the seller.
-     * @param  array|null  $id          __BT-60, From BASIC WL__ An array of identifiers
+     * @param  array<int, mixed>|null $id          __BT-60, From BASIC WL__ An array of identifiers
      * @param  string|null $description __BT-, From __ Further legal information that is relevant for the party
      * @return ZugferdDocumentReader
      */
@@ -1992,7 +1992,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get global identifier of the payee party.
      *
-     * @param  array|null $globalID __BT-60-0/BT-60-1, From BASIC WL__ Array of global ids indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID __BT-60-0/BT-60-1, From BASIC WL__ Array of global ids indexed by the identification scheme.
      * @return ZugferdDocumentReader
      */
     public function getDocumentPayeeGlobalId(?array &$globalID): ZugferdDocumentReader
@@ -2006,7 +2006,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get detailed information on tax details of the payee party.
      *
-     * @param  array|null $taxReg __BT-X-257/BT-X-257-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
+     * @param  array<string, mixed>|null $taxReg __BT-X-257/BT-X-257-0, From EXTENDED__ Array of tax numbers indexed by the schemeid (VA, FC, etc.)
      * @return ZugferdDocumentReader
      */
     public function getDocumentPayeeTaxRegistration(?array &$taxReg): ZugferdDocumentReader
@@ -2027,7 +2027,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $city        __BT-X-253, From EXTENDED__ Usual name of the city or municipality in which the party's address is located
      * @param  string|null $country     __BT-X-254, From EXTENDED__ Code used to identify the country. If no tax agent is specified, this is the country in which the sales tax is due. The lists of approved countries are maintained by the EN ISO 3166-1 Maintenance Agency “Codes for the representation of names of countries and their
      *                                  subdivisions”
-     * @param  array|null  $subDivision __BT-X-255, From EXTENDED__ The party's state
+     * @param  array<int, mixed>|null $subDivision __BT-X-255, From EXTENDED__ The party's state
      * @return ZugferdDocumentReader
      */
     public function getDocumentPayeeAddress(?string &$lineOne, ?string &$lineTwo, ?string &$lineThree, ?string &$postCode, ?string &$city, ?string &$country, ?array &$subDivision): ZugferdDocumentReader
@@ -2251,7 +2251,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      *                                           to reference an identifier for an object specified by the seller.
      * @param  string|null   $uriId              __BT-124, From EN 16931__ A means of locating the resource, including the primary access method intended for it, e.g. http:// or ftp://. The storage location of the external document must be used if the buyer requires further information as
      *                                           supporting documents for the invoiced amounts. External documents are not part of the invoice. Invoice processing should be possible without access to external documents. Access to external documents can entail certain risks.
-     * @param  array|null    $name               __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
+     * @param  array<mixed, mixed>|null $name               __BT-123, From EN 16931__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
      * @param  string|null   $refTypeCode        __BT-, From __ The identifier for the identification scheme of the identifier of the item invoiced. If it is not clear to the recipient which scheme is used for the identifier, an identifier of the scheme should be used, which must be selected from UNTDID 1153 in accordance with the code list entries.
      * @param  DateTime|null $issueDate          __BT-X-149, From EXTENDED__ Document date
      * @param  string|null   $binaryDataFilename __BT-125, From EN 16931__ Contains the content located at the path $this->binarydatadirectory + filename of the embedded binary object Attachment
@@ -2295,7 +2295,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get all additional referenced documents.
      *
-     * @param  array|null $refDocs Array contains all additional referenced documents, but without extracting attached binary objects. If you want to access attached binary objects you have to use ZugferdDocumentReader::getDocumentAdditionalReferencedDocument
+     * @param  array<int, mixed>|null $refDocs Array contains all additional referenced documents, but without extracting attached binary objects. If you want to access attached binary objects you have to use ZugferdDocumentReader::getDocumentAdditionalReferencedDocument
      * @return ZugferdDocumentReader
      */
     public function getDocumentAdditionalReferencedDocuments(?array &$refDocs): ZugferdDocumentReader
@@ -2371,7 +2371,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get all references to the previous invoice.
      *
-     * @param  array|null $invoiceRefDocs
+     * @param  array<int, mixed>|null $invoiceRefDocs
      * Array contains all invoice referenced documents, but without extracting attached binary objects. If you
      * want to access attached binary objects you have to use ZugferdDocumentReader::getDocumentInvoiceReferencedDocument
      * @return ZugferdDocumentReader
@@ -2460,7 +2460,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get all ultimate customer order referenced documents as an array.
      *
-     * @param  array|null $refdocs Returns an array of referenced documents, each containing keys: _issuerAssignedId_ and _issueDate_
+     * @param  array<int, array{issuerAssignedId: mixed, issueDate: DateTime|null}>|null $refdocs Returns an array of referenced documents, each containing keys: _issuerAssignedId_ and _issueDate_
      * @return ZugferdDocumentReader
      */
     public function getDocumentUltimateCustomerOrderReferencedDocuments(?array &$refdocs): ZugferdDocumentReader
@@ -2718,7 +2718,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get information about surcharges and charges applicable to the bill as a whole, Deductions, such as for withheld taxes may also be specified in this group.
      *
-     * @param  array|null $allowanceCharge
+     * @param  array<int, mixed>|null $allowanceCharge
      * @return ZugferdDocumentReader
      */
     public function getDocumentAllowanceCharges(?array &$allowanceCharge): ZugferdDocumentReader
@@ -2860,9 +2860,9 @@ class ZugferdDocumentReader extends ZugferdDocument
      *
      * @param  string|null $description            __BT-X-271, From EXTENDED__ Identification of the service fee
      * @param  float|null  $appliedAmount          __BT-X-272, From EXTENDED__ Amount of the service fee
-     * @param  array|null  $taxTypeCodes           __BT-X-273-0, From EXTENDED__ Code of the Tax type. Note: Fixed value = "VAT"
-     * @param  array|null  $taxCategoryCodes       __BT-X-273, From EXTENDED__ Code of the VAT category
-     * @param  array|null  $rateApplicablePercents __BT-X-274, From EXTENDED__ The sales tax rate, expressed as the percentage applicable to the sales tax category in question. Note: The code of the sales tax category and the category-specific sales tax rate must correspond to one another. The value to be given is the percentage. For example, the value 20 is given for 20% (and not 0.2)
+     * @param  array<int, mixed>|null $taxTypeCodes           __BT-X-273-0, From EXTENDED__ Code of the Tax type. Note: Fixed value = "VAT"
+     * @param  array<int, mixed>|null $taxCategoryCodes       __BT-X-273, From EXTENDED__ Code of the VAT category
+     * @param  array<int, mixed>|null $rateApplicablePercents __BT-X-274, From EXTENDED__ The sales tax rate, expressed as the percentage applicable to the sales tax category in question. Note: The code of the sales tax category and the category-specific sales tax rate must correspond to one another. The value to be given is the percentage. For example, the value 20 is given for 20% (and not 0.2)
      * @return ZugferdDocumentReader
      */
     public function getDocumentLogisticsServiceCharge(?string &$description, ?float &$appliedAmount, ?array &$taxTypeCodes, ?array &$taxCategoryCodes, ?array &$rateApplicablePercents): ZugferdDocumentReader
@@ -2898,7 +2898,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     /**
      * Get all documents payment terms.
      *
-     * @param  array|null $paymentTerms
+     * @param  array<int, mixed>|null $paymentTerms
      * @return ZugferdDocumentReader
      */
     public function getDocumentPaymentTerms(?array &$paymentTerms): ZugferdDocumentReader
@@ -3479,7 +3479,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null $description        __BT-X-19, From EXTENDED__ Description of the included referenced product
      * @param  string|null $sellerAssignedID   __BT-X-16, From EXTENDED__ ID assigned by the seller of the contained referenced product
      * @param  string|null $buyerAssignedID    __BT-X-17, From EXTENDED__ ID of the referenced product assigned by the buyer
-     * @param  array|null  $globalID           __BT-X-15, From EXTENDED__ Array of global ids of the referenced product indexed by the identification scheme.
+     * @param  array<string, mixed>|null $globalID           __BT-X-15, From EXTENDED__ Array of global ids of the referenced product indexed by the identification scheme.
      * @param  float|null  $unitQuantity       __BT-X-20, From EXTENDED__ Quantity of the referenced product contained
      * @param  string|null $unitCode           __BT-X-20-1, From EXTENDED__ Unit code of Quantity of the referenced product contained
      * @param  string|null $industryAssignedID __BT-X-309, From EXTENDED__ ID of the referenced product contained assigned by the industry
@@ -3666,7 +3666,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  string|null   $typeCode           __BT-X-30, From EXTENDED__ Type of referenced document (See codelist UNTDID 1001)
      * @param  string|null   $uriId              __BT-X-28, From EXTENDED__ The Uniform Resource Locator (URL) at which the external document is available. A means of finding the resource including the primary access method intended for it, e.g. http: // or ftp: //. The location of the external document must be used if the buyer needs additional information to support the amounts billed. External documents are not part of the invoice. Access to external documents can involve certain risks.
      * @param  string|null   $lineId             __BT-X-29, From EXTENDED__ The referenced position identifier in the additional document
-     * @param  array|null    $name               __BT-X-299, From EXTENDED__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
+     * @param  array<mixed, mixed>|null $name               __BT-X-299, From EXTENDED__ A description of the document, e.g. Hourly billing, usage or consumption report, etc.
      * @param  string|null   $refTypeCode        __BT-X-32, From EXTENDED__ The identifier for the identification scheme of the identifier of the item invoiced. If it is not clear to the recipient which scheme is used for the identifier, an identifier of the scheme should be used, which must be selected from UNTDID 1153 in accordance with the code list entries.
      * @param  DateTime|null $issueDate          __BT-X-33, From EXTENDED__ Document date
      * @param  string|null   $binaryDataFilename __BT-X-31, From EXTENDED__ Contains a file name of an attachment document embedded as a binary object
@@ -4413,8 +4413,8 @@ class ZugferdDocumentReader extends ZugferdDocument
      * Convert to array
      *
      * @param  mixed $value
-     * @param  array $methods
-     * @return array
+     * @param  array<string|int, string|array{0: string, 1: mixed}|Closure> $methods
+     * @return array<int, mixed>
      */
     private function convertToArray($value, array $methods)
     {
@@ -4460,7 +4460,7 @@ class ZugferdDocumentReader extends ZugferdDocument
      * @param  mixed  $value
      * @param  string $methodKey
      * @param  string $methodValue
-     * @return array
+     * @return array<string, mixed>
      */
     private function convertToAssociativeArray($value, string $methodKey, string $methodValue)
     {

--- a/src/ZugferdDocumentValidator.php
+++ b/src/ZugferdDocumentValidator.php
@@ -13,6 +13,7 @@ use horstoeko\stringmanagement\PathUtils;
 use horstoeko\zugferd\ZugferdSettings;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Class representing the document validator for incoming documents
@@ -27,11 +28,15 @@ class ZugferdDocumentValidator
 {
     /**
      * The invoice document reference
+     *
+     * @var ZugferdDocument
      */
     private $document;
 
     /**
      * The validator instance
+     *
+     * @var ValidatorInterface
      */
     private $validator;
 
@@ -87,7 +92,7 @@ class ZugferdDocumentValidator
      *
      * @param  string  $pattern
      * @param  integer $flags
-     * @return array
+     * @return array<int, string>
      */
     private function globRecursive(string $pattern, int $flags = 0): array
     {

--- a/src/ZugferdKositValidator.php
+++ b/src/ZugferdKositValidator.php
@@ -41,7 +41,7 @@ class ZugferdKositValidator
     /**
      * Internal message bag
      *
-     * @var array
+     * @var array<int, array{type: string, message: string}>
      */
     private $messageBag = [];
 
@@ -553,7 +553,7 @@ class ZugferdKositValidator
      * Get messages from messagebag filtered by message type
      *
      * @param  string $messageType
-     * @return array
+     * @return array<int, string>
      */
     private function getMessageBagFiltered(string $messageType): array
     {
@@ -573,7 +573,7 @@ class ZugferdKositValidator
     /**
      * Returns an array of all validation errors
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getValidationErrors(): array
     {
@@ -603,7 +603,7 @@ class ZugferdKositValidator
     /**
      * Returns an array of all validation warnings
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getValidationWarnings(): array
     {
@@ -633,7 +633,7 @@ class ZugferdKositValidator
     /**
      * Returns an array of all validation information
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getValidationInformation(): array
     {
@@ -663,7 +663,7 @@ class ZugferdKositValidator
     /**
      * Return an array of all internal errors (such as download error or system exceptions)
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getProcessErrors(): array
     {
@@ -693,7 +693,7 @@ class ZugferdKositValidator
     /**
      * Returns an array of all messages from process system (calling external applications)
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getProcessOutput(): array
     {
@@ -1165,8 +1165,8 @@ class ZugferdKositValidator
      * Runs a process. If the process runned successfully this method
      * returns true, otherwise false
      *
-     * @param  array  $command
-     * @param  string $workingdirectory
+     * @param  array<int, string> $command
+     * @param  string             $workingdirectory
      * @return boolean
      */
     private function runValidationApplication(array $command, string $workingdirectory): bool

--- a/src/ZugferdObjectHelper.php
+++ b/src/ZugferdObjectHelper.php
@@ -15,6 +15,7 @@ use finfo;
 use horstoeko\mimedb\MimeDb;
 use horstoeko\stringmanagement\FileUtils;
 use horstoeko\stringmanagement\StringUtils;
+use horstoeko\zugferd\exception\ZugferdInvalidArgumentException;
 use horstoeko\zugferd\exception\ZugferdUnknownDateFormatException;
 use horstoeko\zugferd\exception\ZugferdUnsupportedMimetype;
 use horstoeko\zugferd\ZugferdProfileResolver;
@@ -522,11 +523,15 @@ class ZugferdObjectHelper
 
         if (
             StringUtils::stringIsNullOrEmpty($binaryDataFilename) === false &&
-            StringUtils::stringIsNullOrEmpty($base64EncodedData) === false &&
-            base64_encode($base64EncodedData) !== false
+            StringUtils::stringIsNullOrEmpty($base64EncodedData) === false
         ) {
+            $decodedData = base64_decode($base64EncodedData, true);
+            if ($decodedData === false) {
+                throw new ZugferdInvalidArgumentException('The data of ' . $binaryDataFilename . ' is not valid Base64-encoded data');
+            }
+
             $finfo = new finfo();
-            $mimetype = $finfo->buffer(base64_decode($base64EncodedData), FILEINFO_MIME_TYPE);
+            $mimetype = $finfo->buffer($decodedData, FILEINFO_MIME_TYPE);
             if ($mimetype === false) {
                 throw new ZugferdUnsupportedMimetype('of ' . $binaryDataFilename);
             }
@@ -539,7 +544,7 @@ class ZugferdObjectHelper
             /**
              * PHP 8.0 may misdetect CSV files as "application/csv"; normalize to the standard "text/csv"
              */
-            if (PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 81000 && $mimetype === 'application/csv') {
+            if (PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 80100 && $mimetype === 'application/csv') {
                 $mimetype = 'text/csv';
             }
 

--- a/src/ZugferdObjectHelper.php
+++ b/src/ZugferdObjectHelper.php
@@ -1604,9 +1604,9 @@ class ZugferdObjectHelper
     /**
      * Tries to call a method
      *
-     * @param  object $instance
-     * @param  string $method
-     * @param  mixed  $value
+     * @param  object|null $instance
+     * @param  string      $method
+     * @param  mixed       $value
      * @return ZugferdObjectHelper
      */
     public function tryCall($instance, string $method, $value): ZugferdObjectHelper
@@ -1633,9 +1633,9 @@ class ZugferdObjectHelper
     /**
      * Try call all methods
      *
-     * @param  object   $instance
-     * @param  string[] $methods
-     * @param  mixed    $value
+     * @param  object|null $instance
+     * @param  string[]    $methods
+     * @param  mixed       $value
      * @return ZugferdObjectHelper
      */
     public function tryCallAll($instance, array $methods, $value): ZugferdObjectHelper
@@ -1662,7 +1662,7 @@ class ZugferdObjectHelper
      * Tries to call a method and return the returnvalue from call to $method
      * in object $instance
      *
-     * @param  object $instance
+     * @param  mixed  $instance
      * @param  string $method
      * @return mixed
      */
@@ -1686,9 +1686,9 @@ class ZugferdObjectHelper
     /**
      * Try call methods in a form .object.method1.method2.method3
      *
-     * @param  object $instance
-     * @param  string $methods
-     * @param  mixed  $value
+     * @param  object|null $instance
+     * @param  string      $methods
+     * @param  mixed       $value
      * @return void
      */
     public function tryCallByPath($instance, string $methods, $value)
@@ -1707,7 +1707,7 @@ class ZugferdObjectHelper
     /**
      * Try call methods in a form .object.method1.method2.method3
      *
-     * @param  object $instance
+     * @param  mixed  $instance
      * @param  string $methods
      * @return mixed
      */
@@ -1727,11 +1727,11 @@ class ZugferdObjectHelper
     /**
      * Call $method if exists, otherwise $method2 is calles with $value
      *
-     * @param  object $instance
-     * @param  string $methodToLookFor
-     * @param  string $methodToCall
-     * @param  mixed  $value
-     * @param  mixed  $value2
+     * @param  object|null $instance
+     * @param  string      $methodToLookFor
+     * @param  string      $methodToCall
+     * @param  mixed       $value
+     * @param  mixed       $value2
      * @return ZugferdObjectHelper
      */
     public function tryCallIfMethodExists($instance, string $methodToLookFor, string $methodToCall, $value, $value2): ZugferdObjectHelper
@@ -1855,8 +1855,8 @@ class ZugferdObjectHelper
     /**
      * Wrapper for method_exists for use in PHP8
      *
-     * @param  string|object $instance
-     * @param  string        $method
+     * @param  string|object|null $instance
+     * @param  string             $method
      * @return boolean
      */
     public function methodExists($instance, $method): bool

--- a/src/ZugferdObjectHelper.php
+++ b/src/ZugferdObjectHelper.php
@@ -28,6 +28,8 @@ use horstoeko\zugferd\ZugferdProfileResolver;
  * @author   D. Erling <horstoeko@erling.com.de>
  * @license  https://opensource.org/licenses/MIT MIT
  * @link     https://github.com/horstoeko/zugferd
+ *
+ * @phpstan-import-type ZugferdProfileDefinition from ZugferdProfiles
  */
 class ZugferdObjectHelper
 {
@@ -41,9 +43,9 @@ class ZugferdObjectHelper
     /**
      * Internal profile definition
      *
-     * @var array
+     * @var ZugferdProfileDefinition
      */
-    public $profiledef = [];
+    public $profiledef;
 
     /**
      * A list of supported mimetypes by binaryattachments
@@ -493,7 +495,7 @@ class ZugferdObjectHelper
      * @param  string|null            $uriId
      * @param  string|null            $lineId
      * @param  string|null            $typeCode
-     * @param  string|array|null      $name
+     * @param  string|array<int, string>|null $name
      * @param  string|null            $refTypeCode
      * @param  DateTimeInterface|null $issueDate
      * @param  string|null            $binaryDataFilename
@@ -1176,11 +1178,11 @@ class ZugferdObjectHelper
     /**
      * Get instance of
      *
-     * @param  string|null $description
-     * @param  float|null  $appliedAmount
-     * @param  array|null  $taxTypeCodes
-     * @param  array|null  $taxCategoryCodes
-     * @param  array|null  $rateApplicablePercents
+     * @param  string|null            $description
+     * @param  float|null             $appliedAmount
+     * @param  array<int, string>|null $taxTypeCodes
+     * @param  array<int, string>|null $taxCategoryCodes
+     * @param  array<int, float>|null  $rateApplicablePercents
      * @return object|null
      */
     public function getLogisticsServiceChargeType(?string $description = null, ?float $appliedAmount = null, ?array $taxTypeCodes = null, ?array $taxCategoryCodes = null, ?array $rateApplicablePercents = null): ?object
@@ -1762,8 +1764,8 @@ class ZugferdObjectHelper
     /**
      * Ensure that $input is an array
      *
-     * @param  mixed $input
-     * @return array
+     * @param  string|array<int, string>|null $input
+     * @return array<int, string>
      */
     public function ensureStringArray($input): array
     {
@@ -1778,7 +1780,7 @@ class ZugferdObjectHelper
      * Ensure array
      *
      * @param  mixed $value
-     * @return array
+     * @return array<mixed, mixed>
      */
     public function ensureArray($value): array
     {
@@ -1811,7 +1813,7 @@ class ZugferdObjectHelper
     /**
      * Checks if all function arguments are null or empty
      *
-     * @param  array $args
+     * @param  array<int, mixed> $args
      * @return boolean
      */
     public static function isAllNullOrEmpty(array $args): bool
@@ -1832,7 +1834,7 @@ class ZugferdObjectHelper
     /**
      * Checks if all function arguments are null or empty
      *
-     * @param  array $args
+     * @param  array<int, mixed> $args
      * @return boolean
      */
     public static function isOneNullOrEmpty(array $args): bool

--- a/src/ZugferdPdfValidator.php
+++ b/src/ZugferdPdfValidator.php
@@ -43,7 +43,7 @@ class ZugferdPdfValidator
     /**
      * Internal message bag
      *
-     * @var array
+     * @var array<int, array{type: string, message: string}>
      */
     private $messageBag = [];
 
@@ -455,7 +455,7 @@ class ZugferdPdfValidator
      * Get messages from messagebag filtered by message type
      *
      * @param  string $messageType
-     * @return array
+     * @return array<int, string>
      */
     private function getMessageBagFiltered(string $messageType): array
     {
@@ -475,7 +475,7 @@ class ZugferdPdfValidator
     /**
      * Returns an array of all validation errors
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getValidationErrors(): array
     {
@@ -505,7 +505,7 @@ class ZugferdPdfValidator
     /**
      * Returns an array of all validation warnings
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getValidationWarnings(): array
     {
@@ -535,7 +535,7 @@ class ZugferdPdfValidator
     /**
      * Returns an array of all validation information
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getValidationInformation(): array
     {
@@ -565,7 +565,7 @@ class ZugferdPdfValidator
     /**
      * Return an array of all internal errors (such as download error or system exceptions)
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getProcessErrors(): array
     {
@@ -595,7 +595,7 @@ class ZugferdPdfValidator
     /**
      * Returns an array of all messages from process system (calling external applications)
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getProcessOutput(): array
     {
@@ -999,8 +999,8 @@ class ZugferdPdfValidator
      * Runs a process. If the process runned successfully this method
      * returns true, otherwise false
      *
-     * @param  array  $command
-     * @param  string $workingdirectory
+     * @param  array<int, string> $command
+     * @param  string             $workingdirectory
      * @return bool
      */
     private function runProcess(array $command, string $workingdirectory): bool
@@ -1013,9 +1013,9 @@ class ZugferdPdfValidator
      * returns true, otherwise false. The output of the process wil be
      * returned in $processOutput
      *
-     * @param  array       $command
-     * @param  string      $workingdirectory
-     * @param  null|string &$processOutput
+     * @param  array<int, string> $command
+     * @param  string             $workingdirectory
+     * @param  null|string        &$processOutput
      * @return bool
      */
     private function runProcessAndGetOutput(array $command, string $workingdirectory, ?string &$processOutput): bool

--- a/src/ZugferdPdfWriter.php
+++ b/src/ZugferdPdfWriter.php
@@ -25,21 +25,21 @@ class ZugferdPdfWriter extends PdfFpdi
     /**
      * Contains all attached files
      *
-     * @var array
+     * @var array<int, array{file: mixed, name: string, desc: string, relationship: string, subtype: string, file_index?: int}>
      */
     protected $files = [];
 
     /**
      * Contains meta data
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $metaDataDescriptions = [];
 
     /**
      * Contains meta data
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $metaDataInfos = [];
 
@@ -175,7 +175,7 @@ class ZugferdPdfWriter extends PdfFpdi
     /**
      * Set PDF metadata infos.
      *
-     * @param  array $metaDataInfos
+     * @param  array<string, string> $metaDataInfos
      * The array with metadata information applied to the pdf
      * @return void
      */
@@ -222,7 +222,7 @@ class ZugferdPdfWriter extends PdfFpdi
     /**
      * Put file attachment specification.
      *
-     * @param array $file_info
+     * @param array{file: mixed, name: string, desc: string, relationship: string, subtype: string, file_index?: int} $file_info
      * @return void
      */
     protected function putFileSpecification(array $file_info): void
@@ -252,7 +252,7 @@ class ZugferdPdfWriter extends PdfFpdi
     /**
      * Put file stream.
      *
-     * @param array $file_info
+     * @param array{file: mixed, name: string, desc: string, relationship: string, subtype: string, file_index?: int} $file_info
      */
     protected function putFileStream(array $file_info): void
     {

--- a/src/ZugferdProfileResolver.php
+++ b/src/ZugferdProfileResolver.php
@@ -24,6 +24,8 @@ use horstoeko\zugferd\exception\ZugferdUnknownXmlContentException;
  * @author   D. Erling <horstoeko@erling.com.de>
  * @license  https://opensource.org/licenses/MIT MIT
  * @link     https://github.com/horstoeko/zugferd
+ *
+ * @phpstan-import-type ZugferdProfileDefinition from ZugferdProfiles
  */
 class ZugferdProfileResolver
 {
@@ -31,7 +33,7 @@ class ZugferdProfileResolver
      * Resolve profile id and profile definition by the content of $xmlContent
      *
      * @param  string $xmlContent
-     * @return array
+     * @return array{int, ZugferdProfileDefinition}
      * @throws ZugferdUnknownXmlContentException
      * @throws ZugferdUnknownProfileException
      */
@@ -89,7 +91,7 @@ class ZugferdProfileResolver
      * Resolve profile definition by the content of $xmlContent
      *
      * @param  string $xmlContent
-     * @return array
+     * @return ZugferdProfileDefinition
      * @throws ZugferdUnknownXmlContentException
      * @throws ZugferdUnknownProfileException
      */
@@ -102,7 +104,7 @@ class ZugferdProfileResolver
      * Resolve profile id and profile definition by it's id
      *
      * @param  int $profileId
-     * @return array
+     * @return array{int, ZugferdProfileDefinition}
      * @throws ZugferdUnknownProfileIdException
      */
     public static function resolveById(int $profileId): array
@@ -118,7 +120,7 @@ class ZugferdProfileResolver
      * Resolve profile profile definition by it's id
      *
      * @param  int $profileId
-     * @return array
+     * @return ZugferdProfileDefinition
      * @throws ZugferdUnknownProfileIdException
      */
     public static function resolveProfileDefById(int $profileId): array

--- a/src/ZugferdProfiles.php
+++ b/src/ZugferdProfiles.php
@@ -17,6 +17,21 @@ namespace horstoeko\zugferd;
  * @author   D. Erling <horstoeko@erling.com.de>
  * @license  https://opensource.org/licenses/MIT MIT
  * @link     https://github.com/horstoeko/zugferd
+ *
+ * @phpstan-type ZugferdProfileDefinition array{
+ *     name: string,
+ *     altname: string,
+ *     description: string,
+ *     contextparameter: string,
+ *     alternativecontextparameters: array<int, string>,
+ *     businessprocess: string|null,
+ *     attachmentfilename: string,
+ *     xmpname: string,
+ *     xmpversion: string,
+ *     xsdfilename: string,
+ *     schematronfilename: string,
+ *     xsltfilename: string
+ * }
  */
 class ZugferdProfiles
 {

--- a/src/ZugferdSettings.php
+++ b/src/ZugferdSettings.php
@@ -264,7 +264,7 @@ class ZugferdSettings
     /**
      * Returns a list of node paths which have a special number of decimal places
      *
-     * @return array
+     * @return array<string,integer>
      */
     public static function getSpecialDecimalPlacesMaps(): array
     {
@@ -288,7 +288,7 @@ class ZugferdSettings
     /**
      * Update the map of node paths which have a special number of decimal places
      *
-     * @param  array $specialDecimalPlacesMaps
+     * @param  array<string,integer> $specialDecimalPlacesMaps
      * @return void
      */
     public static function setSpecialDecimalPlacesMaps(array $specialDecimalPlacesMaps): void

--- a/src/ZugferdXsdValidator.php
+++ b/src/ZugferdXsdValidator.php
@@ -39,7 +39,7 @@ class ZugferdXsdValidator
     /**
      * Internal error bag
      *
-     * @var array
+     * @var array<int, string>
      */
     private $errorBag = [];
 
@@ -121,7 +121,7 @@ class ZugferdXsdValidator
     /**
      * Returns an array of all validation errors
      *
-     * @return array
+     * @return array<int, string>
      */
     public function validationErrors(): array
     {

--- a/src/jms/ZugferdTypesHandler.php
+++ b/src/jms/ZugferdTypesHandler.php
@@ -9,6 +9,8 @@
 
 namespace horstoeko\zugferd\jms;
 
+use DOMElement;
+use DOMText;
 use horstoeko\zugferd\ZugferdSettings;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
@@ -37,7 +39,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
      *          ),
      *      )
      *
-     * @return array
+     * @return array<int, array{direction: int, format: string, type: string, method: string}>
      */
     public static function getSubscribingMethods()
     {
@@ -177,6 +179,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
      *
      * @param XmlSerializationVisitor $visitor
      * @param mixed                   $data
+     * @return DOMText
      */
     public function serializeAmountType(XmlSerializationVisitor $visitor, $data)
     {
@@ -204,6 +207,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
      *
      * @param XmlSerializationVisitor $visitor
      * @param mixed                   $data
+     * @return DOMText
      */
     public function serializeQuantityType(XmlSerializationVisitor $visitor, $data)
     {
@@ -231,6 +235,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
      *
      * @param XmlSerializationVisitor $visitor
      * @param mixed                   $data
+     * @return DOMText
      */
     public function serializePercentType(XmlSerializationVisitor $visitor, $data)
     {
@@ -250,6 +255,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
      *
      * @param XmlSerializationVisitor $visitor
      * @param mixed                   $data
+     * @return DOMText
      */
     public function serializeMeasureType(XmlSerializationVisitor $visitor, $data)
     {
@@ -278,6 +284,7 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
      *
      * @param XmlSerializationVisitor $visitor
      * @param mixed                   $data
+     * @return DOMElement|false
      */
     public function serializeIndicatorType(XmlSerializationVisitor $visitor, $data)
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -143,7 +143,7 @@ class TestCase extends PhpUnitTestCase
      *
      * @param  object $object
      * @param  string $methodName
-     * @param  array  $args
+     * @param  mixed  ...$args
      * @return mixed
      */
     public function invokePrivateMethodFromObject($object, string $methodName, ...$args)

--- a/tests/testcases/KositValidatorTest.php
+++ b/tests/testcases/KositValidatorTest.php
@@ -29,7 +29,8 @@ class KositValidatorTest extends TestCase
 
         $this->assertEmpty($this->getPrivatePropertyFromObject($kositValidator, 'messageBag')->getValue($kositValidator));
         $this->assertEmpty($kositValidator->getProcessOutput());
-        $this->assertEmpty($kositValidator->getProcessErrors());
+        $processErrors = $kositValidator->getProcessErrors();
+        $this->assertEmpty($processErrors);
         $this->assertTrue($kositValidator->hasNoProcessErrors());
         $this->assertFalse($kositValidator->hasProcessErrors());
         $this->assertEmpty($kositValidator->getValidationErrors());
@@ -57,8 +58,9 @@ class KositValidatorTest extends TestCase
         $this->assertEmpty($kositValidator->getValidationInformation());
         $this->assertTrue($kositValidator->hasNoValidationInformation());
         $this->assertFalse($kositValidator->hasValidationInformation());
-        $this->assertArrayHasKey(0, $kositValidator->getProcessErrors());
-        $this->assertSame('SomeError', $kositValidator->getProcessErrors()[0] ?? "");
+        $processErrors = $kositValidator->getProcessErrors();
+        $this->assertArrayHasKey(0, $processErrors);
+        $this->assertSame('SomeError', $processErrors[0]);
 
         $this->getPrivateMethodFromObject($kositValidator, 'addToMessageBag')->invokeArgs($kositValidator, ['SomeError', 'validationerror']);
 

--- a/tests/testcases/PdfReaderExtGeneralTest.php
+++ b/tests/testcases/PdfReaderExtGeneralTest.php
@@ -133,6 +133,10 @@ class PdfReaderExtGeneralTest extends TestCase
         $this->checkAdditionalAttachments($additionalDocuments);
     }
 
+    /**
+     * @param  ZugferdDocumentReader $documentReader
+     * @return void
+     */
     private function checkDocumentReader($documentReader): void
     {
         $this->assertNotNull($documentReader);
@@ -140,6 +144,10 @@ class PdfReaderExtGeneralTest extends TestCase
         $this->assertInstanceOf(ZugferdDocumentReader::class, $documentReader);
     }
 
+    /**
+     * @param  string $xmlString
+     * @return void
+     */
     private function checkInvoiceDocumentXml($xmlString): void
     {
         $this->assertNotNull($xmlString);
@@ -149,7 +157,11 @@ class PdfReaderExtGeneralTest extends TestCase
         $this->assertStringContainsString("</rsm:CrossIndustryInvoice>", $xmlString);
     }
 
-    private function checkAdditionalAttachments($additionalDocuments): void
+    /**
+     * @param  array<int, array{type: int, content: string, filename: string, mimetype: string}> $additionalDocuments
+     * @return void
+     */
+    private function checkAdditionalAttachments(array $additionalDocuments): void
     {
         $this->assertNotEmpty($additionalDocuments);
         $this->assertCount(2, $additionalDocuments);

--- a/tests/testcases/ProfileConverterTest.php
+++ b/tests/testcases/ProfileConverterTest.php
@@ -40,7 +40,6 @@ class ProfileConverterTest extends TestCase
         $fromfile = __DIR__ . "/../assets/xml_en16931_1.xml";
         $converterResult = ZugferdDocumentProfileConverter::convertFromFileToString($fromfile, ZugferdProfiles::PROFILE_XRECHNUNG_3);
 
-        $this->assertIsString($converterResult);
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $converterResult);
         $this->assertStringContainsString('<ram:GuidelineSpecifiedDocumentContextParameter>', $converterResult);
         $this->assertStringContainsString('<ram:ID>urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0</ram:ID>', $converterResult);
@@ -81,7 +80,6 @@ class ProfileConverterTest extends TestCase
 
         $converterResult = ZugferdDocumentProfileConverter::convertFromContentToString($fromfileContent, ZugferdProfiles::PROFILE_XRECHNUNG_3);
 
-        $this->assertIsString($converterResult);
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $converterResult);
         $this->assertStringContainsString('<ram:GuidelineSpecifiedDocumentContextParameter>', $converterResult);
         $this->assertStringContainsString('<ram:ID>urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0</ram:ID>', $converterResult);
@@ -119,7 +117,6 @@ class ProfileConverterTest extends TestCase
         $fromfile = __DIR__ . "/../assets/xml_en16931_1.xml";
         $converterResult = ZugferdDocumentProfileConverter::convertFromFileToString($fromfile, ZugferdProfiles::PROFILE_EN16931);
 
-        $this->assertIsString($converterResult);
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $converterResult);
         $this->assertStringContainsString('<ram:GuidelineSpecifiedDocumentContextParameter>', $converterResult);
         $this->assertStringContainsString('<ram:ID>urn:cen.eu:en16931:2017</ram:ID>', $converterResult);
@@ -159,7 +156,6 @@ class ProfileConverterTest extends TestCase
         $fromfileContent = file_get_contents($fromfile);
         $converterResult = ZugferdDocumentProfileConverter::convertFromContentToString($fromfileContent, ZugferdProfiles::PROFILE_EN16931);
 
-        $this->assertIsString($converterResult);
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $converterResult);
         $this->assertStringContainsString('<ram:GuidelineSpecifiedDocumentContextParameter>', $converterResult);
         $this->assertStringContainsString('<ram:ID>urn:cen.eu:en16931:2017</ram:ID>', $converterResult);
@@ -184,7 +180,6 @@ class ProfileConverterTest extends TestCase
         $fromfile = __DIR__ . "/../assets/xml_extended_1.xml";
         $converterResult = ZugferdDocumentProfileConverter::convertFromFileToString($fromfile, ZugferdProfiles::PROFILE_EN16931);
 
-        $this->assertIsString($converterResult);
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $converterResult);
         $this->assertStringContainsString('<ram:GuidelineSpecifiedDocumentContextParameter>', $converterResult);
         $this->assertStringContainsString('<ram:ID>urn:cen.eu:en16931:2017</ram:ID>', $converterResult);

--- a/tests/testcases/ProfileResolverTest.php
+++ b/tests/testcases/ProfileResolverTest.php
@@ -167,7 +167,7 @@ HDR;
         return "This is not a XML";
     }
 
-    public function testResolveEn16931()
+    public function testResolveEn16931(): void
     {
         $resolved = ZugferdProfileResolver::resolve($this->deliverEn16931Header());
 
@@ -199,14 +199,14 @@ HDR;
         $this->assertEquals(ZugferdProfiles::PROFILEDEF[ZugferdProfiles::PROFILE_EN16931]['schematronfilename'], $resolved[1]["schematronfilename"]);
     }
 
-    public function testResolveProfileIdEn16931()
+    public function testResolveProfileIdEn16931(): void
     {
         $resolved = ZugferdProfileResolver::resolveProfileId($this->deliverEn16931Header());
 
         $this->assertSame(ZugferdProfiles::PROFILE_EN16931, $resolved);
     }
 
-    public function testResolveProfileDefEn16931()
+    public function testResolveProfileDefEn16931(): void
     {
         $resolved = ZugferdProfileResolver::resolveProfileDef($this->deliverEn16931Header());
 
@@ -233,7 +233,7 @@ HDR;
         $this->assertEquals(ZugferdProfiles::PROFILEDEF[ZugferdProfiles::PROFILE_EN16931]['schematronfilename'], $resolved["schematronfilename"]);
     }
 
-    public function testResolveProfileDefOldZF20Basic()
+    public function testResolveProfileDefOldZF20Basic(): void
     {
         $resolved = ZugferdProfileResolver::resolveProfileDef($this->deliverOldZF20BasicProfile());
 
@@ -260,7 +260,7 @@ HDR;
         $this->assertEquals(ZugferdProfiles::PROFILEDEF[ZugferdProfiles::PROFILE_BASIC]['schematronfilename'], $resolved["schematronfilename"]);
     }
 
-    public function testResolveProfileDefOldZF20BasicWl()
+    public function testResolveProfileDefOldZF20BasicWl(): void
     {
         $resolved = ZugferdProfileResolver::resolveProfileDef($this->deliverOldZF20BasicWlProfile());
 
@@ -287,7 +287,7 @@ HDR;
         $this->assertEquals(ZugferdProfiles::PROFILEDEF[ZugferdProfiles::PROFILE_BASICWL]['schematronfilename'], $resolved["schematronfilename"]);
     }
 
-    public function testResolveProfileDefOldZF20Minimum()
+    public function testResolveProfileDefOldZF20Minimum(): void
     {
         $resolved = ZugferdProfileResolver::resolveProfileDef($this->deliverOldZF20MinimumProfile());
 
@@ -314,7 +314,7 @@ HDR;
         $this->assertEquals(ZugferdProfiles::PROFILEDEF[ZugferdProfiles::PROFILE_MINIMUM]['schematronfilename'], $resolved["schematronfilename"]);
     }
 
-    public function testResolveProfileDefOldZF20Extended()
+    public function testResolveProfileDefOldZF20Extended(): void
     {
         $resolved = ZugferdProfileResolver::resolveProfileDef($this->deliverOldZF20ExtendedProfile());
 
@@ -341,7 +341,7 @@ HDR;
         $this->assertEquals(ZugferdProfiles::PROFILEDEF[ZugferdProfiles::PROFILE_EXTENDED]['schematronfilename'], $resolved["schematronfilename"]);
     }
 
-    public function testResolveUnknownProfile()
+    public function testResolveUnknownProfile(): void
     {
         $this->expectException(ZugferdUnknownProfileException::class);
         $this->expectExceptionMessage('Cannot determain the profile by unknown');
@@ -349,7 +349,7 @@ HDR;
         ZugferdProfileResolver::resolveProfileId($this->deliverUnknownProfile());
     }
 
-    public function testResolveInvalidXml()
+    public function testResolveInvalidXml(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('The XML does not match the requirements for an XML in CII-Syntax');
@@ -357,7 +357,7 @@ HDR;
         ZugferdProfileResolver::resolveProfileId($this->deliverInvalidXml());
     }
 
-    public function testResolveProfileByIdEn16931()
+    public function testResolveProfileByIdEn16931(): void
     {
         $resolved = ZugferdProfileResolver::resolveById(ZugferdProfiles::PROFILE_EN16931);
 
@@ -389,7 +389,7 @@ HDR;
         $this->assertEquals(ZugferdProfiles::PROFILEDEF[ZugferdProfiles::PROFILE_EN16931]['schematronfilename'], $resolved[1]["schematronfilename"]);
     }
 
-    public function testResolveProfileDefByIdEn16931()
+    public function testResolveProfileDefByIdEn16931(): void
     {
         $resolved = ZugferdProfileResolver::resolveProfileDefById(ZugferdProfiles::PROFILE_EN16931);
 
@@ -416,7 +416,7 @@ HDR;
         $this->assertEquals(ZugferdProfiles::PROFILEDEF[ZugferdProfiles::PROFILE_EN16931]['schematronfilename'], $resolved["schematronfilename"]);
     }
 
-    public function testResolveProfileDefByIdUnknown()
+    public function testResolveProfileDefByIdUnknown(): void
     {
         $this->expectException(ZugferdUnknownProfileIdException::class);
         $this->expectExceptionMessage('The profile id -1 is uknown');
@@ -424,7 +424,7 @@ HDR;
         ZugferdProfileResolver::resolveProfileDefById(-1);
     }
 
-    public function testResolveNotXml()
+    public function testResolveNotXml(): void
     {
         // Test clear LibXml Errors, when error previously occourred (See issue #133)
 

--- a/tests/testcases/ValidatorValidTest.php
+++ b/tests/testcases/ValidatorValidTest.php
@@ -24,6 +24,6 @@ class ValidatorValidTest extends TestCase
     {
         $validator = new ZugferdDocumentValidator(self::$document);
         $validationResult = $validator->validateDocument();
-        $this->assertEmpty($validationResult);
+        $this->assertCount(0, $validationResult);
     }
 }

--- a/tests/testcases/issues/Issue337Test.php
+++ b/tests/testcases/issues/Issue337Test.php
@@ -10,6 +10,7 @@ use horstoeko\zugferd\codelists\ZugferdInvoiceType;
 use horstoeko\zugferd\tests\traits\HandlesXmlTests;
 use horstoeko\zugferd\codelists\ZugferdCurrencyCodes;
 use horstoeko\zugferd\exception\ZugferdUnsupportedMimetype;
+use horstoeko\zugferd\exception\ZugferdInvalidArgumentException;
 
 class Issue337Test extends TestCase
 {
@@ -72,6 +73,14 @@ class Issue337Test extends TestCase
         self::$document->addDocumentInvoiceSupportingDocumentWithBase64Data('REFDOC-2024/00001-1', '00_AdditionalDocument.unknwon', $this->deliverBase64UnknownMimeType(), 'Attachment 1');
     }
 
+    public function testBase64InvalidData(): void
+    {
+        $this->expectException(ZugferdInvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/is not valid Base64-encoded data/');
+
+        self::$document->addDocumentInvoiceSupportingDocumentWithBase64Data('REFDOC-2024/00001-1', '00_AdditionalDocument.pdf', $this->deliverInvalidBase64(), 'Attachment 1');
+    }
+
     private function deliverBase64EncodedPdf(): string
     {
         $content = file_get_contents(__DIR__ . '/../../assets/pdf_plain.pdf');
@@ -94,5 +103,10 @@ class Issue337Test extends TestCase
     {
         $content = file_get_contents(__DIR__ . '/../../assets/xml_dummy.xml');
         return base64_encode($content);
+    }
+
+    private function deliverInvalidBase64(): string
+    {
+        return 'This is not valid Base64 data!!';
     }
 }


### PR DESCRIPTION
# Description

Raises PHPStan from level 3 to level 6 and fixes everything it surfaced along the way. No issue is associated with this — the two bugs below were found by the analyser rather than reported.

Going up one level at a time turned up two real bugs, both in `ZugferdObjectHelper::getReferencedDocumentType()`:

**1. The Base64 guard never validated anything.** Added in 8a3fc33, the guard called `base64_encode()` where `base64_decode()` was meant:

```php
base64_encode($base64EncodedData) !== false   // always true — base64_encode() never returns false
```

So invalid Base64 was never rejected. It fell through to the non-strict `base64_decode()` below, which silently discards invalid characters, and the resulting garbage was then sniffed by `finfo`. Usually that surfaced as a confusing `ZugferdUnsupportedMimetype`, but if the garbage happened to sniff as `text/plain` and the filename ended in `.csv`, it was accepted and a corrupt attachment was embedded.

It now validates with strict `base64_decode()` and throws `ZugferdInvalidArgumentException`, reusing the decoded payload for the `finfo` call rather than decoding twice.

**2. The CSV mimetype workaround was scoped to PHP 8.10, not 8.1.** From a628c9f:

```php
if (PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 81000 && $mimetype === 'application/csv') {
```

`PHP_VERSION_ID` is `major * 10000 + minor * 100 + patch`, so PHP 8.1.0 is `80100`; `81000` is PHP 8.10.0. The upper bound therefore excluded nothing and a fix commented *"PHP 8.0 may misdetect CSV files"* has been running on every 8.x release. Corrected to `80100`. I verified on PHP 8.2 that `finfo` returns `text/csv` / `text/plain` and never `application/csv`, so this touches no live path on supported versions.

Level 5 was already clean. Level 6's 139 findings were all missing annotations. Of note:

- The twelve-key profile definition array is shared by `ZugferdDocument`, `ZugferdObjectHelper`, `ZugferdProfileResolver` and `ZugferdDocumentPdfMerger`, so it is declared once as a `@phpstan-type` alias on `ZugferdProfiles` and imported where needed.
- Types are precise wherever they are provable: the `ZugferdPdfWriter` attachment/metadata shapes, the KOSIT and PDF validator message bags, and the JMS handlers (which return `DOMText` / `DOMElement|false`).
- `ZugferdDocumentReader` is the exception. Every value it yields comes from `tryCallByPathAndReturn()`, which returns `mixed` by design, so no precise value type is provable there. Those out-parameters are annotated with what the code actually guarantees — `array<int, mixed>` from `convertToArray()`, which builds integer keys, versus `array<mixed, mixed>` from `ensureArray()`, which returns its input untouched. The existing prose docblocks already name each array's keys, so no documentation is lost.

The final commit corrects the `tryCall` family's docblocks. `tryCall()`, `tryCallAll()`, `tryCallAndReturn()`, `tryCallIfMethodExists()` and `methodExists()` all open with an `if (!$instance)` early return, and callers pass `createClassInstance()`, which is `null` whenever the entity class does not exist for the active profile. The `@param object` annotations described a contract the code never had. This is not a widening to silence anything — it is what these methods already accept and handle. It accounts for 182 of the 418 errors reported at level 8.

**Why stop at 6?** Level 8 leaves ~236 findings that need real decisions rather than annotations: how `createClassInstance()`'s documented `null` is handled at ~90 call sites, and the `DOMXPath::query()` / `->item()` false-and-null returns. A further blocker is upstream — `StringUtils::stringIsNullOrEmpty()` guards correctly at runtime but carries no `@phpstan-assert-if-false`, so PHPStan cannot narrow `?string` through it; that is better fixed in `horstoeko/stringmanagement` than worked around here. Levels 9 and max report ~1362 and ~1644 findings, overwhelmingly the reflective `mixed`-based core restated, which is a redesign rather than a lint bump. Happy to pursue any of that separately if you'd like.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

On the breaking-change box — two behavioural changes worth your attention, both small but real:

1. Invalid Base64 passed to `addDocumentInvoiceSupportingDocumentWithBase64Data()` (and friends) now throws `ZugferdInvalidArgumentException`. Previously it usually threw `ZugferdUnsupportedMimetype`, and occasionally succeeded with corrupt data. Both are `ZugferdBaseException` subclasses, so only callers catching the specific type are affected.
2. `application/csv` is no longer normalised to `text/csv` on PHP 8.1+. This restores the documented intent, and `finfo` does not emit `application/csv` on those versions — but it is a narrowing, so please sanity-check it against your own expectations.

Tell me if you would rather have either split out or reverted.

# How Has This Been Tested?

- [x] Full suite: `composer tests` — 2132 tests, 15277 assertions, all passing except one pre-existing failure (see below)
- [x] Added `Issue337Test::testBase64InvalidData`, covering the new invalid-Base64 rejection. I confirmed it genuinely fails against the pre-fix code (where the invalid input reaches the non-strict `base64_decode()`, and the sniffed garbage throws `ZugferdUnsupportedMimetype` from a different line) and passes with the fix
- [x] Static analysis: `composer phpstan` clean at the new level 6
- [x] Code style: `composer phpcs` reports only the two findings that already exist on a clean `master` (a >500 char line in `ZugferdDocumentBuilder.php`, and a missing EOF newline in `ReaderExtendedBuyerTaxRepresentativeTest.php`) — neither is touched by this PR
- [x] Verified the CSV bound empirically: checked `finfo` output for both CSV fixtures on PHP 8.2 before narrowing the guard
- [x] Verified the reader's array shapes by observing real runtime types from the test fixtures, rather than inferring them from the mapping defaults

`KositValidatorTest::testCheckRequirementsRemoteWithCompleteSetup` fails both with and without this branch — it needs a local KOSIT validator daemon. I confirmed it fails identically on a clean checkout of `master`.

**Test Configuration**:

* OS: macOS (Darwin)
* OS Version: 25.5.0
* PHP Version: 8.2.31

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules

Being straight about the unchecked boxes:

- **No new comments.** `ZugferdObjectHelper` does not use `@throws` anywhere, including for the `ZugferdUnsupportedMimetype` throws that were already there, so I followed the file's existing convention rather than introducing one.
- **No separate docs change.** The docblocks are updated in place; nothing in the wiki appeared to describe these internals.
- Dependent changes: none, though the `stringmanagement` assertion note above would help a future level-8 attempt.
