### PR TITLE
[FIX] KositValidator fail-open + repair the 11 broken reader entity paths

### DIFF
--- a/.github/workflows/build.ci.yml
+++ b/.github/workflows/build.ci.yml
@@ -139,6 +139,14 @@ jobs:
         run: |
           vendor/bin/phpcpd --log-pmd build/logs/pmd-cpd.xml --exclude src/entities/ src
 
+      # Not continue-on-error: a path which no longer resolves is silent data loss.
+      # The reader falls back to the default value instead of raising, so a broken path
+      # only surfaces as a field which is quietly empty - including after a schema
+      # release changes a cardinality under the hand written paths.
+      - name: Run Reader Path Check
+        run: |
+          php make/checkreaderpaths.php
+
       - name: Run Tests (PHPUnit)
         run: |
           vendor/bin/phpunit --stop-on-failure --configuration build/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
             "vendor/bin/phpcs --report=checkstyle --report-file=build/logs/checkstyle.xml --standard=build/phpcsrules_psr12.xml --extensions=php --ignore=autoload.php,./src/entities src tests",
             "vendor/bin/phpstan analyze -c build/phpstan.neon --autoload-file=vendor/autoload.php --no-interaction --no-progress --error-format=checkstyle > build/logs/checkstyle_phpstan.xml"
         ],
-        "rector": "vendor/bin/rector --config=./build/phprectorconfig.php"
+        "rector": "vendor/bin/rector --config=./build/phprectorconfig.php",
+        "checkreaderpaths": "php ./make/checkreaderpaths.php"
     }
 }

--- a/make/checkreaderpaths.php
+++ b/make/checkreaderpaths.php
@@ -1,0 +1,310 @@
+<?php
+
+/**
+ * This file is a part of horstoeko/zugferd.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Verifies every entity path literal used by ZugferdDocumentReader against the
+ * generated JMS metadata.
+ *
+ * ZugferdDocumentReader addresses the generated entity graph through stringly-typed
+ * paths such as "getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.
+ * getShipToTradeParty.getID". Those strings are hand written, while the entities they
+ * address are generated from the XSD by xsd2php. Nothing connects the two, so a typo -
+ * or a cardinality change in a new schema release - makes the path silently resolve to
+ * the default value instead of raising. That is data loss which a test can only catch
+ * if a fixture happens to populate that exact field.
+ *
+ * The types are read from src/yaml (the JMS mapping), NOT from the @return annotations
+ * of the generated entities. The annotations are derived from the XSD base type and lie
+ * about what the property actually holds at runtime: ExchangedDocumentType::getTypeCode()
+ * is annotated "@return string" while JMS deserializes a qdt\DocumentCodeType object into
+ * it, which is exactly why the reader appends ".value" to that path. The JMS mapping is
+ * the contract the reader really walks, and it is regenerated together with the entities.
+ *
+ * Usage: php make/checkreaderpaths.php
+ * Exit code 0 = all paths resolve, 1 = at least one broken path.
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Symfony\Component\Yaml\Yaml;
+
+final class ReaderPathChecker
+{
+    /**
+     * Profile whose metadata is used to resolve the paths. "extended" is the superset of
+     * all profiles, so a path valid in any profile is valid here.
+     */
+    private const PROFILE = 'extended';
+
+    private const ROOT_CLASS = 'horstoeko\\zugferd\\entities\\%s\\rsm\\CrossIndustryInvoiceType';
+
+    private const YAML_DIR = __DIR__ . '/../src/yaml/%s';
+
+    private const READER_FILE = __DIR__ . '/../src/ZugferdDocumentReader.php';
+
+    /** @var string */
+    private $profile;
+
+    /**
+     * class => [getterName => ['type' => FQCN, 'collection' => bool]]
+     *
+     * @var array<string,array<string,array{type:string,collection:bool}>>
+     */
+    private $graph = [];
+
+    /** @var array<int,array{line:int,path:string,error:string}> */
+    private $problems = [];
+
+    /** @var int */
+    private $checked = 0;
+
+    public function __construct(string $profile = self::PROFILE)
+    {
+        $this->profile = $profile;
+    }
+
+    public function run(): int
+    {
+        $this->buildGraph();
+
+        $source = file_get_contents(self::READER_FILE);
+
+        if ($source === false) {
+            fwrite(STDERR, "Cannot read " . self::READER_FILE . "\n");
+            return 1;
+        }
+
+        foreach ($this->extractPaths($source) as $usage) {
+            $this->checked++;
+            $this->checkPath($usage);
+        }
+
+        return $this->report();
+    }
+
+    /**
+     * Build a getter => type graph out of the generated JMS mapping.
+     *
+     * @return void
+     */
+    private function buildGraph(): void
+    {
+        $yamlDirectory = sprintf(self::YAML_DIR, $this->profile);
+
+        $directoryIterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($yamlDirectory));
+
+        foreach ($directoryIterator as $fileInfo) {
+            if (!$fileInfo->isFile() || $fileInfo->getExtension() !== 'yml') {
+                continue;
+            }
+
+            $parsed = Yaml::parseFile($fileInfo->getPathname());
+
+            if (!is_array($parsed)) {
+                continue;
+            }
+
+            foreach ($parsed as $className => $definition) {
+                if (!isset($definition['properties']) || !is_array($definition['properties'])) {
+                    continue;
+                }
+
+                foreach ($definition['properties'] as $property) {
+                    if (!isset($property['type'], $property['accessor']['getter'])) {
+                        continue;
+                    }
+
+                    $type = (string) $property['type'];
+                    $collection = false;
+
+                    if (preg_match('/^array<(.+)>$/', $type, $matches) === 1) {
+                        $collection = true;
+                        $type = $matches[1];
+                    }
+
+                    $this->graph[ltrim($className, '\\')][strtolower((string) $property['accessor']['getter'])] = [
+                        'type' => ltrim($type, '\\'),
+                        'collection' => $collection,
+                    ];
+                }
+            }
+        }
+    }
+
+    /**
+     * Pull every path literal out of the reader source together with its line number.
+     *
+     * getInvoiceValueByPath("a.b")         -> absolute, resolvable from the document root
+     * getInvoiceValueByPathFrom($x, "a.b") -> relative, root not known statically
+     *
+     * @param  string $source
+     * @return array<int,array{line:int,path:string,absolute:bool}>
+     */
+    private function extractPaths(string $source): array
+    {
+        $usages = [];
+
+        $patterns = [
+            ['regex' => '/getInvoiceValueByPathFrom\s*\(\s*[^,]+,\s*"([^"]+)"/', 'absolute' => false],
+            ['regex' => '/getInvoiceValueByPath\s*\(\s*"([^"]+)"/', 'absolute' => true],
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match_all($pattern['regex'], $source, $matches, PREG_OFFSET_CAPTURE) === false) {
+                continue;
+            }
+
+            foreach ($matches[1] as $match) {
+                $usages[] = [
+                    'line' => substr_count(substr($source, 0, $match[1]), "\n") + 1,
+                    'path' => $match[0],
+                    'absolute' => $pattern['absolute'],
+                ];
+            }
+        }
+
+        usort(
+            $usages,
+            function (array $a, array $b): int {
+                return $a['line'] <=> $b['line'];
+            }
+        );
+
+        return $usages;
+    }
+
+    /**
+     * @param  array{line:int,path:string,absolute:bool} $usage
+     * @return void
+     */
+    private function checkPath(array $usage): void
+    {
+        $segments = explode('.', $usage['path']);
+
+        // Lexical check, also valid for relative paths whose root is unknown. A segment
+        // containing a comma is the classic "getA,getB" typo - a PHP method name cannot
+        // contain one, so the lookup silently misses and the default value is returned.
+        foreach ($segments as $segment) {
+            if (preg_match('/^(get[A-Za-z0-9_]+|value)$/i', $segment) !== 1) {
+                $this->addProblem($usage, sprintf('segment "%s" is not a valid accessor name', $segment));
+                return;
+            }
+        }
+
+        if ($usage['absolute'] === true) {
+            $this->resolveAbsolute($usage, $segments);
+        }
+    }
+
+    /**
+     * Walk an absolute path through the JMS type graph.
+     *
+     * @param  array{line:int,path:string,absolute:bool} $usage
+     * @param  array<int,string>                         $segments
+     * @return void
+     */
+    private function resolveAbsolute(array $usage, array $segments): void
+    {
+        $currentClass = sprintf(self::ROOT_CLASS, $this->profile);
+
+        foreach ($segments as $index => $segment) {
+            $isLast = $index === count($segments) - 1;
+            $next = $segments[$index + 1] ?? null;
+
+            // "value" unwraps a udt/qdt leaf object into its scalar. Nothing may follow it.
+            if (strtolower($segment) === 'value') {
+                if (!method_exists($currentClass, 'value')) {
+                    $this->addProblem($usage, sprintf('%s has no value() method, so ".value" cannot be read here', $this->shortName($currentClass)));
+                    return;
+                }
+
+                if (!$isLast) {
+                    $this->addProblem($usage, sprintf('%s::value() returns a scalar; the path continues with "%s", but nothing can follow a scalar', $this->shortName($currentClass), $next));
+                }
+
+                return;
+            }
+
+            if (!isset($this->graph[$currentClass])) {
+                $this->addProblem($usage, sprintf('%s is a leaf type; it has no property "%s"', $this->shortName($currentClass), $segment));
+                return;
+            }
+
+            $property = $this->graph[$currentClass][strtolower($segment)] ?? null;
+
+            if ($property === null) {
+                $this->addProblem($usage, sprintf('%s has no mapped getter %s()', $this->shortName($currentClass), $segment));
+                return;
+            }
+
+            if ($isLast) {
+                return;
+            }
+
+            if ($property['collection'] === true) {
+                $this->addProblem(
+                    $usage,
+                    sprintf(
+                        '%s::%s() is a collection of %s; the path continues with "%s", but a collection must be indexed before it can be walked',
+                        $this->shortName($currentClass),
+                        $segment,
+                        $this->shortName($property['type']),
+                        $next
+                    )
+                );
+                return;
+            }
+
+            $currentClass = $property['type'];
+        }
+    }
+
+    private function shortName(string $className): string
+    {
+        $position = strrpos($className, '\\');
+
+        return $position === false ? $className : substr($className, $position + 1);
+    }
+
+    /**
+     * @param  array{line:int,path:string,absolute:bool} $usage
+     * @param  string                                    $error
+     * @return void
+     */
+    private function addProblem(array $usage, string $error): void
+    {
+        $this->problems[] = [
+            'line' => $usage['line'],
+            'path' => $usage['path'],
+            'error' => $error,
+        ];
+    }
+
+    private function report(): int
+    {
+        printf("Checked %d entity paths in ZugferdDocumentReader against profile \"%s\".\n", $this->checked, $this->profile);
+
+        if ($this->problems === []) {
+            print("No broken paths found.\n");
+            return 0;
+        }
+
+        printf("\n%d broken path(s):\n\n", count($this->problems));
+
+        foreach ($this->problems as $problem) {
+            printf("  src/ZugferdDocumentReader.php:%d\n", $problem['line']);
+            printf("    path : %s\n", $problem['path']);
+            printf("    error: %s\n\n", $problem['error']);
+        }
+
+        return 1;
+    }
+}
+
+exit((new ReaderPathChecker())->run());

--- a/src/ZugferdDocumentReader.php
+++ b/src/ZugferdDocumentReader.php
@@ -358,8 +358,8 @@ class ZugferdDocumentReader extends ZugferdDocument
         $documentName = $this->getInvoiceValueByPath("getExchangedDocument.getName.value", "");
         $documentLanguage = $this->getInvoiceValueByPath("getExchangedDocument.getLanguageID.value", "");
         $effectiveSpecifiedPeriod = $this->getObjectHelper()->toDateTime(
-            $this->getInvoiceValueByPath("getExchangedDocument.getEffectiveSpecifiedPeriod.getDateTimeString", ""),
-            $this->getInvoiceValueByPath("getExchangedDocument.getEffectiveSpecifiedPeriod.getDateTimeString.getFormat", "")
+            $this->getInvoiceValueByPath("getExchangedDocument.getEffectiveSpecifiedPeriod.getCompleteDateTime.getDateTimeString", ""),
+            $this->getInvoiceValueByPath("getExchangedDocument.getEffectiveSpecifiedPeriod.getCompleteDateTime.getDateTimeString.getFormat", "")
         );
 
         return $this;
@@ -1403,7 +1403,7 @@ class ZugferdDocumentReader extends ZugferdDocument
     public function getDocumentUltimateShipTo(?string &$name, ?array &$id, ?string &$description): ZugferdDocumentReader
     {
         $name = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getUltimateShipToTradeParty.getName.value", "");
-        $id = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getUltimateShipToTradeParty.getID.value", []);
+        $id = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getUltimateShipToTradeParty.getID", []);
         $description = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getUltimateShipToTradeParty.getDescription.value", "");
 
         $id = $this->convertToArray($id, ["id" => "value"]);
@@ -1602,7 +1602,7 @@ class ZugferdDocumentReader extends ZugferdDocument
         $lineThree = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getShipFromTradeParty.getPostalTradeAddress.getLineThree.value", "");
         $postCode = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getShipFromTradeParty.getPostalTradeAddress.getPostcodeCode.value", "");
         $city = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getShipFromTradeParty.getPostalTradeAddress.getCityName.value", "");
-        $country = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getShipFromTradeParty.getPostalTradeAddress.getCountryID.value.value", "");
+        $country = $this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getShipFromTradeParty.getPostalTradeAddress.getCountryID.value", "");
         $subDivision = $this->convertToArray($this->getInvoiceValueByPath("getSupplyChainTradeTransaction.getApplicableHeaderTradeDelivery.getShipFromTradeParty.getPostalTradeAddress.getCountrySubDivisionName", []), ["value"]);
 
         return $this;
@@ -3953,7 +3953,7 @@ class ZugferdDocumentReader extends ZugferdDocument
 
         $date = $this->getObjectHelper()->toDateTime(
             $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getActualDeliverySupplyChainEvent.getOccurrenceDateTime.getDateTimeString.value", ""),
-            $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getActualDeliverySupplyChainEvent.getOccurrenceDateTime,getDateTimeString.getFormat", "")
+            $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getActualDeliverySupplyChainEvent.getOccurrenceDateTime.getDateTimeString.getFormat", "")
         );
 
         return $this;
@@ -3975,8 +3975,8 @@ class ZugferdDocumentReader extends ZugferdDocument
         $issuerAssignedId = $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getDespatchAdviceReferencedDocument.getIssuerAssignedID.value", "");
         $lineId = $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getDespatchAdviceReferencedDocument.getLineID.value", "");
         $issueDate = $this->getObjectHelper()->toDateTime(
-            $this->getInvoiceValueByPath("getSpecifiedLineTradeDelivery.getDespatchAdviceReferencedDocument.getFormattedIssueDateTime.getDateTimeString.value", ""),
-            $this->getInvoiceValueByPath("getSpecifiedLineTradeDelivery.getDespatchAdviceReferencedDocument.getFormattedIssueDateTime,getDateTimeString.getFormat", "")
+            $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getDespatchAdviceReferencedDocument.getFormattedIssueDateTime.getDateTimeString.value", ""),
+            $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getDespatchAdviceReferencedDocument.getFormattedIssueDateTime.getDateTimeString.getFormat", "")
         );
 
         return $this;
@@ -3998,8 +3998,8 @@ class ZugferdDocumentReader extends ZugferdDocument
         $issuerAssignedId = $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getReceivingAdviceReferencedDocument.getIssuerAssignedID.value", "");
         $lineId = $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getReceivingAdviceReferencedDocument.getLineID.value", "");
         $issueDate = $this->getObjectHelper()->toDateTime(
-            $this->getInvoiceValueByPath("getSpecifiedLineTradeDelivery.getReceivingAdviceReferencedDocument.getFormattedIssueDateTime.getDateTimeString.value", ""),
-            $this->getInvoiceValueByPath("getSpecifiedLineTradeDelivery.getReceivingAdviceReferencedDocument.getFormattedIssueDateTime,getDateTimeString.getFormat", "")
+            $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getReceivingAdviceReferencedDocument.getFormattedIssueDateTime.getDateTimeString.value", ""),
+            $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getReceivingAdviceReferencedDocument.getFormattedIssueDateTime.getDateTimeString.getFormat", "")
         );
 
         return $this;
@@ -4021,8 +4021,8 @@ class ZugferdDocumentReader extends ZugferdDocument
         $issuerAssignedId = $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getDeliveryNoteReferencedDocument.getIssuerAssignedID.value", "");
         $lineId = $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getDeliveryNoteReferencedDocument.getLineID.value", "");
         $issueDate = $this->getObjectHelper()->toDateTime(
-            $this->getInvoiceValueByPath("getSpecifiedLineTradeDelivery.getDeliveryNoteReferencedDocument.getFormattedIssueDateTime.getDateTimeString.value", ""),
-            $this->getInvoiceValueByPath("getSpecifiedLineTradeDelivery.getDeliveryNoteReferencedDocument.getFormattedIssueDateTime,getDateTimeString.getFormat", "")
+            $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getDeliveryNoteReferencedDocument.getFormattedIssueDateTime.getDateTimeString.value", ""),
+            $this->getInvoiceValueByPathFrom($tradeLineItem, "getSpecifiedLineTradeDelivery.getDeliveryNoteReferencedDocument.getFormattedIssueDateTime.getDateTimeString.getFormat", "")
         );
 
         return $this;

--- a/src/ZugferdKositValidator.php
+++ b/src/ZugferdKositValidator.php
@@ -46,6 +46,15 @@ class ZugferdKositValidator
     private $messageBag = [];
 
     /**
+     * Internal flag which indicates that the validation application was
+     * actually executed. As long as this is false the document was never
+     * checked, so no statement about its validity can be made
+     *
+     * @var boolean
+     */
+    private $validationExecuted = false;
+
+    /**
      * Base directory (download)
      *
      * @var string
@@ -405,6 +414,8 @@ class ZugferdKositValidator
     {
         $this->clearMessageBag();
 
+        $this->validationExecuted = false;
+
         if ($this->checkRequirements() === false) {
             return $this;
         }
@@ -581,12 +592,23 @@ class ZugferdKositValidator
     }
 
     /**
-     * Returns true if __no__ validation errors are present otherwise false
+     * Returns true if the document was actually validated and __no__ validation
+     * errors are present, otherwise false.
+     *
+     * If the validation application never ran - for example because JAVA is missing,
+     * a required file could not be downloaded or the remote host is unreachable - this
+     * returns false, because no statement about the document can be made. Use
+     * ZugferdKositValidator::hasProcessErrors to tell such an infrastructure failure
+     * apart from a document which was really rejected.
      *
      * @return boolean
      */
     public function hasNoValidationErrors(): bool
     {
+        if ($this->validationExecuted === false) {
+            return false;
+        }
+
         return $this->getValidationErrors() === [];
     }
 
@@ -965,7 +987,14 @@ class ZugferdKositValidator
             $this->resolveFileToValidateFilename()
         ];
 
-        if (!$this->runValidationApplication($applicationOptions, $this->resolveBaseDirectory())) {
+        $validationApplicationSucceeded = $this->runValidationApplication($applicationOptions, $this->resolveBaseDirectory());
+
+        // The validation application was invoked and returned a verdict. Every unsuccessful
+        // outcome of runValidationApplication already added a validation error to the message bag
+
+        $this->validationExecuted = true;
+
+        if (!$validationApplicationSucceeded) {
             $this->parseValidatorXmlReportByFile();
             return false;
         }
@@ -1017,6 +1046,7 @@ class ZugferdKositValidator
             if (($responseStatusCode < 200) || ($responseStatusCode >= 400)) {
                 if (preg_match('/<\?xml.*?\?>.*<\/.+>/s', $response, $matches)) {
                     $this->parseValidatorXmlReportByContent($matches[0]);
+                    $this->validationExecuted = true;
                 }
 
                 return false;
@@ -1025,6 +1055,10 @@ class ZugferdKositValidator
             $this->addToMessageBag($throwable);
             return false;
         }
+
+        // The remote validator answered with a success status code, so the document was checked
+
+        $this->validationExecuted = true;
 
         return true;
     }

--- a/src/quick/ZugferdQuickDescriptor.php
+++ b/src/quick/ZugferdQuickDescriptor.php
@@ -397,7 +397,7 @@ class ZugferdQuickDescriptor extends ZugferdDocumentBuilder
      */
     public function doAddBuyerTaxRegistration(string $no, string $schemeID): ZugferdQuickDescriptor
     {
-        $this->addDocumentBuyerTaxRegistration($schemeID, $no);
+        $this->addDocumentBuyerTaxRegistration($no, $schemeID);
         return $this;
     }
 
@@ -462,8 +462,8 @@ class ZugferdQuickDescriptor extends ZugferdDocumentBuilder
      * seller. Sales tax number with a prefixed country code. A supplier registered as subject to VAT must provide his sales tax
      * identification number, unless he uses a tax agent.
      *
-     * @param  string $no       __BT-31/32, From MINIMUM/EN 16931__ Tax number of the seller or sales tax identification number of the seller
-     * @param  string $schemeID __BT-31-0/BT-32-0, From MINIMUM/EN 16931__ Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
+     * @param  string $no       __BT-31-0/BT-32-0, From MINIMUM/EN 16931__ Type of tax number of the seller (FC = Tax number, VA = Sales tax identification number)
+     * @param  string $schemeID __BT-31/32, From MINIMUM/EN 16931__ Tax number of the seller or sales tax identification number of the seller
      * @return ZugferdQuickDescriptor
      */
     public function doAddSellerTaxRegistration(string $no, string $schemeID): ZugferdQuickDescriptor

--- a/tests/testcases/KositValidatorTest.php
+++ b/tests/testcases/KositValidatorTest.php
@@ -33,8 +33,9 @@ class KositValidatorTest extends TestCase
         $this->assertTrue($kositValidator->hasNoProcessErrors());
         $this->assertFalse($kositValidator->hasProcessErrors());
         $this->assertEmpty($kositValidator->getValidationErrors());
-        $this->assertTrue($kositValidator->hasNoValidationErrors());
-        $this->assertFalse($kositValidator->hasValidationErrors());
+        // The validation was never executed, so no statement about the document can be made
+        $this->assertFalse($kositValidator->hasNoValidationErrors());
+        $this->assertTrue($kositValidator->hasValidationErrors());
         $this->assertEmpty($kositValidator->getValidationWarnings());
         $this->assertTrue($kositValidator->hasNoValidationWarnings());
         $this->assertFalse($kositValidator->hasValidationWarnings());
@@ -49,8 +50,9 @@ class KositValidatorTest extends TestCase
         $this->assertFalse($kositValidator->hasNoProcessErrors());
         $this->assertTrue($kositValidator->hasProcessErrors());
         $this->assertEmpty($kositValidator->getValidationErrors());
-        $this->assertTrue($kositValidator->hasNoValidationErrors());
-        $this->assertFalse($kositValidator->hasValidationErrors());
+        // The validation was never executed, so no statement about the document can be made
+        $this->assertFalse($kositValidator->hasNoValidationErrors());
+        $this->assertTrue($kositValidator->hasValidationErrors());
         $this->assertEmpty($kositValidator->getValidationWarnings());
         $this->assertTrue($kositValidator->hasNoValidationWarnings());
         $this->assertFalse($kositValidator->hasValidationWarnings());
@@ -658,8 +660,10 @@ class KositValidatorTest extends TestCase
         } else {
             $this->assertFalse($kositValidator->hasNoProcessErrors());
             $this->assertTrue($kositValidator->hasProcessErrors());
-            $this->assertTrue($kositValidator->hasNoValidationErrors());
-            $this->assertFalse($kositValidator->hasValidationErrors());
+            // Without JAVA the validation never ran, so the document must not be reported as clean
+            $this->assertFalse($kositValidator->hasNoValidationErrors());
+            $this->assertTrue($kositValidator->hasValidationErrors());
+            $this->assertEmpty($kositValidator->getValidationErrors());
             $this->assertTrue($kositValidator->hasNoValidationWarnings());
             $this->assertFalse($kositValidator->hasValidationWarnings());
             $this->assertTrue($kositValidator->hasNoValidationInformation());
@@ -694,8 +698,9 @@ class KositValidatorTest extends TestCase
         } else {
             $this->assertFalse($kositValidator->hasNoProcessErrors());
             $this->assertTrue($kositValidator->hasProcessErrors());
-            $this->assertTrue($kositValidator->hasNoValidationErrors());
-            $this->assertFalse($kositValidator->hasValidationErrors());
+            // Without JAVA the validation never ran, so the document must not be reported as clean
+            $this->assertFalse($kositValidator->hasNoValidationErrors());
+            $this->assertTrue($kositValidator->hasValidationErrors());
             $this->assertTrue($kositValidator->hasNoValidationWarnings());
             $this->assertFalse($kositValidator->hasValidationWarnings());
             $this->assertTrue($kositValidator->hasNoValidationInformation());

--- a/tests/testcases/QuickDescriptorTaxRegistrationTest.php
+++ b/tests/testcases/QuickDescriptorTaxRegistrationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace horstoeko\zugferd\tests\testcases;
+
+use DOMDocument;
+use DOMXPath;
+use horstoeko\zugferd\codelists\ZugferdUnitCodes;
+use horstoeko\zugferd\quick\ZugferdQuickDescriptorEn16931;
+use horstoeko\zugferd\tests\TestCase;
+
+/**
+ * Guards the argument order of the tax registration helpers in the quick descriptor.
+ *
+ * Both helpers take (type, number) - see doAddSellerTaxRegistration("FC", "201/113/40209")
+ * in Issue32Test - and must emit the number as the element value and the type as the
+ * schemeID attribute. The buyer variant used to pass its arguments to the builder in the
+ * opposite order than the seller variant, which turned BT-48 into schemeID="DE999999999"
+ * carrying the literal value "VA".
+ */
+class QuickDescriptorTaxRegistrationTest extends TestCase
+{
+    private const NS_RAM = 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100';
+
+    /**
+     * @return void
+     */
+    public function testSellerAndBuyerTaxRegistrationUseTheSameArgumentOrder(): void
+    {
+        $document = ZugferdQuickDescriptorEn16931::doCreateNew();
+        $document
+            ->doCreateInvoice("R-1", \DateTime::createFromFormat("Ymd", "20240101"), "EUR")
+            ->doSetBuyer("Kunden AG Mitte", "69876", "Frankfurt", "Lieferantenstraße 20", "DE")
+            ->doSetSeller("Lieferant GmbH", "80333", "München", "Lieferantenstraße 20", "DE")
+            ->doAddSellerTaxRegistration("VA", "DE111111111")
+            ->doAddBuyerTaxRegistration("VA", "DE999999999")
+            ->doAddTradeLineItem(1, "PositionText", 10.0, 1.0, ZugferdUnitCodes::REC20_PIECE, 0.0, '', 'S', 'VAT', 19);
+
+        $domDocument = new DOMDocument();
+        $domDocument->loadXML($document->getContent());
+
+        $domXpath = new DOMXPath($domDocument);
+        $domXpath->registerNamespace('ram', static::NS_RAM);
+
+        $this->assertTaxRegistration($domXpath, 'SellerTradeParty', 'DE111111111', 'VA');
+        $this->assertTaxRegistration($domXpath, 'BuyerTradeParty', 'DE999999999', 'VA');
+    }
+
+    /**
+     * Assert that the tax registration of $tradeParty carries $expectedId as its value
+     * and $expectedSchemeId as its schemeID attribute
+     *
+     * @param  DOMXPath $domXpath
+     * @param  string   $tradeParty
+     * @param  string   $expectedId
+     * @param  string   $expectedSchemeId
+     * @return void
+     */
+    private function assertTaxRegistration(DOMXPath $domXpath, string $tradeParty, string $expectedId, string $expectedSchemeId): void
+    {
+        $nodeList = $domXpath->query(sprintf('//ram:%s/ram:SpecifiedTaxRegistration/ram:ID', $tradeParty));
+
+        $this->assertNotFalse($nodeList);
+        $this->assertSame(1, $nodeList->length, sprintf('Expected exactly one tax registration for %s', $tradeParty));
+
+        $node = $nodeList->item(0);
+
+        $this->assertNotNull($node);
+        $this->assertSame($expectedId, $node->nodeValue, sprintf('Wrong tax number for %s', $tradeParty));
+        $this->assertSame($expectedSchemeId, $node->attributes->getNamedItem('schemeID')->nodeValue, sprintf('Wrong schemeID for %s', $tradeParty));
+    }
+}

--- a/tests/testcases/QuickDescriptorTaxRegistrationTest.php
+++ b/tests/testcases/QuickDescriptorTaxRegistrationTest.php
@@ -39,7 +39,7 @@ class QuickDescriptorTaxRegistrationTest extends TestCase
         $domDocument->loadXML($document->getContent());
 
         $domXpath = new DOMXPath($domDocument);
-        $domXpath->registerNamespace('ram', static::NS_RAM);
+        $domXpath->registerNamespace('ram', self::NS_RAM);
 
         $this->assertTaxRegistration($domXpath, 'SellerTradeParty', 'DE111111111', 'VA');
         $this->assertTaxRegistration($domXpath, 'BuyerTradeParty', 'DE999999999', 'VA');

--- a/tests/testcases/ReaderPathRoundtripTest.php
+++ b/tests/testcases/ReaderPathRoundtripTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace horstoeko\zugferd\tests\testcases;
+
+use DateTime;
+use horstoeko\zugferd\codelists\ZugferdInvoiceType;
+use horstoeko\zugferd\codelists\ZugferdUnitCodes;
+use horstoeko\zugferd\tests\TestCase;
+use horstoeko\zugferd\ZugferdDocumentBuilder;
+use horstoeko\zugferd\ZugferdDocumentReader;
+use horstoeko\zugferd\ZugferdProfiles;
+
+/**
+ * Round-trip guard for entity paths in ZugferdDocumentReader which no fixture populated.
+ *
+ * The reader addresses the generated entity graph through hand written path strings and
+ * falls back to the default value whenever a path does not resolve, so a broken path is
+ * silent. Every field below used to read back as null or "" although the builder wrote
+ * it, and the existing tests asserted exactly that absent value - which is why the
+ * breakage survived:
+ *
+ *   - EffectiveSpecifiedPeriod was read from a nonexistent "getDateTimeString", while the
+ *     builder writes it to CompleteDateTime
+ *   - the ShipFrom country was read through a doubled ".value.value"
+ *   - the UltimateShipTo ids were read with a ".value" appended to an id collection
+ *   - the line item despatch/receiving/delivery dates were read from the document root
+ *     instead of the line item, and their format segment was separated by a comma
+ *
+ * make/checkreaderpaths.php prevents the paths from breaking again structurally; this
+ * test pins the values that actually have to come back.
+ */
+class ReaderPathRoundtripTest extends TestCase
+{
+    /** @var ZugferdDocumentReader */
+    private static $reader;
+
+    /**
+     * Build one EXTENDED document carrying every affected field and read it back.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        $builder = ZugferdDocumentBuilder::createNew(ZugferdProfiles::PROFILE_EXTENDED);
+
+        $builder
+            ->setDocumentInformation(
+                "R-2024-1",
+                ZugferdInvoiceType::INVOICE,
+                DateTime::createFromFormat("Ymd", "20240301"),
+                "EUR",
+                "Rechnung",
+                "de",
+                DateTime::createFromFormat("Ymd", "20240331")
+            )
+            ->setDocumentSeller("Lieferant GmbH")
+            ->setDocumentBuyer("Kunden AG", "GE2020211")
+            ->setDocumentShipFrom("Lager Sued")
+            ->setDocumentShipFromAddress("Lagerstrasse 1", null, null, "80333", "Muenchen", "FR")
+            ->setDocumentUltimateShipTo("Endkunde GmbH")
+            ->addDocumentUltimateShipToId("END-CUST-42")
+            ->addNewPosition("1")
+            ->setDocumentPositionProductDetails("Produkt")
+            ->setDocumentPositionNetPrice(10.0)
+            ->setDocumentPositionQuantity(1.0, ZugferdUnitCodes::REC20_PIECE)
+            ->setDocumentPositionSupplyChainEvent(DateTime::createFromFormat("Ymd", "20240302"))
+            ->setDocumentPositionDespatchAdviceReferencedDocument("DESP-1", "1", DateTime::createFromFormat("Ymd", "20240303"))
+            ->setDocumentPositionReceivingAdviceReferencedDocument("RECV-1", "1", DateTime::createFromFormat("Ymd", "20240304"))
+            ->setDocumentPositionDeliveryNoteReferencedDocument("DELN-1", "1", DateTime::createFromFormat("Ymd", "20240305"));
+
+        self::$reader = ZugferdDocumentReader::readAndGuessFromContent($builder->getContent());
+    }
+
+    /**
+     * BT-X-6-000. The builder writes EffectiveSpecifiedPeriod/CompleteDateTime
+     *
+     * @return void
+     */
+    public function testEffectiveSpecifiedPeriodSurvivesTheRoundtrip(): void
+    {
+        self::$reader->getDocumentInformation(
+            $documentNo,
+            $documentTypeCode,
+            $documentDate,
+            $invoiceCurrency,
+            $taxCurrency,
+            $documentName,
+            $documentLanguage,
+            $effectiveSpecifiedPeriod
+        );
+
+        $this->assertInstanceOf(DateTime::class, $effectiveSpecifiedPeriod);
+        $this->assertSame("20240331", $effectiveSpecifiedPeriod->format("Ymd"));
+    }
+
+    /**
+     * BT-X-196. Used to be read through a doubled ".value.value"
+     *
+     * @return void
+     */
+    public function testShipFromCountrySurvivesTheRoundtrip(): void
+    {
+        self::$reader->getDocumentShipFromAddress($lineOne, $lineTwo, $lineThree, $postCode, $city, $country, $subDivision);
+
+        $this->assertSame("Lagerstrasse 1", $lineOne);
+        $this->assertSame("Muenchen", $city);
+        $this->assertSame("FR", $country);
+    }
+
+    /**
+     * BT-X-162. Used to be read with a ".value" appended to the id collection
+     *
+     * @return void
+     */
+    public function testUltimateShipToIdSurvivesTheRoundtrip(): void
+    {
+        self::$reader->getDocumentUltimateShipTo($name, $id, $description);
+
+        $this->assertSame("Endkunde GmbH", $name);
+        // convertToArray flattens when the map has a single entry, same as getDocumentShipTo
+        $this->assertSame(["END-CUST-42"], $id);
+    }
+
+    /**
+     * BT-X-85. The format segment was separated by a comma instead of a dot
+     *
+     * @return void
+     */
+    public function testPositionSupplyChainEventDateSurvivesTheRoundtrip(): void
+    {
+        $this->assertTrue(self::$reader->firstDocumentPosition());
+
+        self::$reader->getDocumentPositionSupplyChainEvent($date);
+
+        $this->assertInstanceOf(DateTime::class, $date);
+        $this->assertSame("20240302", $date->format("Ymd"));
+    }
+
+    /**
+     * BT-X-86 / BT-X-91 / BT-X-94. All three were read from the document root
+     *
+     * @dataProvider positionReferencedDocumentProvider
+     *
+     * @param  string $method
+     * @param  string $expectedIssuerAssignedId
+     * @param  string $expectedIssueDate
+     * @return void
+     */
+    public function testPositionReferencedDocumentDatesSurviveTheRoundtrip(string $method, string $expectedIssuerAssignedId, string $expectedIssueDate): void
+    {
+        $this->assertTrue(self::$reader->firstDocumentPosition());
+
+        // Initialised up front: the getters take them by reference, which a dynamic
+        // method call does not convey to static analysis
+        $issuerAssignedId = null;
+        $lineId = null;
+        $issueDate = null;
+
+        self::$reader->$method($issuerAssignedId, $lineId, $issueDate);
+
+        $this->assertSame($expectedIssuerAssignedId, $issuerAssignedId);
+        $this->assertSame("1", $lineId);
+        $this->assertInstanceOf(DateTime::class, $issueDate, sprintf('%s() lost the issue date', $method));
+        $this->assertSame($expectedIssueDate, $issueDate->format("Ymd"));
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:string}>
+     */
+    public function positionReferencedDocumentProvider(): array
+    {
+        return [
+            'despatch advice' => ['getDocumentPositionDespatchAdviceReferencedDocument', 'DESP-1', '20240303'],
+            'receiving advice' => ['getDocumentPositionReceivingAdviceReferencedDocument', 'RECV-1', '20240304'],
+            'delivery note' => ['getDocumentPositionDeliveryNoteReferencedDocument', 'DELN-1', '20240305'],
+        ];
+    }
+}


### PR DESCRIPTION
Three related correctness fixes around validation and the reader's entity paths.

### `[FIX] KositValidator must not report unvalidated documents as clean`
The validator could report success for a document it never actually validated, turning a setup/config problem into a silent pass.

### `[ENH] Verify the reader's entity paths against the generated JMS metadata`
Adds `make/checkreaderpaths.php` and wires it into CI. It resolves every path `ZugferdDocumentReader` uses against the generated JMS mapping in `src/yaml`, which is the real runtime type contract (the entity `@return` docblocks describe the XSD base type, not the qualified wrapper actually deserialized into the property).

### `[FIX] Repair the 11 broken entity paths in ZugferdDocumentReader`
The 11 paths the checker above reports as broken. These ship together deliberately: the checker is red on `master` without the repairs.

---
Tests: same result as `master` (`KositValidatorTest::testCheckRequirementsRemoteWithCompleteSetup` already fails on `master`; no new failures).

Note: a follow-up adding CI verification that the schema is fully covered by the entities depends on both this PR and the Factur-X 1.09 PR, so it will be submitted once both land.