### PR TITLE
[FIX] Align phpdoc nullability in the generated entities

### DIFF
--- a/src/entities/basic/qdt/AllowanceChargeReasonCodeType.php
+++ b/src/entities/basic/qdt/AllowanceChargeReasonCodeType.php
@@ -11,7 +11,7 @@ class AllowanceChargeReasonCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class AllowanceChargeReasonCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basic/qdt/CountryIDType.php
+++ b/src/entities/basic/qdt/CountryIDType.php
@@ -11,7 +11,7 @@ class CountryIDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CountryIDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basic/qdt/CurrencyCodeType.php
+++ b/src/entities/basic/qdt/CurrencyCodeType.php
@@ -11,7 +11,7 @@ class CurrencyCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CurrencyCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basic/qdt/DocumentCodeType.php
+++ b/src/entities/basic/qdt/DocumentCodeType.php
@@ -11,7 +11,7 @@ class DocumentCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class DocumentCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basic/qdt/FormattedDateTimeType.php
+++ b/src/entities/basic/qdt/FormattedDateTimeType.php
@@ -11,14 +11,14 @@ class FormattedDateTimeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType\DateTimeStringAType $dateTimeString
+     * @var \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType\DateTimeStringAType|null $dateTimeString
      */
     private $dateTimeString = null;
 
     /**
      * Gets as dateTimeString
      *
-     * @return \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType\DateTimeStringAType
+     * @return \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType\DateTimeStringAType|null
      */
     public function getDateTimeString()
     {

--- a/src/entities/basic/qdt/FormattedDateTimeType/DateTimeStringAType.php
+++ b/src/entities/basic/qdt/FormattedDateTimeType/DateTimeStringAType.php
@@ -9,12 +9,12 @@ class DateTimeStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateTimeStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateTimeStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/basic/qdt/PaymentMeansCodeType.php
+++ b/src/entities/basic/qdt/PaymentMeansCodeType.php
@@ -11,7 +11,7 @@ class PaymentMeansCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class PaymentMeansCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basic/qdt/TaxCategoryCodeType.php
+++ b/src/entities/basic/qdt/TaxCategoryCodeType.php
@@ -11,7 +11,7 @@ class TaxCategoryCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TaxCategoryCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basic/qdt/TaxTypeCodeType.php
+++ b/src/entities/basic/qdt/TaxTypeCodeType.php
@@ -11,7 +11,7 @@ class TaxTypeCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TaxTypeCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basic/qdt/TimeReferenceCodeType.php
+++ b/src/entities/basic/qdt/TimeReferenceCodeType.php
@@ -11,7 +11,7 @@ class TimeReferenceCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TimeReferenceCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basic/ram/CreditorFinancialAccountType.php
+++ b/src/entities/basic/ram/CreditorFinancialAccountType.php
@@ -11,19 +11,19 @@ class CreditorFinancialAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $iBANID
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $iBANID
      */
     private $iBANID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $proprietaryID
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $proprietaryID
      */
     private $proprietaryID = null;
 
     /**
      * Gets as iBANID
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getIBANID()
     {
@@ -33,7 +33,7 @@ class CreditorFinancialAccountType
     /**
      * Sets a new iBANID
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\IDType $iBANID
+     * @param  \horstoeko\zugferd\entities\basic\udt\IDType|null $iBANID
      * @return self
      */
     public function setIBANID(?\horstoeko\zugferd\entities\basic\udt\IDType $iBANID = null)
@@ -45,7 +45,7 @@ class CreditorFinancialAccountType
     /**
      * Gets as proprietaryID
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getProprietaryID()
     {
@@ -55,7 +55,7 @@ class CreditorFinancialAccountType
     /**
      * Sets a new proprietaryID
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\IDType $proprietaryID
+     * @param  \horstoeko\zugferd\entities\basic\udt\IDType|null $proprietaryID
      * @return self
      */
     public function setProprietaryID(?\horstoeko\zugferd\entities\basic\udt\IDType $proprietaryID = null)

--- a/src/entities/basic/ram/DebtorFinancialAccountType.php
+++ b/src/entities/basic/ram/DebtorFinancialAccountType.php
@@ -11,14 +11,14 @@ class DebtorFinancialAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $iBANID
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $iBANID
      */
     private $iBANID = null;
 
     /**
      * Gets as iBANID
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getIBANID()
     {

--- a/src/entities/basic/ram/DocumentContextParameterType.php
+++ b/src/entities/basic/ram/DocumentContextParameterType.php
@@ -11,14 +11,14 @@ class DocumentContextParameterType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/basic/ram/DocumentLineDocumentType.php
+++ b/src/entities/basic/ram/DocumentLineDocumentType.php
@@ -11,19 +11,19 @@ class DocumentLineDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $lineID
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $lineID
      */
     private $lineID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\NoteType $includedNote
+     * @var \horstoeko\zugferd\entities\basic\ram\NoteType|null $includedNote
      */
     private $includedNote = null;
 
     /**
      * Gets as lineID
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getLineID()
     {
@@ -45,7 +45,7 @@ class DocumentLineDocumentType
     /**
      * Gets as includedNote
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\NoteType
+     * @return \horstoeko\zugferd\entities\basic\ram\NoteType|null
      */
     public function getIncludedNote()
     {
@@ -55,7 +55,7 @@ class DocumentLineDocumentType
     /**
      * Sets a new includedNote
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\NoteType $includedNote
+     * @param  \horstoeko\zugferd\entities\basic\ram\NoteType|null $includedNote
      * @return self
      */
     public function setIncludedNote(?\horstoeko\zugferd\entities\basic\ram\NoteType $includedNote = null)

--- a/src/entities/basic/ram/ExchangedDocumentContextType.php
+++ b/src/entities/basic/ram/ExchangedDocumentContextType.php
@@ -11,19 +11,19 @@ class ExchangedDocumentContextType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      */
     private $businessProcessSpecifiedDocumentContextParameter = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType $guidelineSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType|null $guidelineSpecifiedDocumentContextParameter
      */
     private $guidelineSpecifiedDocumentContextParameter = null;
 
     /**
      * Gets as businessProcessSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType|null
      */
     public function getBusinessProcessSpecifiedDocumentContextParameter()
     {
@@ -33,7 +33,7 @@ class ExchangedDocumentContextType
     /**
      * Sets a new businessProcessSpecifiedDocumentContextParameter
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @param  \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      * @return self
      */
     public function setBusinessProcessSpecifiedDocumentContextParameter(?\horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter = null)
@@ -45,7 +45,7 @@ class ExchangedDocumentContextType
     /**
      * Gets as guidelineSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\basic\ram\DocumentContextParameterType|null
      */
     public function getGuidelineSpecifiedDocumentContextParameter()
     {

--- a/src/entities/basic/ram/ExchangedDocumentType.php
+++ b/src/entities/basic/ram/ExchangedDocumentType.php
@@ -11,17 +11,17 @@ class ExchangedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType $issueDateTime
+     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType|null $issueDateTime
      */
     private $issueDateTime = null;
 
@@ -35,7 +35,7 @@ class ExchangedDocumentType
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getID()
     {
@@ -57,7 +57,7 @@ class ExchangedDocumentType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -79,7 +79,7 @@ class ExchangedDocumentType
     /**
      * Gets as issueDateTime
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType|null
      */
     public function getIssueDateTime()
     {
@@ -145,7 +145,7 @@ class ExchangedDocumentType
     /**
      * Sets a new includedNote
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\NoteType[] $includedNote
+     * @param  \horstoeko\zugferd\entities\basic\ram\NoteType[]|null $includedNote
      * @return self
      */
     public function setIncludedNote(?array $includedNote = null)

--- a/src/entities/basic/ram/HeaderTradeAgreementType.php
+++ b/src/entities/basic/ram/HeaderTradeAgreementType.php
@@ -11,39 +11,39 @@ class HeaderTradeAgreementType
 {
 
     /**
-     * @var string $buyerReference
+     * @var string|null $buyerReference
      */
     private $buyerReference = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType $sellerTradeParty
+     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType|null $sellerTradeParty
      */
     private $sellerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType $buyerTradeParty
+     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType|null $buyerTradeParty
      */
     private $buyerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType $sellerTaxRepresentativeTradeParty
+     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType|null $sellerTaxRepresentativeTradeParty
      */
     private $sellerTaxRepresentativeTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      */
     private $buyerOrderReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType $contractReferencedDocument
+     * @var \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType|null $contractReferencedDocument
      */
     private $contractReferencedDocument = null;
 
     /**
      * Gets as buyerReference
      *
-     * @return string
+     * @return string|null
      */
     public function getBuyerReference()
     {
@@ -65,7 +65,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType|null
      */
     public function getSellerTradeParty()
     {
@@ -87,7 +87,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType|null
      */
     public function getBuyerTradeParty()
     {
@@ -109,7 +109,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerTaxRepresentativeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType|null
      */
     public function getSellerTaxRepresentativeTradeParty()
     {
@@ -119,7 +119,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new sellerTaxRepresentativeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradePartyType $sellerTaxRepresentativeTradeParty
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradePartyType|null $sellerTaxRepresentativeTradeParty
      * @return self
      */
     public function setSellerTaxRepresentativeTradeParty(?\horstoeko\zugferd\entities\basic\ram\TradePartyType $sellerTaxRepresentativeTradeParty = null)
@@ -131,7 +131,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType|null
      */
     public function getBuyerOrderReferencedDocument()
     {
@@ -141,7 +141,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new buyerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      * @return self
      */
     public function setBuyerOrderReferencedDocument(?\horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType $buyerOrderReferencedDocument = null)
@@ -153,7 +153,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as contractReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType|null
      */
     public function getContractReferencedDocument()
     {
@@ -163,7 +163,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new contractReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType $contractReferencedDocument
+     * @param  \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType|null $contractReferencedDocument
      * @return self
      */
     public function setContractReferencedDocument(?\horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType $contractReferencedDocument = null)

--- a/src/entities/basic/ram/HeaderTradeDeliveryType.php
+++ b/src/entities/basic/ram/HeaderTradeDeliveryType.php
@@ -11,24 +11,24 @@ class HeaderTradeDeliveryType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType $shipToTradeParty
+     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType|null $shipToTradeParty
      */
     private $shipToTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @var \horstoeko\zugferd\entities\basic\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      */
     private $actualDeliverySupplyChainEvent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @var \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      */
     private $despatchAdviceReferencedDocument = null;
 
     /**
      * Gets as shipToTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType|null
      */
     public function getShipToTradeParty()
     {
@@ -38,7 +38,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new shipToTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradePartyType $shipToTradeParty
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradePartyType|null $shipToTradeParty
      * @return self
      */
     public function setShipToTradeParty(?\horstoeko\zugferd\entities\basic\ram\TradePartyType $shipToTradeParty = null)
@@ -50,7 +50,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as actualDeliverySupplyChainEvent
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\SupplyChainEventType
+     * @return \horstoeko\zugferd\entities\basic\ram\SupplyChainEventType|null
      */
     public function getActualDeliverySupplyChainEvent()
     {
@@ -60,7 +60,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new actualDeliverySupplyChainEvent
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @param  \horstoeko\zugferd\entities\basic\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      * @return self
      */
     public function setActualDeliverySupplyChainEvent(?\horstoeko\zugferd\entities\basic\ram\SupplyChainEventType $actualDeliverySupplyChainEvent = null)
@@ -72,7 +72,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as despatchAdviceReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType|null
      */
     public function getDespatchAdviceReferencedDocument()
     {
@@ -82,7 +82,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new despatchAdviceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      * @return self
      */
     public function setDespatchAdviceReferencedDocument(?\horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType $despatchAdviceReferencedDocument = null)

--- a/src/entities/basic/ram/HeaderTradeSettlementType.php
+++ b/src/entities/basic/ram/HeaderTradeSettlementType.php
@@ -11,27 +11,27 @@ class HeaderTradeSettlementType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $creditorReferenceID
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $creditorReferenceID
      */
     private $creditorReferenceID = null;
 
     /**
-     * @var string $paymentReference
+     * @var string|null $paymentReference
      */
     private $paymentReference = null;
 
     /**
-     * @var string $taxCurrencyCode
+     * @var string|null $taxCurrencyCode
      */
     private $taxCurrencyCode = null;
 
     /**
-     * @var string $invoiceCurrencyCode
+     * @var string|null $invoiceCurrencyCode
      */
     private $invoiceCurrencyCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType $payeeTradeParty
+     * @var \horstoeko\zugferd\entities\basic\ram\TradePartyType|null $payeeTradeParty
      */
     private $payeeTradeParty = null;
 
@@ -50,7 +50,7 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @var \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      */
     private $billingSpecifiedPeriod = null;
 
@@ -62,12 +62,12 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradePaymentTermsType $specifiedTradePaymentTerms
+     * @var \horstoeko\zugferd\entities\basic\ram\TradePaymentTermsType|null $specifiedTradePaymentTerms
      */
     private $specifiedTradePaymentTerms = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradeSettlementHeaderMonetarySummationType $specifiedTradeSettlementHeaderMonetarySummation
+     * @var \horstoeko\zugferd\entities\basic\ram\TradeSettlementHeaderMonetarySummationType|null $specifiedTradeSettlementHeaderMonetarySummation
      */
     private $specifiedTradeSettlementHeaderMonetarySummation = null;
 
@@ -79,14 +79,14 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount
+     * @var \horstoeko\zugferd\entities\basic\ram\TradeAccountingAccountType|null $receivableSpecifiedTradeAccountingAccount
      */
     private $receivableSpecifiedTradeAccountingAccount = null;
 
     /**
      * Gets as creditorReferenceID
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getCreditorReferenceID()
     {
@@ -96,7 +96,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new creditorReferenceID
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\IDType $creditorReferenceID
+     * @param  \horstoeko\zugferd\entities\basic\udt\IDType|null $creditorReferenceID
      * @return self
      */
     public function setCreditorReferenceID(?\horstoeko\zugferd\entities\basic\udt\IDType $creditorReferenceID = null)
@@ -108,7 +108,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as paymentReference
      *
-     * @return string
+     * @return string|null
      */
     public function getPaymentReference()
     {
@@ -130,7 +130,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as taxCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTaxCurrencyCode()
     {
@@ -152,7 +152,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as invoiceCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getInvoiceCurrencyCode()
     {
@@ -174,7 +174,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as payeeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradePartyType|null
      */
     public function getPayeeTradeParty()
     {
@@ -184,7 +184,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new payeeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradePartyType $payeeTradeParty
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradePartyType|null $payeeTradeParty
      * @return self
      */
     public function setPayeeTradeParty(?\horstoeko\zugferd\entities\basic\ram\TradePartyType $payeeTradeParty = null)
@@ -240,7 +240,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradeSettlementPaymentMeans
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradeSettlementPaymentMeansType[] $specifiedTradeSettlementPaymentMeans
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradeSettlementPaymentMeansType[]|null $specifiedTradeSettlementPaymentMeans
      * @return self
      */
     public function setSpecifiedTradeSettlementPaymentMeans(?array $specifiedTradeSettlementPaymentMeans = null)
@@ -308,7 +308,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as billingSpecifiedPeriod
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType
+     * @return \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType|null
      */
     public function getBillingSpecifiedPeriod()
     {
@@ -318,7 +318,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new billingSpecifiedPeriod
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @param  \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      * @return self
      */
     public function setBillingSpecifiedPeriod(?\horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType $billingSpecifiedPeriod = null)
@@ -374,7 +374,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType[] $specifiedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType[]|null $specifiedTradeAllowanceCharge
      * @return self
      */
     public function setSpecifiedTradeAllowanceCharge(?array $specifiedTradeAllowanceCharge = null)
@@ -386,7 +386,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as specifiedTradePaymentTerms
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradePaymentTermsType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradePaymentTermsType|null
      */
     public function getSpecifiedTradePaymentTerms()
     {
@@ -396,7 +396,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradePaymentTerms
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradePaymentTermsType $specifiedTradePaymentTerms
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradePaymentTermsType|null $specifiedTradePaymentTerms
      * @return self
      */
     public function setSpecifiedTradePaymentTerms(?\horstoeko\zugferd\entities\basic\ram\TradePaymentTermsType $specifiedTradePaymentTerms = null)
@@ -408,7 +408,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as specifiedTradeSettlementHeaderMonetarySummation
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradeSettlementHeaderMonetarySummationType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradeSettlementHeaderMonetarySummationType|null
      */
     public function getSpecifiedTradeSettlementHeaderMonetarySummation()
     {
@@ -474,7 +474,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new invoiceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType[] $invoiceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\basic\ram\ReferencedDocumentType[]|null $invoiceReferencedDocument
      * @return self
      */
     public function setInvoiceReferencedDocument(?array $invoiceReferencedDocument = null)
@@ -486,7 +486,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as receivableSpecifiedTradeAccountingAccount
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradeAccountingAccountType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradeAccountingAccountType|null
      */
     public function getReceivableSpecifiedTradeAccountingAccount()
     {
@@ -496,7 +496,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new receivableSpecifiedTradeAccountingAccount
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAccountingAccountType|null $receivableSpecifiedTradeAccountingAccount
      * @return self
      */
     public function setReceivableSpecifiedTradeAccountingAccount(?\horstoeko\zugferd\entities\basic\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount = null)

--- a/src/entities/basic/ram/LegalOrganizationType.php
+++ b/src/entities/basic/ram/LegalOrganizationType.php
@@ -11,19 +11,19 @@ class LegalOrganizationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $tradingBusinessName
+     * @var string|null $tradingBusinessName
      */
     private $tradingBusinessName = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getID()
     {
@@ -33,7 +33,7 @@ class LegalOrganizationType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\IDType $iD
+     * @param  \horstoeko\zugferd\entities\basic\udt\IDType|null $iD
      * @return self
      */
     public function setID(?\horstoeko\zugferd\entities\basic\udt\IDType $iD = null)
@@ -45,7 +45,7 @@ class LegalOrganizationType
     /**
      * Gets as tradingBusinessName
      *
-     * @return string
+     * @return string|null
      */
     public function getTradingBusinessName()
     {

--- a/src/entities/basic/ram/LineTradeAgreementType.php
+++ b/src/entities/basic/ram/LineTradeAgreementType.php
@@ -11,19 +11,19 @@ class LineTradeAgreementType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradePriceType $grossPriceProductTradePrice
+     * @var \horstoeko\zugferd\entities\basic\ram\TradePriceType|null $grossPriceProductTradePrice
      */
     private $grossPriceProductTradePrice = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradePriceType $netPriceProductTradePrice
+     * @var \horstoeko\zugferd\entities\basic\ram\TradePriceType|null $netPriceProductTradePrice
      */
     private $netPriceProductTradePrice = null;
 
     /**
      * Gets as grossPriceProductTradePrice
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradePriceType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradePriceType|null
      */
     public function getGrossPriceProductTradePrice()
     {
@@ -33,7 +33,7 @@ class LineTradeAgreementType
     /**
      * Sets a new grossPriceProductTradePrice
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradePriceType $grossPriceProductTradePrice
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradePriceType|null $grossPriceProductTradePrice
      * @return self
      */
     public function setGrossPriceProductTradePrice(?\horstoeko\zugferd\entities\basic\ram\TradePriceType $grossPriceProductTradePrice = null)
@@ -45,7 +45,7 @@ class LineTradeAgreementType
     /**
      * Gets as netPriceProductTradePrice
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradePriceType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradePriceType|null
      */
     public function getNetPriceProductTradePrice()
     {

--- a/src/entities/basic/ram/LineTradeDeliveryType.php
+++ b/src/entities/basic/ram/LineTradeDeliveryType.php
@@ -11,14 +11,14 @@ class LineTradeDeliveryType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\QuantityType $billedQuantity
+     * @var \horstoeko\zugferd\entities\basic\udt\QuantityType|null $billedQuantity
      */
     private $billedQuantity = null;
 
     /**
      * Gets as billedQuantity
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\basic\udt\QuantityType|null
      */
     public function getBilledQuantity()
     {

--- a/src/entities/basic/ram/LineTradeSettlementType.php
+++ b/src/entities/basic/ram/LineTradeSettlementType.php
@@ -11,12 +11,12 @@ class LineTradeSettlementType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradeTaxType $applicableTradeTax
+     * @var \horstoeko\zugferd\entities\basic\ram\TradeTaxType|null $applicableTradeTax
      */
     private $applicableTradeTax = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @var \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      */
     private $billingSpecifiedPeriod = null;
 
@@ -28,14 +28,14 @@ class LineTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradeSettlementLineMonetarySummationType $specifiedTradeSettlementLineMonetarySummation
+     * @var \horstoeko\zugferd\entities\basic\ram\TradeSettlementLineMonetarySummationType|null $specifiedTradeSettlementLineMonetarySummation
      */
     private $specifiedTradeSettlementLineMonetarySummation = null;
 
     /**
      * Gets as applicableTradeTax
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradeTaxType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradeTaxType|null
      */
     public function getApplicableTradeTax()
     {
@@ -57,7 +57,7 @@ class LineTradeSettlementType
     /**
      * Gets as billingSpecifiedPeriod
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType
+     * @return \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType|null
      */
     public function getBillingSpecifiedPeriod()
     {
@@ -67,7 +67,7 @@ class LineTradeSettlementType
     /**
      * Sets a new billingSpecifiedPeriod
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @param  \horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      * @return self
      */
     public function setBillingSpecifiedPeriod(?\horstoeko\zugferd\entities\basic\ram\SpecifiedPeriodType $billingSpecifiedPeriod = null)
@@ -123,7 +123,7 @@ class LineTradeSettlementType
     /**
      * Sets a new specifiedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType[] $specifiedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType[]|null $specifiedTradeAllowanceCharge
      * @return self
      */
     public function setSpecifiedTradeAllowanceCharge(?array $specifiedTradeAllowanceCharge = null)
@@ -135,7 +135,7 @@ class LineTradeSettlementType
     /**
      * Gets as specifiedTradeSettlementLineMonetarySummation
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradeSettlementLineMonetarySummationType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradeSettlementLineMonetarySummationType|null
      */
     public function getSpecifiedTradeSettlementLineMonetarySummation()
     {

--- a/src/entities/basic/ram/NoteType.php
+++ b/src/entities/basic/ram/NoteType.php
@@ -11,19 +11,19 @@ class NoteType
 {
 
     /**
-     * @var string $content
+     * @var string|null $content
      */
     private $content = null;
 
     /**
-     * @var string $subjectCode
+     * @var string|null $subjectCode
      */
     private $subjectCode = null;
 
     /**
      * Gets as content
      *
-     * @return string
+     * @return string|null
      */
     public function getContent()
     {
@@ -45,7 +45,7 @@ class NoteType
     /**
      * Gets as subjectCode
      *
-     * @return string
+     * @return string|null
      */
     public function getSubjectCode()
     {

--- a/src/entities/basic/ram/ReferencedDocumentType.php
+++ b/src/entities/basic/ram/ReferencedDocumentType.php
@@ -11,19 +11,19 @@ class ReferencedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $issuerAssignedID
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $issuerAssignedID
      */
     private $issuerAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType $formattedIssueDateTime
+     * @var \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType|null $formattedIssueDateTime
      */
     private $formattedIssueDateTime = null;
 
     /**
      * Gets as issuerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getIssuerAssignedID()
     {
@@ -45,7 +45,7 @@ class ReferencedDocumentType
     /**
      * Gets as formattedIssueDateTime
      *
-     * @return \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType
+     * @return \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType|null
      */
     public function getFormattedIssueDateTime()
     {
@@ -55,7 +55,7 @@ class ReferencedDocumentType
     /**
      * Sets a new formattedIssueDateTime
      *
-     * @param  \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType $formattedIssueDateTime
+     * @param  \horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType|null $formattedIssueDateTime
      * @return self
      */
     public function setFormattedIssueDateTime(?\horstoeko\zugferd\entities\basic\qdt\FormattedDateTimeType $formattedIssueDateTime = null)

--- a/src/entities/basic/ram/SpecifiedPeriodType.php
+++ b/src/entities/basic/ram/SpecifiedPeriodType.php
@@ -11,19 +11,19 @@ class SpecifiedPeriodType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType $startDateTime
+     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType|null $startDateTime
      */
     private $startDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType $endDateTime
+     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType|null $endDateTime
      */
     private $endDateTime = null;
 
     /**
      * Gets as startDateTime
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType|null
      */
     public function getStartDateTime()
     {
@@ -33,7 +33,7 @@ class SpecifiedPeriodType
     /**
      * Sets a new startDateTime
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\DateTimeType $startDateTime
+     * @param  \horstoeko\zugferd\entities\basic\udt\DateTimeType|null $startDateTime
      * @return self
      */
     public function setStartDateTime(?\horstoeko\zugferd\entities\basic\udt\DateTimeType $startDateTime = null)
@@ -45,7 +45,7 @@ class SpecifiedPeriodType
     /**
      * Gets as endDateTime
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType|null
      */
     public function getEndDateTime()
     {
@@ -55,7 +55,7 @@ class SpecifiedPeriodType
     /**
      * Sets a new endDateTime
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\DateTimeType $endDateTime
+     * @param  \horstoeko\zugferd\entities\basic\udt\DateTimeType|null $endDateTime
      * @return self
      */
     public function setEndDateTime(?\horstoeko\zugferd\entities\basic\udt\DateTimeType $endDateTime = null)

--- a/src/entities/basic/ram/SupplyChainEventType.php
+++ b/src/entities/basic/ram/SupplyChainEventType.php
@@ -11,14 +11,14 @@ class SupplyChainEventType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType $occurrenceDateTime
+     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType|null $occurrenceDateTime
      */
     private $occurrenceDateTime = null;
 
     /**
      * Gets as occurrenceDateTime
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType|null
      */
     public function getOccurrenceDateTime()
     {

--- a/src/entities/basic/ram/SupplyChainTradeLineItemType.php
+++ b/src/entities/basic/ram/SupplyChainTradeLineItemType.php
@@ -11,34 +11,34 @@ class SupplyChainTradeLineItemType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\DocumentLineDocumentType $associatedDocumentLineDocument
+     * @var \horstoeko\zugferd\entities\basic\ram\DocumentLineDocumentType|null $associatedDocumentLineDocument
      */
     private $associatedDocumentLineDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradeProductType $specifiedTradeProduct
+     * @var \horstoeko\zugferd\entities\basic\ram\TradeProductType|null $specifiedTradeProduct
      */
     private $specifiedTradeProduct = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\LineTradeAgreementType $specifiedLineTradeAgreement
+     * @var \horstoeko\zugferd\entities\basic\ram\LineTradeAgreementType|null $specifiedLineTradeAgreement
      */
     private $specifiedLineTradeAgreement = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\LineTradeDeliveryType $specifiedLineTradeDelivery
+     * @var \horstoeko\zugferd\entities\basic\ram\LineTradeDeliveryType|null $specifiedLineTradeDelivery
      */
     private $specifiedLineTradeDelivery = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\LineTradeSettlementType $specifiedLineTradeSettlement
+     * @var \horstoeko\zugferd\entities\basic\ram\LineTradeSettlementType|null $specifiedLineTradeSettlement
      */
     private $specifiedLineTradeSettlement = null;
 
     /**
      * Gets as associatedDocumentLineDocument
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\DocumentLineDocumentType
+     * @return \horstoeko\zugferd\entities\basic\ram\DocumentLineDocumentType|null
      */
     public function getAssociatedDocumentLineDocument()
     {
@@ -60,7 +60,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedTradeProduct
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradeProductType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradeProductType|null
      */
     public function getSpecifiedTradeProduct()
     {
@@ -82,7 +82,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedLineTradeAgreement
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\LineTradeAgreementType
+     * @return \horstoeko\zugferd\entities\basic\ram\LineTradeAgreementType|null
      */
     public function getSpecifiedLineTradeAgreement()
     {
@@ -104,7 +104,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedLineTradeDelivery
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\LineTradeDeliveryType
+     * @return \horstoeko\zugferd\entities\basic\ram\LineTradeDeliveryType|null
      */
     public function getSpecifiedLineTradeDelivery()
     {
@@ -126,7 +126,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedLineTradeSettlement
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\LineTradeSettlementType
+     * @return \horstoeko\zugferd\entities\basic\ram\LineTradeSettlementType|null
      */
     public function getSpecifiedLineTradeSettlement()
     {

--- a/src/entities/basic/ram/SupplyChainTradeTransactionType.php
+++ b/src/entities/basic/ram/SupplyChainTradeTransactionType.php
@@ -18,17 +18,17 @@ class SupplyChainTradeTransactionType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\HeaderTradeAgreementType $applicableHeaderTradeAgreement
+     * @var \horstoeko\zugferd\entities\basic\ram\HeaderTradeAgreementType|null $applicableHeaderTradeAgreement
      */
     private $applicableHeaderTradeAgreement = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\HeaderTradeDeliveryType $applicableHeaderTradeDelivery
+     * @var \horstoeko\zugferd\entities\basic\ram\HeaderTradeDeliveryType|null $applicableHeaderTradeDelivery
      */
     private $applicableHeaderTradeDelivery = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\HeaderTradeSettlementType $applicableHeaderTradeSettlement
+     * @var \horstoeko\zugferd\entities\basic\ram\HeaderTradeSettlementType|null $applicableHeaderTradeSettlement
      */
     private $applicableHeaderTradeSettlement = null;
 
@@ -91,7 +91,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeAgreement
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\HeaderTradeAgreementType
+     * @return \horstoeko\zugferd\entities\basic\ram\HeaderTradeAgreementType|null
      */
     public function getApplicableHeaderTradeAgreement()
     {
@@ -113,7 +113,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeDelivery
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\HeaderTradeDeliveryType
+     * @return \horstoeko\zugferd\entities\basic\ram\HeaderTradeDeliveryType|null
      */
     public function getApplicableHeaderTradeDelivery()
     {
@@ -135,7 +135,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeSettlement
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\HeaderTradeSettlementType
+     * @return \horstoeko\zugferd\entities\basic\ram\HeaderTradeSettlementType|null
      */
     public function getApplicableHeaderTradeSettlement()
     {

--- a/src/entities/basic/ram/TaxRegistrationType.php
+++ b/src/entities/basic/ram/TaxRegistrationType.php
@@ -11,14 +11,14 @@ class TaxRegistrationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/basic/ram/TradeAccountingAccountType.php
+++ b/src/entities/basic/ram/TradeAccountingAccountType.php
@@ -11,14 +11,14 @@ class TradeAccountingAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/basic/ram/TradeAddressType.php
+++ b/src/entities/basic/ram/TradeAddressType.php
@@ -11,44 +11,44 @@ class TradeAddressType
 {
 
     /**
-     * @var string $postcodeCode
+     * @var string|null $postcodeCode
      */
     private $postcodeCode = null;
 
     /**
-     * @var string $lineOne
+     * @var string|null $lineOne
      */
     private $lineOne = null;
 
     /**
-     * @var string $lineTwo
+     * @var string|null $lineTwo
      */
     private $lineTwo = null;
 
     /**
-     * @var string $lineThree
+     * @var string|null $lineThree
      */
     private $lineThree = null;
 
     /**
-     * @var string $cityName
+     * @var string|null $cityName
      */
     private $cityName = null;
 
     /**
-     * @var string $countryID
+     * @var string|null $countryID
      */
     private $countryID = null;
 
     /**
-     * @var string $countrySubDivisionName
+     * @var string|null $countrySubDivisionName
      */
     private $countrySubDivisionName = null;
 
     /**
      * Gets as postcodeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getPostcodeCode()
     {
@@ -70,7 +70,7 @@ class TradeAddressType
     /**
      * Gets as lineOne
      *
-     * @return string
+     * @return string|null
      */
     public function getLineOne()
     {
@@ -92,7 +92,7 @@ class TradeAddressType
     /**
      * Gets as lineTwo
      *
-     * @return string
+     * @return string|null
      */
     public function getLineTwo()
     {
@@ -114,7 +114,7 @@ class TradeAddressType
     /**
      * Gets as lineThree
      *
-     * @return string
+     * @return string|null
      */
     public function getLineThree()
     {
@@ -136,7 +136,7 @@ class TradeAddressType
     /**
      * Gets as cityName
      *
-     * @return string
+     * @return string|null
      */
     public function getCityName()
     {
@@ -158,7 +158,7 @@ class TradeAddressType
     /**
      * Gets as countryID
      *
-     * @return string
+     * @return string|null
      */
     public function getCountryID()
     {
@@ -180,7 +180,7 @@ class TradeAddressType
     /**
      * Gets as countrySubDivisionName
      *
-     * @return string
+     * @return string|null
      */
     public function getCountrySubDivisionName()
     {

--- a/src/entities/basic/ram/TradeAllowanceChargeType.php
+++ b/src/entities/basic/ram/TradeAllowanceChargeType.php
@@ -11,44 +11,44 @@ class TradeAllowanceChargeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IndicatorType $chargeIndicator
+     * @var \horstoeko\zugferd\entities\basic\udt\IndicatorType|null $chargeIndicator
      */
     private $chargeIndicator = null;
 
     /**
-     * @var float $calculationPercent
+     * @var float|null $calculationPercent
      */
     private $calculationPercent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $actualAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $actualAmount
      */
     private $actualAmount = null;
 
     /**
-     * @var string $reasonCode
+     * @var string|null $reasonCode
      */
     private $reasonCode = null;
 
     /**
-     * @var string $reason
+     * @var string|null $reason
      */
     private $reason = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradeTaxType $categoryTradeTax
+     * @var \horstoeko\zugferd\entities\basic\ram\TradeTaxType|null $categoryTradeTax
      */
     private $categoryTradeTax = null;
 
     /**
      * Gets as chargeIndicator
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IndicatorType
+     * @return \horstoeko\zugferd\entities\basic\udt\IndicatorType|null
      */
     public function getChargeIndicator()
     {
@@ -70,7 +70,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as calculationPercent
      *
-     * @return float
+     * @return float|null
      */
     public function getCalculationPercent()
     {
@@ -92,7 +92,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -102,7 +102,7 @@ class TradeAllowanceChargeType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\basic\udt\AmountType $basisAmount = null)
@@ -114,7 +114,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as actualAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getActualAmount()
     {
@@ -136,7 +136,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as reasonCode
      *
-     * @return string
+     * @return string|null
      */
     public function getReasonCode()
     {
@@ -158,7 +158,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as reason
      *
-     * @return string
+     * @return string|null
      */
     public function getReason()
     {
@@ -180,7 +180,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as categoryTradeTax
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradeTaxType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradeTaxType|null
      */
     public function getCategoryTradeTax()
     {
@@ -190,7 +190,7 @@ class TradeAllowanceChargeType
     /**
      * Sets a new categoryTradeTax
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradeTaxType $categoryTradeTax
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradeTaxType|null $categoryTradeTax
      * @return self
      */
     public function setCategoryTradeTax(?\horstoeko\zugferd\entities\basic\ram\TradeTaxType $categoryTradeTax = null)

--- a/src/entities/basic/ram/TradePartyType.php
+++ b/src/entities/basic/ram/TradePartyType.php
@@ -25,22 +25,22 @@ class TradePartyType
     ];
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @var \horstoeko\zugferd\entities\basic\ram\LegalOrganizationType|null $specifiedLegalOrganization
      */
     private $specifiedLegalOrganization = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradeAddressType $postalTradeAddress
+     * @var \horstoeko\zugferd\entities\basic\ram\TradeAddressType|null $postalTradeAddress
      */
     private $postalTradeAddress = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\UniversalCommunicationType $uRIUniversalCommunication
+     * @var \horstoeko\zugferd\entities\basic\ram\UniversalCommunicationType|null $uRIUniversalCommunication
      */
     private $uRIUniversalCommunication = null;
 
@@ -98,7 +98,7 @@ class TradePartyType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\IDType[] $iD
+     * @param  \horstoeko\zugferd\entities\basic\udt\IDType[]|null $iD
      * @return self
      */
     public function setID(?array $iD = null)
@@ -154,7 +154,7 @@ class TradePartyType
     /**
      * Sets a new globalID
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\IDType[] $globalID
+     * @param  \horstoeko\zugferd\entities\basic\udt\IDType[]|null $globalID
      * @return self
      */
     public function setGlobalID(?array $globalID = null)
@@ -166,7 +166,7 @@ class TradePartyType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -188,7 +188,7 @@ class TradePartyType
     /**
      * Gets as specifiedLegalOrganization
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\LegalOrganizationType
+     * @return \horstoeko\zugferd\entities\basic\ram\LegalOrganizationType|null
      */
     public function getSpecifiedLegalOrganization()
     {
@@ -198,7 +198,7 @@ class TradePartyType
     /**
      * Sets a new specifiedLegalOrganization
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @param  \horstoeko\zugferd\entities\basic\ram\LegalOrganizationType|null $specifiedLegalOrganization
      * @return self
      */
     public function setSpecifiedLegalOrganization(?\horstoeko\zugferd\entities\basic\ram\LegalOrganizationType $specifiedLegalOrganization = null)
@@ -210,7 +210,7 @@ class TradePartyType
     /**
      * Gets as postalTradeAddress
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradeAddressType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradeAddressType|null
      */
     public function getPostalTradeAddress()
     {
@@ -220,7 +220,7 @@ class TradePartyType
     /**
      * Sets a new postalTradeAddress
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAddressType $postalTradeAddress
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAddressType|null $postalTradeAddress
      * @return self
      */
     public function setPostalTradeAddress(?\horstoeko\zugferd\entities\basic\ram\TradeAddressType $postalTradeAddress = null)
@@ -232,7 +232,7 @@ class TradePartyType
     /**
      * Gets as uRIUniversalCommunication
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\UniversalCommunicationType
+     * @return \horstoeko\zugferd\entities\basic\ram\UniversalCommunicationType|null
      */
     public function getURIUniversalCommunication()
     {
@@ -242,7 +242,7 @@ class TradePartyType
     /**
      * Sets a new uRIUniversalCommunication
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\UniversalCommunicationType $uRIUniversalCommunication
+     * @param  \horstoeko\zugferd\entities\basic\ram\UniversalCommunicationType|null $uRIUniversalCommunication
      * @return self
      */
     public function setURIUniversalCommunication(?\horstoeko\zugferd\entities\basic\ram\UniversalCommunicationType $uRIUniversalCommunication = null)
@@ -298,7 +298,7 @@ class TradePartyType
     /**
      * Sets a new specifiedTaxRegistration
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TaxRegistrationType[] $specifiedTaxRegistration
+     * @param  \horstoeko\zugferd\entities\basic\ram\TaxRegistrationType[]|null $specifiedTaxRegistration
      * @return self
      */
     public function setSpecifiedTaxRegistration(?array $specifiedTaxRegistration = null)

--- a/src/entities/basic/ram/TradePaymentTermsType.php
+++ b/src/entities/basic/ram/TradePaymentTermsType.php
@@ -11,24 +11,24 @@ class TradePaymentTermsType
 {
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType $dueDateDateTime
+     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType|null $dueDateDateTime
      */
     private $dueDateDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $directDebitMandateID
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $directDebitMandateID
      */
     private $directDebitMandateID = null;
 
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -50,7 +50,7 @@ class TradePaymentTermsType
     /**
      * Gets as dueDateDateTime
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType|null
      */
     public function getDueDateDateTime()
     {
@@ -60,7 +60,7 @@ class TradePaymentTermsType
     /**
      * Sets a new dueDateDateTime
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\DateTimeType $dueDateDateTime
+     * @param  \horstoeko\zugferd\entities\basic\udt\DateTimeType|null $dueDateDateTime
      * @return self
      */
     public function setDueDateDateTime(?\horstoeko\zugferd\entities\basic\udt\DateTimeType $dueDateDateTime = null)
@@ -72,7 +72,7 @@ class TradePaymentTermsType
     /**
      * Gets as directDebitMandateID
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getDirectDebitMandateID()
     {
@@ -82,7 +82,7 @@ class TradePaymentTermsType
     /**
      * Sets a new directDebitMandateID
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\IDType $directDebitMandateID
+     * @param  \horstoeko\zugferd\entities\basic\udt\IDType|null $directDebitMandateID
      * @return self
      */
     public function setDirectDebitMandateID(?\horstoeko\zugferd\entities\basic\udt\IDType $directDebitMandateID = null)

--- a/src/entities/basic/ram/TradePriceType.php
+++ b/src/entities/basic/ram/TradePriceType.php
@@ -11,24 +11,24 @@ class TradePriceType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $chargeAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $chargeAmount
      */
     private $chargeAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\QuantityType $basisQuantity
+     * @var \horstoeko\zugferd\entities\basic\udt\QuantityType|null $basisQuantity
      */
     private $basisQuantity = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType $appliedTradeAllowanceCharge
+     * @var \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType|null $appliedTradeAllowanceCharge
      */
     private $appliedTradeAllowanceCharge = null;
 
     /**
      * Gets as chargeAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getChargeAmount()
     {
@@ -50,7 +50,7 @@ class TradePriceType
     /**
      * Gets as basisQuantity
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\basic\udt\QuantityType|null
      */
     public function getBasisQuantity()
     {
@@ -60,7 +60,7 @@ class TradePriceType
     /**
      * Sets a new basisQuantity
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\QuantityType $basisQuantity
+     * @param  \horstoeko\zugferd\entities\basic\udt\QuantityType|null $basisQuantity
      * @return self
      */
     public function setBasisQuantity(?\horstoeko\zugferd\entities\basic\udt\QuantityType $basisQuantity = null)
@@ -72,7 +72,7 @@ class TradePriceType
     /**
      * Gets as appliedTradeAllowanceCharge
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType
+     * @return \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType|null
      */
     public function getAppliedTradeAllowanceCharge()
     {
@@ -82,7 +82,7 @@ class TradePriceType
     /**
      * Sets a new appliedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType $appliedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType|null $appliedTradeAllowanceCharge
      * @return self
      */
     public function setAppliedTradeAllowanceCharge(?\horstoeko\zugferd\entities\basic\ram\TradeAllowanceChargeType $appliedTradeAllowanceCharge = null)

--- a/src/entities/basic/ram/TradeProductType.php
+++ b/src/entities/basic/ram/TradeProductType.php
@@ -11,19 +11,19 @@ class TradeProductType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $globalID
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $globalID
      */
     private $globalID = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
      * Gets as globalID
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getGlobalID()
     {
@@ -33,7 +33,7 @@ class TradeProductType
     /**
      * Sets a new globalID
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\IDType $globalID
+     * @param  \horstoeko\zugferd\entities\basic\udt\IDType|null $globalID
      * @return self
      */
     public function setGlobalID(?\horstoeko\zugferd\entities\basic\udt\IDType $globalID = null)
@@ -45,7 +45,7 @@ class TradeProductType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {

--- a/src/entities/basic/ram/TradeSettlementHeaderMonetarySummationType.php
+++ b/src/entities/basic/ram/TradeSettlementHeaderMonetarySummationType.php
@@ -11,22 +11,22 @@ class TradeSettlementHeaderMonetarySummationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $lineTotalAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $lineTotalAmount
      */
     private $lineTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $chargeTotalAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $chargeTotalAmount
      */
     private $chargeTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $allowanceTotalAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $allowanceTotalAmount
      */
     private $allowanceTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $taxBasisTotalAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $taxBasisTotalAmount
      */
     private $taxBasisTotalAmount = null;
 
@@ -38,24 +38,24 @@ class TradeSettlementHeaderMonetarySummationType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $grandTotalAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $grandTotalAmount
      */
     private $grandTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $totalPrepaidAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $totalPrepaidAmount
      */
     private $totalPrepaidAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $duePayableAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $duePayableAmount
      */
     private $duePayableAmount = null;
 
     /**
      * Gets as lineTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getLineTotalAmount()
     {
@@ -77,7 +77,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as chargeTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getChargeTotalAmount()
     {
@@ -87,7 +87,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new chargeTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType $chargeTotalAmount
+     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType|null $chargeTotalAmount
      * @return self
      */
     public function setChargeTotalAmount(?\horstoeko\zugferd\entities\basic\udt\AmountType $chargeTotalAmount = null)
@@ -99,7 +99,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as allowanceTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getAllowanceTotalAmount()
     {
@@ -109,7 +109,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new allowanceTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType $allowanceTotalAmount
+     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType|null $allowanceTotalAmount
      * @return self
      */
     public function setAllowanceTotalAmount(?\horstoeko\zugferd\entities\basic\udt\AmountType $allowanceTotalAmount = null)
@@ -121,7 +121,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as taxBasisTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getTaxBasisTotalAmount()
     {
@@ -187,7 +187,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new taxTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType[] $taxTotalAmount
+     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType[]|null $taxTotalAmount
      * @return self
      */
     public function setTaxTotalAmount(?array $taxTotalAmount = null)
@@ -199,7 +199,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as grandTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getGrandTotalAmount()
     {
@@ -221,7 +221,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as totalPrepaidAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getTotalPrepaidAmount()
     {
@@ -231,7 +231,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new totalPrepaidAmount
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType $totalPrepaidAmount
+     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType|null $totalPrepaidAmount
      * @return self
      */
     public function setTotalPrepaidAmount(?\horstoeko\zugferd\entities\basic\udt\AmountType $totalPrepaidAmount = null)
@@ -243,7 +243,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as duePayableAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getDuePayableAmount()
     {

--- a/src/entities/basic/ram/TradeSettlementLineMonetarySummationType.php
+++ b/src/entities/basic/ram/TradeSettlementLineMonetarySummationType.php
@@ -11,14 +11,14 @@ class TradeSettlementLineMonetarySummationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $lineTotalAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $lineTotalAmount
      */
     private $lineTotalAmount = null;
 
     /**
      * Gets as lineTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getLineTotalAmount()
     {

--- a/src/entities/basic/ram/TradeSettlementPaymentMeansType.php
+++ b/src/entities/basic/ram/TradeSettlementPaymentMeansType.php
@@ -11,24 +11,24 @@ class TradeSettlementPaymentMeansType
 {
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount
+     * @var \horstoeko\zugferd\entities\basic\ram\DebtorFinancialAccountType|null $payerPartyDebtorFinancialAccount
      */
     private $payerPartyDebtorFinancialAccount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount
+     * @var \horstoeko\zugferd\entities\basic\ram\CreditorFinancialAccountType|null $payeePartyCreditorFinancialAccount
      */
     private $payeePartyCreditorFinancialAccount = null;
 
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -50,7 +50,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payerPartyDebtorFinancialAccount
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\DebtorFinancialAccountType
+     * @return \horstoeko\zugferd\entities\basic\ram\DebtorFinancialAccountType|null
      */
     public function getPayerPartyDebtorFinancialAccount()
     {
@@ -60,7 +60,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payerPartyDebtorFinancialAccount
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount
+     * @param  \horstoeko\zugferd\entities\basic\ram\DebtorFinancialAccountType|null $payerPartyDebtorFinancialAccount
      * @return self
      */
     public function setPayerPartyDebtorFinancialAccount(?\horstoeko\zugferd\entities\basic\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount = null)
@@ -72,7 +72,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payeePartyCreditorFinancialAccount
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\CreditorFinancialAccountType
+     * @return \horstoeko\zugferd\entities\basic\ram\CreditorFinancialAccountType|null
      */
     public function getPayeePartyCreditorFinancialAccount()
     {
@@ -82,7 +82,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payeePartyCreditorFinancialAccount
      *
-     * @param  \horstoeko\zugferd\entities\basic\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount
+     * @param  \horstoeko\zugferd\entities\basic\ram\CreditorFinancialAccountType|null $payeePartyCreditorFinancialAccount
      * @return self
      */
     public function setPayeePartyCreditorFinancialAccount(?\horstoeko\zugferd\entities\basic\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount = null)

--- a/src/entities/basic/ram/TradeTaxType.php
+++ b/src/entities/basic/ram/TradeTaxType.php
@@ -11,49 +11,49 @@ class TradeTaxType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $calculatedAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $calculatedAmount
      */
     private $calculatedAmount = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var string $exemptionReason
+     * @var string|null $exemptionReason
      */
     private $exemptionReason = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\basic\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var string $categoryCode
+     * @var string|null $categoryCode
      */
     private $categoryCode = null;
 
     /**
-     * @var string $exemptionReasonCode
+     * @var string|null $exemptionReasonCode
      */
     private $exemptionReasonCode = null;
 
     /**
-     * @var string $dueDateTypeCode
+     * @var string|null $dueDateTypeCode
      */
     private $dueDateTypeCode = null;
 
     /**
-     * @var float $rateApplicablePercent
+     * @var float|null $rateApplicablePercent
      */
     private $rateApplicablePercent = null;
 
     /**
      * Gets as calculatedAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getCalculatedAmount()
     {
@@ -63,7 +63,7 @@ class TradeTaxType
     /**
      * Sets a new calculatedAmount
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType $calculatedAmount
+     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType|null $calculatedAmount
      * @return self
      */
     public function setCalculatedAmount(?\horstoeko\zugferd\entities\basic\udt\AmountType $calculatedAmount = null)
@@ -75,7 +75,7 @@ class TradeTaxType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -97,7 +97,7 @@ class TradeTaxType
     /**
      * Gets as exemptionReason
      *
-     * @return string
+     * @return string|null
      */
     public function getExemptionReason()
     {
@@ -119,7 +119,7 @@ class TradeTaxType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basic\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -129,7 +129,7 @@ class TradeTaxType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\basic\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\basic\udt\AmountType $basisAmount = null)
@@ -141,7 +141,7 @@ class TradeTaxType
     /**
      * Gets as categoryCode
      *
-     * @return string
+     * @return string|null
      */
     public function getCategoryCode()
     {
@@ -163,7 +163,7 @@ class TradeTaxType
     /**
      * Gets as exemptionReasonCode
      *
-     * @return string
+     * @return string|null
      */
     public function getExemptionReasonCode()
     {
@@ -185,7 +185,7 @@ class TradeTaxType
     /**
      * Gets as dueDateTypeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getDueDateTypeCode()
     {
@@ -207,7 +207,7 @@ class TradeTaxType
     /**
      * Gets as rateApplicablePercent
      *
-     * @return float
+     * @return float|null
      */
     public function getRateApplicablePercent()
     {

--- a/src/entities/basic/ram/UniversalCommunicationType.php
+++ b/src/entities/basic/ram/UniversalCommunicationType.php
@@ -11,14 +11,14 @@ class UniversalCommunicationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\IDType $uRIID
+     * @var \horstoeko\zugferd\entities\basic\udt\IDType|null $uRIID
      */
     private $uRIID = null;
 
     /**
      * Gets as uRIID
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\IDType
+     * @return \horstoeko\zugferd\entities\basic\udt\IDType|null
      */
     public function getURIID()
     {

--- a/src/entities/basic/rsm/CrossIndustryInvoiceType.php
+++ b/src/entities/basic/rsm/CrossIndustryInvoiceType.php
@@ -11,24 +11,24 @@ class CrossIndustryInvoiceType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\ExchangedDocumentContextType $exchangedDocumentContext
+     * @var \horstoeko\zugferd\entities\basic\ram\ExchangedDocumentContextType|null $exchangedDocumentContext
      */
     private $exchangedDocumentContext = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\ExchangedDocumentType $exchangedDocument
+     * @var \horstoeko\zugferd\entities\basic\ram\ExchangedDocumentType|null $exchangedDocument
      */
     private $exchangedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\ram\SupplyChainTradeTransactionType $supplyChainTradeTransaction
+     * @var \horstoeko\zugferd\entities\basic\ram\SupplyChainTradeTransactionType|null $supplyChainTradeTransaction
      */
     private $supplyChainTradeTransaction = null;
 
     /**
      * Gets as exchangedDocumentContext
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\ExchangedDocumentContextType
+     * @return \horstoeko\zugferd\entities\basic\ram\ExchangedDocumentContextType|null
      */
     public function getExchangedDocumentContext()
     {
@@ -50,7 +50,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as exchangedDocument
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\ExchangedDocumentType
+     * @return \horstoeko\zugferd\entities\basic\ram\ExchangedDocumentType|null
      */
     public function getExchangedDocument()
     {
@@ -72,7 +72,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as supplyChainTradeTransaction
      *
-     * @return \horstoeko\zugferd\entities\basic\ram\SupplyChainTradeTransactionType
+     * @return \horstoeko\zugferd\entities\basic\ram\SupplyChainTradeTransactionType|null
      */
     public function getSupplyChainTradeTransaction()
     {

--- a/src/entities/basic/udt/AmountType.php
+++ b/src/entities/basic/udt/AmountType.php
@@ -11,12 +11,12 @@ class AmountType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $currencyID
+     * @var string|null $currencyID
      */
     private $currencyID = null;
 
@@ -34,7 +34,7 @@ class AmountType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class AmountType
     /**
      * Gets as currencyID
      *
-     * @return string
+     * @return string|null
      */
     public function getCurrencyID()
     {

--- a/src/entities/basic/udt/CodeType.php
+++ b/src/entities/basic/udt/CodeType.php
@@ -11,7 +11,7 @@ class CodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basic/udt/DateTimeType.php
+++ b/src/entities/basic/udt/DateTimeType.php
@@ -11,14 +11,14 @@ class DateTimeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @var \horstoeko\zugferd\entities\basic\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      */
     private $dateTimeString = null;
 
     /**
      * Gets as dateTimeString
      *
-     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType\DateTimeStringAType
+     * @return \horstoeko\zugferd\entities\basic\udt\DateTimeType\DateTimeStringAType|null
      */
     public function getDateTimeString()
     {
@@ -28,7 +28,7 @@ class DateTimeType
     /**
      * Sets a new dateTimeString
      *
-     * @param  \horstoeko\zugferd\entities\basic\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @param  \horstoeko\zugferd\entities\basic\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      * @return self
      */
     public function setDateTimeString(?\horstoeko\zugferd\entities\basic\udt\DateTimeType\DateTimeStringAType $dateTimeString = null)

--- a/src/entities/basic/udt/DateTimeType/DateTimeStringAType.php
+++ b/src/entities/basic/udt/DateTimeType/DateTimeStringAType.php
@@ -9,12 +9,12 @@ class DateTimeStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateTimeStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateTimeStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/basic/udt/IDType.php
+++ b/src/entities/basic/udt/IDType.php
@@ -11,12 +11,12 @@ class IDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $schemeID
+     * @var string|null $schemeID
      */
     private $schemeID = null;
 
@@ -34,7 +34,7 @@ class IDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class IDType
     /**
      * Gets as schemeID
      *
-     * @return string
+     * @return string|null
      */
     public function getSchemeID()
     {

--- a/src/entities/basic/udt/IndicatorType.php
+++ b/src/entities/basic/udt/IndicatorType.php
@@ -11,14 +11,14 @@ class IndicatorType
 {
 
     /**
-     * @var bool $indicator
+     * @var bool|null $indicator
      */
     private $indicator = null;
 
     /**
      * Gets as indicator
      *
-     * @return bool
+     * @return bool|null
      */
     public function getIndicator()
     {

--- a/src/entities/basic/udt/PercentType.php
+++ b/src/entities/basic/udt/PercentType.php
@@ -11,7 +11,7 @@ class PercentType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class PercentType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {

--- a/src/entities/basic/udt/QuantityType.php
+++ b/src/entities/basic/udt/QuantityType.php
@@ -11,12 +11,12 @@ class QuantityType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $unitCode
+     * @var string|null $unitCode
      */
     private $unitCode = null;
 
@@ -34,7 +34,7 @@ class QuantityType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class QuantityType
     /**
      * Gets as unitCode
      *
-     * @return string
+     * @return string|null
      */
     public function getUnitCode()
     {

--- a/src/entities/basic/udt/TextType.php
+++ b/src/entities/basic/udt/TextType.php
@@ -11,7 +11,7 @@ class TextType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TextType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/qdt/AllowanceChargeReasonCodeType.php
+++ b/src/entities/basicwl/qdt/AllowanceChargeReasonCodeType.php
@@ -11,7 +11,7 @@ class AllowanceChargeReasonCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class AllowanceChargeReasonCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/qdt/CountryIDType.php
+++ b/src/entities/basicwl/qdt/CountryIDType.php
@@ -11,7 +11,7 @@ class CountryIDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CountryIDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/qdt/CurrencyCodeType.php
+++ b/src/entities/basicwl/qdt/CurrencyCodeType.php
@@ -11,7 +11,7 @@ class CurrencyCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CurrencyCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/qdt/DocumentCodeType.php
+++ b/src/entities/basicwl/qdt/DocumentCodeType.php
@@ -11,7 +11,7 @@ class DocumentCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class DocumentCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/qdt/FormattedDateTimeType.php
+++ b/src/entities/basicwl/qdt/FormattedDateTimeType.php
@@ -11,14 +11,14 @@ class FormattedDateTimeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType\DateTimeStringAType $dateTimeString
+     * @var \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType\DateTimeStringAType|null $dateTimeString
      */
     private $dateTimeString = null;
 
     /**
      * Gets as dateTimeString
      *
-     * @return \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType\DateTimeStringAType
+     * @return \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType\DateTimeStringAType|null
      */
     public function getDateTimeString()
     {

--- a/src/entities/basicwl/qdt/FormattedDateTimeType/DateTimeStringAType.php
+++ b/src/entities/basicwl/qdt/FormattedDateTimeType/DateTimeStringAType.php
@@ -9,12 +9,12 @@ class DateTimeStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateTimeStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateTimeStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/basicwl/qdt/PaymentMeansCodeType.php
+++ b/src/entities/basicwl/qdt/PaymentMeansCodeType.php
@@ -11,7 +11,7 @@ class PaymentMeansCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class PaymentMeansCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/qdt/TaxCategoryCodeType.php
+++ b/src/entities/basicwl/qdt/TaxCategoryCodeType.php
@@ -11,7 +11,7 @@ class TaxCategoryCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TaxCategoryCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/qdt/TaxTypeCodeType.php
+++ b/src/entities/basicwl/qdt/TaxTypeCodeType.php
@@ -11,7 +11,7 @@ class TaxTypeCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TaxTypeCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/qdt/TimeReferenceCodeType.php
+++ b/src/entities/basicwl/qdt/TimeReferenceCodeType.php
@@ -11,7 +11,7 @@ class TimeReferenceCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TimeReferenceCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/ram/CreditorFinancialAccountType.php
+++ b/src/entities/basicwl/ram/CreditorFinancialAccountType.php
@@ -11,19 +11,19 @@ class CreditorFinancialAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $iBANID
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $iBANID
      */
     private $iBANID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $proprietaryID
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $proprietaryID
      */
     private $proprietaryID = null;
 
     /**
      * Gets as iBANID
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getIBANID()
     {
@@ -33,7 +33,7 @@ class CreditorFinancialAccountType
     /**
      * Sets a new iBANID
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType $iBANID
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType|null $iBANID
      * @return self
      */
     public function setIBANID(?\horstoeko\zugferd\entities\basicwl\udt\IDType $iBANID = null)
@@ -45,7 +45,7 @@ class CreditorFinancialAccountType
     /**
      * Gets as proprietaryID
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getProprietaryID()
     {
@@ -55,7 +55,7 @@ class CreditorFinancialAccountType
     /**
      * Sets a new proprietaryID
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType $proprietaryID
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType|null $proprietaryID
      * @return self
      */
     public function setProprietaryID(?\horstoeko\zugferd\entities\basicwl\udt\IDType $proprietaryID = null)

--- a/src/entities/basicwl/ram/DebtorFinancialAccountType.php
+++ b/src/entities/basicwl/ram/DebtorFinancialAccountType.php
@@ -11,14 +11,14 @@ class DebtorFinancialAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $iBANID
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $iBANID
      */
     private $iBANID = null;
 
     /**
      * Gets as iBANID
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getIBANID()
     {

--- a/src/entities/basicwl/ram/DocumentContextParameterType.php
+++ b/src/entities/basicwl/ram/DocumentContextParameterType.php
@@ -11,14 +11,14 @@ class DocumentContextParameterType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/basicwl/ram/ExchangedDocumentContextType.php
+++ b/src/entities/basicwl/ram/ExchangedDocumentContextType.php
@@ -11,19 +11,19 @@ class ExchangedDocumentContextType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      */
     private $businessProcessSpecifiedDocumentContextParameter = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType $guidelineSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType|null $guidelineSpecifiedDocumentContextParameter
      */
     private $guidelineSpecifiedDocumentContextParameter = null;
 
     /**
      * Gets as businessProcessSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType|null
      */
     public function getBusinessProcessSpecifiedDocumentContextParameter()
     {
@@ -33,7 +33,7 @@ class ExchangedDocumentContextType
     /**
      * Sets a new businessProcessSpecifiedDocumentContextParameter
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      * @return self
      */
     public function setBusinessProcessSpecifiedDocumentContextParameter(?\horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter = null)
@@ -45,7 +45,7 @@ class ExchangedDocumentContextType
     /**
      * Gets as guidelineSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\DocumentContextParameterType|null
      */
     public function getGuidelineSpecifiedDocumentContextParameter()
     {

--- a/src/entities/basicwl/ram/ExchangedDocumentType.php
+++ b/src/entities/basicwl/ram/ExchangedDocumentType.php
@@ -11,17 +11,17 @@ class ExchangedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType $issueDateTime
+     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null $issueDateTime
      */
     private $issueDateTime = null;
 
@@ -35,7 +35,7 @@ class ExchangedDocumentType
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getID()
     {
@@ -57,7 +57,7 @@ class ExchangedDocumentType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -79,7 +79,7 @@ class ExchangedDocumentType
     /**
      * Gets as issueDateTime
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null
      */
     public function getIssueDateTime()
     {
@@ -145,7 +145,7 @@ class ExchangedDocumentType
     /**
      * Sets a new includedNote
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\NoteType[] $includedNote
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\NoteType[]|null $includedNote
      * @return self
      */
     public function setIncludedNote(?array $includedNote = null)

--- a/src/entities/basicwl/ram/HeaderTradeAgreementType.php
+++ b/src/entities/basicwl/ram/HeaderTradeAgreementType.php
@@ -11,39 +11,39 @@ class HeaderTradeAgreementType
 {
 
     /**
-     * @var string $buyerReference
+     * @var string|null $buyerReference
      */
     private $buyerReference = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType $sellerTradeParty
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null $sellerTradeParty
      */
     private $sellerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType $buyerTradeParty
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null $buyerTradeParty
      */
     private $buyerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType $sellerTaxRepresentativeTradeParty
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null $sellerTaxRepresentativeTradeParty
      */
     private $sellerTaxRepresentativeTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      */
     private $buyerOrderReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType $contractReferencedDocument
+     * @var \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType|null $contractReferencedDocument
      */
     private $contractReferencedDocument = null;
 
     /**
      * Gets as buyerReference
      *
-     * @return string
+     * @return string|null
      */
     public function getBuyerReference()
     {
@@ -65,7 +65,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null
      */
     public function getSellerTradeParty()
     {
@@ -87,7 +87,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null
      */
     public function getBuyerTradeParty()
     {
@@ -109,7 +109,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerTaxRepresentativeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null
      */
     public function getSellerTaxRepresentativeTradeParty()
     {
@@ -119,7 +119,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new sellerTaxRepresentativeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradePartyType $sellerTaxRepresentativeTradeParty
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null $sellerTaxRepresentativeTradeParty
      * @return self
      */
     public function setSellerTaxRepresentativeTradeParty(?\horstoeko\zugferd\entities\basicwl\ram\TradePartyType $sellerTaxRepresentativeTradeParty = null)
@@ -131,7 +131,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType|null
      */
     public function getBuyerOrderReferencedDocument()
     {
@@ -141,7 +141,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new buyerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      * @return self
      */
     public function setBuyerOrderReferencedDocument(?\horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType $buyerOrderReferencedDocument = null)
@@ -153,7 +153,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as contractReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType|null
      */
     public function getContractReferencedDocument()
     {
@@ -163,7 +163,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new contractReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType $contractReferencedDocument
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType|null $contractReferencedDocument
      * @return self
      */
     public function setContractReferencedDocument(?\horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType $contractReferencedDocument = null)

--- a/src/entities/basicwl/ram/HeaderTradeDeliveryType.php
+++ b/src/entities/basicwl/ram/HeaderTradeDeliveryType.php
@@ -11,24 +11,24 @@ class HeaderTradeDeliveryType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType $shipToTradeParty
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null $shipToTradeParty
      */
     private $shipToTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @var \horstoeko\zugferd\entities\basicwl\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      */
     private $actualDeliverySupplyChainEvent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @var \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      */
     private $despatchAdviceReferencedDocument = null;
 
     /**
      * Gets as shipToTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null
      */
     public function getShipToTradeParty()
     {
@@ -38,7 +38,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new shipToTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradePartyType $shipToTradeParty
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null $shipToTradeParty
      * @return self
      */
     public function setShipToTradeParty(?\horstoeko\zugferd\entities\basicwl\ram\TradePartyType $shipToTradeParty = null)
@@ -50,7 +50,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as actualDeliverySupplyChainEvent
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\SupplyChainEventType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\SupplyChainEventType|null
      */
     public function getActualDeliverySupplyChainEvent()
     {
@@ -60,7 +60,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new actualDeliverySupplyChainEvent
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      * @return self
      */
     public function setActualDeliverySupplyChainEvent(?\horstoeko\zugferd\entities\basicwl\ram\SupplyChainEventType $actualDeliverySupplyChainEvent = null)
@@ -72,7 +72,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as despatchAdviceReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType|null
      */
     public function getDespatchAdviceReferencedDocument()
     {
@@ -82,7 +82,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new despatchAdviceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      * @return self
      */
     public function setDespatchAdviceReferencedDocument(?\horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType $despatchAdviceReferencedDocument = null)

--- a/src/entities/basicwl/ram/HeaderTradeSettlementType.php
+++ b/src/entities/basicwl/ram/HeaderTradeSettlementType.php
@@ -11,27 +11,27 @@ class HeaderTradeSettlementType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $creditorReferenceID
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $creditorReferenceID
      */
     private $creditorReferenceID = null;
 
     /**
-     * @var string $paymentReference
+     * @var string|null $paymentReference
      */
     private $paymentReference = null;
 
     /**
-     * @var string $taxCurrencyCode
+     * @var string|null $taxCurrencyCode
      */
     private $taxCurrencyCode = null;
 
     /**
-     * @var string $invoiceCurrencyCode
+     * @var string|null $invoiceCurrencyCode
      */
     private $invoiceCurrencyCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType $payeeTradeParty
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null $payeeTradeParty
      */
     private $payeeTradeParty = null;
 
@@ -50,7 +50,7 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @var \horstoeko\zugferd\entities\basicwl\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      */
     private $billingSpecifiedPeriod = null;
 
@@ -62,12 +62,12 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePaymentTermsType $specifiedTradePaymentTerms
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradePaymentTermsType|null $specifiedTradePaymentTerms
      */
     private $specifiedTradePaymentTerms = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradeSettlementHeaderMonetarySummationType $specifiedTradeSettlementHeaderMonetarySummation
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradeSettlementHeaderMonetarySummationType|null $specifiedTradeSettlementHeaderMonetarySummation
      */
     private $specifiedTradeSettlementHeaderMonetarySummation = null;
 
@@ -79,14 +79,14 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradeAccountingAccountType|null $receivableSpecifiedTradeAccountingAccount
      */
     private $receivableSpecifiedTradeAccountingAccount = null;
 
     /**
      * Gets as creditorReferenceID
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getCreditorReferenceID()
     {
@@ -96,7 +96,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new creditorReferenceID
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType $creditorReferenceID
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType|null $creditorReferenceID
      * @return self
      */
     public function setCreditorReferenceID(?\horstoeko\zugferd\entities\basicwl\udt\IDType $creditorReferenceID = null)
@@ -108,7 +108,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as paymentReference
      *
-     * @return string
+     * @return string|null
      */
     public function getPaymentReference()
     {
@@ -130,7 +130,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as taxCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTaxCurrencyCode()
     {
@@ -152,7 +152,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as invoiceCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getInvoiceCurrencyCode()
     {
@@ -174,7 +174,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as payeeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null
      */
     public function getPayeeTradeParty()
     {
@@ -184,7 +184,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new payeeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradePartyType $payeeTradeParty
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradePartyType|null $payeeTradeParty
      * @return self
      */
     public function setPayeeTradeParty(?\horstoeko\zugferd\entities\basicwl\ram\TradePartyType $payeeTradeParty = null)
@@ -240,7 +240,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradeSettlementPaymentMeans
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradeSettlementPaymentMeansType[] $specifiedTradeSettlementPaymentMeans
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradeSettlementPaymentMeansType[]|null $specifiedTradeSettlementPaymentMeans
      * @return self
      */
     public function setSpecifiedTradeSettlementPaymentMeans(?array $specifiedTradeSettlementPaymentMeans = null)
@@ -308,7 +308,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as billingSpecifiedPeriod
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\SpecifiedPeriodType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\SpecifiedPeriodType|null
      */
     public function getBillingSpecifiedPeriod()
     {
@@ -318,7 +318,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new billingSpecifiedPeriod
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      * @return self
      */
     public function setBillingSpecifiedPeriod(?\horstoeko\zugferd\entities\basicwl\ram\SpecifiedPeriodType $billingSpecifiedPeriod = null)
@@ -374,7 +374,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradeAllowanceChargeType[] $specifiedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradeAllowanceChargeType[]|null $specifiedTradeAllowanceCharge
      * @return self
      */
     public function setSpecifiedTradeAllowanceCharge(?array $specifiedTradeAllowanceCharge = null)
@@ -386,7 +386,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as specifiedTradePaymentTerms
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePaymentTermsType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradePaymentTermsType|null
      */
     public function getSpecifiedTradePaymentTerms()
     {
@@ -396,7 +396,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradePaymentTerms
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradePaymentTermsType $specifiedTradePaymentTerms
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradePaymentTermsType|null $specifiedTradePaymentTerms
      * @return self
      */
     public function setSpecifiedTradePaymentTerms(?\horstoeko\zugferd\entities\basicwl\ram\TradePaymentTermsType $specifiedTradePaymentTerms = null)
@@ -408,7 +408,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as specifiedTradeSettlementHeaderMonetarySummation
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradeSettlementHeaderMonetarySummationType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradeSettlementHeaderMonetarySummationType|null
      */
     public function getSpecifiedTradeSettlementHeaderMonetarySummation()
     {
@@ -474,7 +474,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new invoiceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType[] $invoiceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\ReferencedDocumentType[]|null $invoiceReferencedDocument
      * @return self
      */
     public function setInvoiceReferencedDocument(?array $invoiceReferencedDocument = null)
@@ -486,7 +486,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as receivableSpecifiedTradeAccountingAccount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradeAccountingAccountType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradeAccountingAccountType|null
      */
     public function getReceivableSpecifiedTradeAccountingAccount()
     {
@@ -496,7 +496,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new receivableSpecifiedTradeAccountingAccount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradeAccountingAccountType|null $receivableSpecifiedTradeAccountingAccount
      * @return self
      */
     public function setReceivableSpecifiedTradeAccountingAccount(?\horstoeko\zugferd\entities\basicwl\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount = null)

--- a/src/entities/basicwl/ram/LegalOrganizationType.php
+++ b/src/entities/basicwl/ram/LegalOrganizationType.php
@@ -11,19 +11,19 @@ class LegalOrganizationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $tradingBusinessName
+     * @var string|null $tradingBusinessName
      */
     private $tradingBusinessName = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getID()
     {
@@ -33,7 +33,7 @@ class LegalOrganizationType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType $iD
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType|null $iD
      * @return self
      */
     public function setID(?\horstoeko\zugferd\entities\basicwl\udt\IDType $iD = null)
@@ -45,7 +45,7 @@ class LegalOrganizationType
     /**
      * Gets as tradingBusinessName
      *
-     * @return string
+     * @return string|null
      */
     public function getTradingBusinessName()
     {

--- a/src/entities/basicwl/ram/NoteType.php
+++ b/src/entities/basicwl/ram/NoteType.php
@@ -11,19 +11,19 @@ class NoteType
 {
 
     /**
-     * @var string $content
+     * @var string|null $content
      */
     private $content = null;
 
     /**
-     * @var string $subjectCode
+     * @var string|null $subjectCode
      */
     private $subjectCode = null;
 
     /**
      * Gets as content
      *
-     * @return string
+     * @return string|null
      */
     public function getContent()
     {
@@ -45,7 +45,7 @@ class NoteType
     /**
      * Gets as subjectCode
      *
-     * @return string
+     * @return string|null
      */
     public function getSubjectCode()
     {

--- a/src/entities/basicwl/ram/ReferencedDocumentType.php
+++ b/src/entities/basicwl/ram/ReferencedDocumentType.php
@@ -11,19 +11,19 @@ class ReferencedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $issuerAssignedID
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $issuerAssignedID
      */
     private $issuerAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType $formattedIssueDateTime
+     * @var \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType|null $formattedIssueDateTime
      */
     private $formattedIssueDateTime = null;
 
     /**
      * Gets as issuerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getIssuerAssignedID()
     {
@@ -45,7 +45,7 @@ class ReferencedDocumentType
     /**
      * Gets as formattedIssueDateTime
      *
-     * @return \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType
+     * @return \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType|null
      */
     public function getFormattedIssueDateTime()
     {
@@ -55,7 +55,7 @@ class ReferencedDocumentType
     /**
      * Sets a new formattedIssueDateTime
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType $formattedIssueDateTime
+     * @param  \horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType|null $formattedIssueDateTime
      * @return self
      */
     public function setFormattedIssueDateTime(?\horstoeko\zugferd\entities\basicwl\qdt\FormattedDateTimeType $formattedIssueDateTime = null)

--- a/src/entities/basicwl/ram/SpecifiedPeriodType.php
+++ b/src/entities/basicwl/ram/SpecifiedPeriodType.php
@@ -11,19 +11,19 @@ class SpecifiedPeriodType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType $startDateTime
+     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null $startDateTime
      */
     private $startDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType $endDateTime
+     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null $endDateTime
      */
     private $endDateTime = null;
 
     /**
      * Gets as startDateTime
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null
      */
     public function getStartDateTime()
     {
@@ -33,7 +33,7 @@ class SpecifiedPeriodType
     /**
      * Sets a new startDateTime
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\DateTimeType $startDateTime
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null $startDateTime
      * @return self
      */
     public function setStartDateTime(?\horstoeko\zugferd\entities\basicwl\udt\DateTimeType $startDateTime = null)
@@ -45,7 +45,7 @@ class SpecifiedPeriodType
     /**
      * Gets as endDateTime
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null
      */
     public function getEndDateTime()
     {
@@ -55,7 +55,7 @@ class SpecifiedPeriodType
     /**
      * Sets a new endDateTime
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\DateTimeType $endDateTime
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null $endDateTime
      * @return self
      */
     public function setEndDateTime(?\horstoeko\zugferd\entities\basicwl\udt\DateTimeType $endDateTime = null)

--- a/src/entities/basicwl/ram/SupplyChainEventType.php
+++ b/src/entities/basicwl/ram/SupplyChainEventType.php
@@ -11,14 +11,14 @@ class SupplyChainEventType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType $occurrenceDateTime
+     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null $occurrenceDateTime
      */
     private $occurrenceDateTime = null;
 
     /**
      * Gets as occurrenceDateTime
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null
      */
     public function getOccurrenceDateTime()
     {

--- a/src/entities/basicwl/ram/SupplyChainTradeTransactionType.php
+++ b/src/entities/basicwl/ram/SupplyChainTradeTransactionType.php
@@ -11,24 +11,24 @@ class SupplyChainTradeTransactionType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeAgreementType $applicableHeaderTradeAgreement
+     * @var \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeAgreementType|null $applicableHeaderTradeAgreement
      */
     private $applicableHeaderTradeAgreement = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeDeliveryType $applicableHeaderTradeDelivery
+     * @var \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeDeliveryType|null $applicableHeaderTradeDelivery
      */
     private $applicableHeaderTradeDelivery = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeSettlementType $applicableHeaderTradeSettlement
+     * @var \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeSettlementType|null $applicableHeaderTradeSettlement
      */
     private $applicableHeaderTradeSettlement = null;
 
     /**
      * Gets as applicableHeaderTradeAgreement
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeAgreementType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeAgreementType|null
      */
     public function getApplicableHeaderTradeAgreement()
     {
@@ -50,7 +50,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeDelivery
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeDeliveryType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeDeliveryType|null
      */
     public function getApplicableHeaderTradeDelivery()
     {
@@ -72,7 +72,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeSettlement
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeSettlementType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\HeaderTradeSettlementType|null
      */
     public function getApplicableHeaderTradeSettlement()
     {

--- a/src/entities/basicwl/ram/TaxRegistrationType.php
+++ b/src/entities/basicwl/ram/TaxRegistrationType.php
@@ -11,14 +11,14 @@ class TaxRegistrationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/basicwl/ram/TradeAccountingAccountType.php
+++ b/src/entities/basicwl/ram/TradeAccountingAccountType.php
@@ -11,14 +11,14 @@ class TradeAccountingAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/basicwl/ram/TradeAddressType.php
+++ b/src/entities/basicwl/ram/TradeAddressType.php
@@ -11,44 +11,44 @@ class TradeAddressType
 {
 
     /**
-     * @var string $postcodeCode
+     * @var string|null $postcodeCode
      */
     private $postcodeCode = null;
 
     /**
-     * @var string $lineOne
+     * @var string|null $lineOne
      */
     private $lineOne = null;
 
     /**
-     * @var string $lineTwo
+     * @var string|null $lineTwo
      */
     private $lineTwo = null;
 
     /**
-     * @var string $lineThree
+     * @var string|null $lineThree
      */
     private $lineThree = null;
 
     /**
-     * @var string $cityName
+     * @var string|null $cityName
      */
     private $cityName = null;
 
     /**
-     * @var string $countryID
+     * @var string|null $countryID
      */
     private $countryID = null;
 
     /**
-     * @var string $countrySubDivisionName
+     * @var string|null $countrySubDivisionName
      */
     private $countrySubDivisionName = null;
 
     /**
      * Gets as postcodeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getPostcodeCode()
     {
@@ -70,7 +70,7 @@ class TradeAddressType
     /**
      * Gets as lineOne
      *
-     * @return string
+     * @return string|null
      */
     public function getLineOne()
     {
@@ -92,7 +92,7 @@ class TradeAddressType
     /**
      * Gets as lineTwo
      *
-     * @return string
+     * @return string|null
      */
     public function getLineTwo()
     {
@@ -114,7 +114,7 @@ class TradeAddressType
     /**
      * Gets as lineThree
      *
-     * @return string
+     * @return string|null
      */
     public function getLineThree()
     {
@@ -136,7 +136,7 @@ class TradeAddressType
     /**
      * Gets as cityName
      *
-     * @return string
+     * @return string|null
      */
     public function getCityName()
     {
@@ -158,7 +158,7 @@ class TradeAddressType
     /**
      * Gets as countryID
      *
-     * @return string
+     * @return string|null
      */
     public function getCountryID()
     {
@@ -180,7 +180,7 @@ class TradeAddressType
     /**
      * Gets as countrySubDivisionName
      *
-     * @return string
+     * @return string|null
      */
     public function getCountrySubDivisionName()
     {

--- a/src/entities/basicwl/ram/TradeAllowanceChargeType.php
+++ b/src/entities/basicwl/ram/TradeAllowanceChargeType.php
@@ -11,44 +11,44 @@ class TradeAllowanceChargeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IndicatorType $chargeIndicator
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IndicatorType|null $chargeIndicator
      */
     private $chargeIndicator = null;
 
     /**
-     * @var float $calculationPercent
+     * @var float|null $calculationPercent
      */
     private $calculationPercent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $actualAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $actualAmount
      */
     private $actualAmount = null;
 
     /**
-     * @var string $reasonCode
+     * @var string|null $reasonCode
      */
     private $reasonCode = null;
 
     /**
-     * @var string $reason
+     * @var string|null $reason
      */
     private $reason = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradeTaxType $categoryTradeTax
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradeTaxType|null $categoryTradeTax
      */
     private $categoryTradeTax = null;
 
     /**
      * Gets as chargeIndicator
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IndicatorType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IndicatorType|null
      */
     public function getChargeIndicator()
     {
@@ -70,7 +70,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as calculationPercent
      *
-     * @return float
+     * @return float|null
      */
     public function getCalculationPercent()
     {
@@ -92,7 +92,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -102,7 +102,7 @@ class TradeAllowanceChargeType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\basicwl\udt\AmountType $basisAmount = null)
@@ -114,7 +114,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as actualAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getActualAmount()
     {
@@ -136,7 +136,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as reasonCode
      *
-     * @return string
+     * @return string|null
      */
     public function getReasonCode()
     {
@@ -158,7 +158,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as reason
      *
-     * @return string
+     * @return string|null
      */
     public function getReason()
     {
@@ -180,7 +180,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as categoryTradeTax
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradeTaxType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradeTaxType|null
      */
     public function getCategoryTradeTax()
     {

--- a/src/entities/basicwl/ram/TradePartyType.php
+++ b/src/entities/basicwl/ram/TradePartyType.php
@@ -25,22 +25,22 @@ class TradePartyType
     ];
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @var \horstoeko\zugferd\entities\basicwl\ram\LegalOrganizationType|null $specifiedLegalOrganization
      */
     private $specifiedLegalOrganization = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\TradeAddressType $postalTradeAddress
+     * @var \horstoeko\zugferd\entities\basicwl\ram\TradeAddressType|null $postalTradeAddress
      */
     private $postalTradeAddress = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\UniversalCommunicationType $uRIUniversalCommunication
+     * @var \horstoeko\zugferd\entities\basicwl\ram\UniversalCommunicationType|null $uRIUniversalCommunication
      */
     private $uRIUniversalCommunication = null;
 
@@ -98,7 +98,7 @@ class TradePartyType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType[] $iD
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType[]|null $iD
      * @return self
      */
     public function setID(?array $iD = null)
@@ -154,7 +154,7 @@ class TradePartyType
     /**
      * Sets a new globalID
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType[] $globalID
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType[]|null $globalID
      * @return self
      */
     public function setGlobalID(?array $globalID = null)
@@ -166,7 +166,7 @@ class TradePartyType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -188,7 +188,7 @@ class TradePartyType
     /**
      * Gets as specifiedLegalOrganization
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\LegalOrganizationType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\LegalOrganizationType|null
      */
     public function getSpecifiedLegalOrganization()
     {
@@ -198,7 +198,7 @@ class TradePartyType
     /**
      * Sets a new specifiedLegalOrganization
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\LegalOrganizationType|null $specifiedLegalOrganization
      * @return self
      */
     public function setSpecifiedLegalOrganization(?\horstoeko\zugferd\entities\basicwl\ram\LegalOrganizationType $specifiedLegalOrganization = null)
@@ -210,7 +210,7 @@ class TradePartyType
     /**
      * Gets as postalTradeAddress
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\TradeAddressType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\TradeAddressType|null
      */
     public function getPostalTradeAddress()
     {
@@ -220,7 +220,7 @@ class TradePartyType
     /**
      * Sets a new postalTradeAddress
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradeAddressType $postalTradeAddress
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\TradeAddressType|null $postalTradeAddress
      * @return self
      */
     public function setPostalTradeAddress(?\horstoeko\zugferd\entities\basicwl\ram\TradeAddressType $postalTradeAddress = null)
@@ -232,7 +232,7 @@ class TradePartyType
     /**
      * Gets as uRIUniversalCommunication
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\UniversalCommunicationType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\UniversalCommunicationType|null
      */
     public function getURIUniversalCommunication()
     {
@@ -242,7 +242,7 @@ class TradePartyType
     /**
      * Sets a new uRIUniversalCommunication
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\UniversalCommunicationType $uRIUniversalCommunication
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\UniversalCommunicationType|null $uRIUniversalCommunication
      * @return self
      */
     public function setURIUniversalCommunication(?\horstoeko\zugferd\entities\basicwl\ram\UniversalCommunicationType $uRIUniversalCommunication = null)
@@ -298,7 +298,7 @@ class TradePartyType
     /**
      * Sets a new specifiedTaxRegistration
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\TaxRegistrationType[] $specifiedTaxRegistration
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\TaxRegistrationType[]|null $specifiedTaxRegistration
      * @return self
      */
     public function setSpecifiedTaxRegistration(?array $specifiedTaxRegistration = null)

--- a/src/entities/basicwl/ram/TradePaymentTermsType.php
+++ b/src/entities/basicwl/ram/TradePaymentTermsType.php
@@ -11,24 +11,24 @@ class TradePaymentTermsType
 {
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType $dueDateDateTime
+     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null $dueDateDateTime
      */
     private $dueDateDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $directDebitMandateID
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $directDebitMandateID
      */
     private $directDebitMandateID = null;
 
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -50,7 +50,7 @@ class TradePaymentTermsType
     /**
      * Gets as dueDateDateTime
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null
      */
     public function getDueDateDateTime()
     {
@@ -60,7 +60,7 @@ class TradePaymentTermsType
     /**
      * Sets a new dueDateDateTime
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\DateTimeType $dueDateDateTime
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\DateTimeType|null $dueDateDateTime
      * @return self
      */
     public function setDueDateDateTime(?\horstoeko\zugferd\entities\basicwl\udt\DateTimeType $dueDateDateTime = null)
@@ -72,7 +72,7 @@ class TradePaymentTermsType
     /**
      * Gets as directDebitMandateID
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getDirectDebitMandateID()
     {
@@ -82,7 +82,7 @@ class TradePaymentTermsType
     /**
      * Sets a new directDebitMandateID
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType $directDebitMandateID
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\IDType|null $directDebitMandateID
      * @return self
      */
     public function setDirectDebitMandateID(?\horstoeko\zugferd\entities\basicwl\udt\IDType $directDebitMandateID = null)

--- a/src/entities/basicwl/ram/TradeSettlementHeaderMonetarySummationType.php
+++ b/src/entities/basicwl/ram/TradeSettlementHeaderMonetarySummationType.php
@@ -11,22 +11,22 @@ class TradeSettlementHeaderMonetarySummationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $lineTotalAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $lineTotalAmount
      */
     private $lineTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $chargeTotalAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $chargeTotalAmount
      */
     private $chargeTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $allowanceTotalAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $allowanceTotalAmount
      */
     private $allowanceTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $taxBasisTotalAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $taxBasisTotalAmount
      */
     private $taxBasisTotalAmount = null;
 
@@ -38,24 +38,24 @@ class TradeSettlementHeaderMonetarySummationType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $grandTotalAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $grandTotalAmount
      */
     private $grandTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $totalPrepaidAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $totalPrepaidAmount
      */
     private $totalPrepaidAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $duePayableAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $duePayableAmount
      */
     private $duePayableAmount = null;
 
     /**
      * Gets as lineTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getLineTotalAmount()
     {
@@ -77,7 +77,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as chargeTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getChargeTotalAmount()
     {
@@ -87,7 +87,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new chargeTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType $chargeTotalAmount
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $chargeTotalAmount
      * @return self
      */
     public function setChargeTotalAmount(?\horstoeko\zugferd\entities\basicwl\udt\AmountType $chargeTotalAmount = null)
@@ -99,7 +99,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as allowanceTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getAllowanceTotalAmount()
     {
@@ -109,7 +109,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new allowanceTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType $allowanceTotalAmount
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $allowanceTotalAmount
      * @return self
      */
     public function setAllowanceTotalAmount(?\horstoeko\zugferd\entities\basicwl\udt\AmountType $allowanceTotalAmount = null)
@@ -121,7 +121,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as taxBasisTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getTaxBasisTotalAmount()
     {
@@ -187,7 +187,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new taxTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType[] $taxTotalAmount
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType[]|null $taxTotalAmount
      * @return self
      */
     public function setTaxTotalAmount(?array $taxTotalAmount = null)
@@ -199,7 +199,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as grandTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getGrandTotalAmount()
     {
@@ -221,7 +221,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as totalPrepaidAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getTotalPrepaidAmount()
     {
@@ -231,7 +231,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new totalPrepaidAmount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType $totalPrepaidAmount
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $totalPrepaidAmount
      * @return self
      */
     public function setTotalPrepaidAmount(?\horstoeko\zugferd\entities\basicwl\udt\AmountType $totalPrepaidAmount = null)
@@ -243,7 +243,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as duePayableAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getDuePayableAmount()
     {

--- a/src/entities/basicwl/ram/TradeSettlementPaymentMeansType.php
+++ b/src/entities/basicwl/ram/TradeSettlementPaymentMeansType.php
@@ -11,24 +11,24 @@ class TradeSettlementPaymentMeansType
 {
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount
+     * @var \horstoeko\zugferd\entities\basicwl\ram\DebtorFinancialAccountType|null $payerPartyDebtorFinancialAccount
      */
     private $payerPartyDebtorFinancialAccount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount
+     * @var \horstoeko\zugferd\entities\basicwl\ram\CreditorFinancialAccountType|null $payeePartyCreditorFinancialAccount
      */
     private $payeePartyCreditorFinancialAccount = null;
 
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -50,7 +50,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payerPartyDebtorFinancialAccount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\DebtorFinancialAccountType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\DebtorFinancialAccountType|null
      */
     public function getPayerPartyDebtorFinancialAccount()
     {
@@ -60,7 +60,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payerPartyDebtorFinancialAccount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\DebtorFinancialAccountType|null $payerPartyDebtorFinancialAccount
      * @return self
      */
     public function setPayerPartyDebtorFinancialAccount(?\horstoeko\zugferd\entities\basicwl\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount = null)
@@ -72,7 +72,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payeePartyCreditorFinancialAccount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\CreditorFinancialAccountType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\CreditorFinancialAccountType|null
      */
     public function getPayeePartyCreditorFinancialAccount()
     {
@@ -82,7 +82,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payeePartyCreditorFinancialAccount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount
+     * @param  \horstoeko\zugferd\entities\basicwl\ram\CreditorFinancialAccountType|null $payeePartyCreditorFinancialAccount
      * @return self
      */
     public function setPayeePartyCreditorFinancialAccount(?\horstoeko\zugferd\entities\basicwl\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount = null)

--- a/src/entities/basicwl/ram/TradeTaxType.php
+++ b/src/entities/basicwl/ram/TradeTaxType.php
@@ -11,49 +11,49 @@ class TradeTaxType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $calculatedAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $calculatedAmount
      */
     private $calculatedAmount = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var string $exemptionReason
+     * @var string|null $exemptionReason
      */
     private $exemptionReason = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var string $categoryCode
+     * @var string|null $categoryCode
      */
     private $categoryCode = null;
 
     /**
-     * @var string $exemptionReasonCode
+     * @var string|null $exemptionReasonCode
      */
     private $exemptionReasonCode = null;
 
     /**
-     * @var string $dueDateTypeCode
+     * @var string|null $dueDateTypeCode
      */
     private $dueDateTypeCode = null;
 
     /**
-     * @var float $rateApplicablePercent
+     * @var float|null $rateApplicablePercent
      */
     private $rateApplicablePercent = null;
 
     /**
      * Gets as calculatedAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getCalculatedAmount()
     {
@@ -63,7 +63,7 @@ class TradeTaxType
     /**
      * Sets a new calculatedAmount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType $calculatedAmount
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $calculatedAmount
      * @return self
      */
     public function setCalculatedAmount(?\horstoeko\zugferd\entities\basicwl\udt\AmountType $calculatedAmount = null)
@@ -75,7 +75,7 @@ class TradeTaxType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -97,7 +97,7 @@ class TradeTaxType
     /**
      * Gets as exemptionReason
      *
-     * @return string
+     * @return string|null
      */
     public function getExemptionReason()
     {
@@ -119,7 +119,7 @@ class TradeTaxType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -129,7 +129,7 @@ class TradeTaxType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\basicwl\udt\AmountType $basisAmount = null)
@@ -141,7 +141,7 @@ class TradeTaxType
     /**
      * Gets as categoryCode
      *
-     * @return string
+     * @return string|null
      */
     public function getCategoryCode()
     {
@@ -163,7 +163,7 @@ class TradeTaxType
     /**
      * Gets as exemptionReasonCode
      *
-     * @return string
+     * @return string|null
      */
     public function getExemptionReasonCode()
     {
@@ -185,7 +185,7 @@ class TradeTaxType
     /**
      * Gets as dueDateTypeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getDueDateTypeCode()
     {
@@ -207,7 +207,7 @@ class TradeTaxType
     /**
      * Gets as rateApplicablePercent
      *
-     * @return float
+     * @return float|null
      */
     public function getRateApplicablePercent()
     {

--- a/src/entities/basicwl/ram/UniversalCommunicationType.php
+++ b/src/entities/basicwl/ram/UniversalCommunicationType.php
@@ -11,14 +11,14 @@ class UniversalCommunicationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType $uRIID
+     * @var \horstoeko\zugferd\entities\basicwl\udt\IDType|null $uRIID
      */
     private $uRIID = null;
 
     /**
      * Gets as uRIID
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\IDType|null
      */
     public function getURIID()
     {

--- a/src/entities/basicwl/rsm/CrossIndustryInvoiceType.php
+++ b/src/entities/basicwl/rsm/CrossIndustryInvoiceType.php
@@ -11,24 +11,24 @@ class CrossIndustryInvoiceType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\ExchangedDocumentContextType $exchangedDocumentContext
+     * @var \horstoeko\zugferd\entities\basicwl\ram\ExchangedDocumentContextType|null $exchangedDocumentContext
      */
     private $exchangedDocumentContext = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\ExchangedDocumentType $exchangedDocument
+     * @var \horstoeko\zugferd\entities\basicwl\ram\ExchangedDocumentType|null $exchangedDocument
      */
     private $exchangedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\ram\SupplyChainTradeTransactionType $supplyChainTradeTransaction
+     * @var \horstoeko\zugferd\entities\basicwl\ram\SupplyChainTradeTransactionType|null $supplyChainTradeTransaction
      */
     private $supplyChainTradeTransaction = null;
 
     /**
      * Gets as exchangedDocumentContext
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\ExchangedDocumentContextType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\ExchangedDocumentContextType|null
      */
     public function getExchangedDocumentContext()
     {
@@ -50,7 +50,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as exchangedDocument
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\ExchangedDocumentType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\ExchangedDocumentType|null
      */
     public function getExchangedDocument()
     {
@@ -72,7 +72,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as supplyChainTradeTransaction
      *
-     * @return \horstoeko\zugferd\entities\basicwl\ram\SupplyChainTradeTransactionType
+     * @return \horstoeko\zugferd\entities\basicwl\ram\SupplyChainTradeTransactionType|null
      */
     public function getSupplyChainTradeTransaction()
     {

--- a/src/entities/basicwl/udt/AmountType.php
+++ b/src/entities/basicwl/udt/AmountType.php
@@ -11,12 +11,12 @@ class AmountType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $currencyID
+     * @var string|null $currencyID
      */
     private $currencyID = null;
 
@@ -34,7 +34,7 @@ class AmountType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class AmountType
     /**
      * Gets as currencyID
      *
-     * @return string
+     * @return string|null
      */
     public function getCurrencyID()
     {

--- a/src/entities/basicwl/udt/CodeType.php
+++ b/src/entities/basicwl/udt/CodeType.php
@@ -11,7 +11,7 @@ class CodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/basicwl/udt/DateTimeType.php
+++ b/src/entities/basicwl/udt/DateTimeType.php
@@ -11,14 +11,14 @@ class DateTimeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @var \horstoeko\zugferd\entities\basicwl\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      */
     private $dateTimeString = null;
 
     /**
      * Gets as dateTimeString
      *
-     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType\DateTimeStringAType
+     * @return \horstoeko\zugferd\entities\basicwl\udt\DateTimeType\DateTimeStringAType|null
      */
     public function getDateTimeString()
     {
@@ -28,7 +28,7 @@ class DateTimeType
     /**
      * Sets a new dateTimeString
      *
-     * @param  \horstoeko\zugferd\entities\basicwl\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @param  \horstoeko\zugferd\entities\basicwl\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      * @return self
      */
     public function setDateTimeString(?\horstoeko\zugferd\entities\basicwl\udt\DateTimeType\DateTimeStringAType $dateTimeString = null)

--- a/src/entities/basicwl/udt/DateTimeType/DateTimeStringAType.php
+++ b/src/entities/basicwl/udt/DateTimeType/DateTimeStringAType.php
@@ -9,12 +9,12 @@ class DateTimeStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateTimeStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateTimeStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/basicwl/udt/IDType.php
+++ b/src/entities/basicwl/udt/IDType.php
@@ -11,12 +11,12 @@ class IDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $schemeID
+     * @var string|null $schemeID
      */
     private $schemeID = null;
 
@@ -34,7 +34,7 @@ class IDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class IDType
     /**
      * Gets as schemeID
      *
-     * @return string
+     * @return string|null
      */
     public function getSchemeID()
     {

--- a/src/entities/basicwl/udt/IndicatorType.php
+++ b/src/entities/basicwl/udt/IndicatorType.php
@@ -11,14 +11,14 @@ class IndicatorType
 {
 
     /**
-     * @var bool $indicator
+     * @var bool|null $indicator
      */
     private $indicator = null;
 
     /**
      * Gets as indicator
      *
-     * @return bool
+     * @return bool|null
      */
     public function getIndicator()
     {

--- a/src/entities/basicwl/udt/PercentType.php
+++ b/src/entities/basicwl/udt/PercentType.php
@@ -11,7 +11,7 @@ class PercentType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class PercentType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {

--- a/src/entities/basicwl/udt/TextType.php
+++ b/src/entities/basicwl/udt/TextType.php
@@ -11,7 +11,7 @@ class TextType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TextType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/qdt/AllowanceChargeReasonCodeType.php
+++ b/src/entities/en16931/qdt/AllowanceChargeReasonCodeType.php
@@ -11,7 +11,7 @@ class AllowanceChargeReasonCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class AllowanceChargeReasonCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/qdt/CountryIDType.php
+++ b/src/entities/en16931/qdt/CountryIDType.php
@@ -11,7 +11,7 @@ class CountryIDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CountryIDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/qdt/CurrencyCodeType.php
+++ b/src/entities/en16931/qdt/CurrencyCodeType.php
@@ -11,7 +11,7 @@ class CurrencyCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CurrencyCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/qdt/DocumentCodeType.php
+++ b/src/entities/en16931/qdt/DocumentCodeType.php
@@ -11,7 +11,7 @@ class DocumentCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class DocumentCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/qdt/FormattedDateTimeType.php
+++ b/src/entities/en16931/qdt/FormattedDateTimeType.php
@@ -11,14 +11,14 @@ class FormattedDateTimeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType\DateTimeStringAType $dateTimeString
+     * @var \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType\DateTimeStringAType|null $dateTimeString
      */
     private $dateTimeString = null;
 
     /**
      * Gets as dateTimeString
      *
-     * @return \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType\DateTimeStringAType
+     * @return \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType\DateTimeStringAType|null
      */
     public function getDateTimeString()
     {

--- a/src/entities/en16931/qdt/FormattedDateTimeType/DateTimeStringAType.php
+++ b/src/entities/en16931/qdt/FormattedDateTimeType/DateTimeStringAType.php
@@ -9,12 +9,12 @@ class DateTimeStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateTimeStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateTimeStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/en16931/qdt/PaymentMeansCodeType.php
+++ b/src/entities/en16931/qdt/PaymentMeansCodeType.php
@@ -11,7 +11,7 @@ class PaymentMeansCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class PaymentMeansCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/qdt/ReferenceCodeType.php
+++ b/src/entities/en16931/qdt/ReferenceCodeType.php
@@ -11,7 +11,7 @@ class ReferenceCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class ReferenceCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/qdt/TaxCategoryCodeType.php
+++ b/src/entities/en16931/qdt/TaxCategoryCodeType.php
@@ -11,7 +11,7 @@ class TaxCategoryCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TaxCategoryCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/qdt/TaxTypeCodeType.php
+++ b/src/entities/en16931/qdt/TaxTypeCodeType.php
@@ -11,7 +11,7 @@ class TaxTypeCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TaxTypeCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/qdt/TimeReferenceCodeType.php
+++ b/src/entities/en16931/qdt/TimeReferenceCodeType.php
@@ -11,7 +11,7 @@ class TimeReferenceCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TimeReferenceCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/en16931/ram/CreditorFinancialAccountType.php
+++ b/src/entities/en16931/ram/CreditorFinancialAccountType.php
@@ -11,24 +11,24 @@ class CreditorFinancialAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $iBANID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $iBANID
      */
     private $iBANID = null;
 
     /**
-     * @var string $accountName
+     * @var string|null $accountName
      */
     private $accountName = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $proprietaryID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $proprietaryID
      */
     private $proprietaryID = null;
 
     /**
      * Gets as iBANID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getIBANID()
     {
@@ -38,7 +38,7 @@ class CreditorFinancialAccountType
     /**
      * Sets a new iBANID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $iBANID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $iBANID
      * @return self
      */
     public function setIBANID(?\horstoeko\zugferd\entities\en16931\udt\IDType $iBANID = null)
@@ -50,7 +50,7 @@ class CreditorFinancialAccountType
     /**
      * Gets as accountName
      *
-     * @return string
+     * @return string|null
      */
     public function getAccountName()
     {
@@ -72,7 +72,7 @@ class CreditorFinancialAccountType
     /**
      * Gets as proprietaryID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getProprietaryID()
     {
@@ -82,7 +82,7 @@ class CreditorFinancialAccountType
     /**
      * Sets a new proprietaryID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $proprietaryID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $proprietaryID
      * @return self
      */
     public function setProprietaryID(?\horstoeko\zugferd\entities\en16931\udt\IDType $proprietaryID = null)

--- a/src/entities/en16931/ram/CreditorFinancialInstitutionType.php
+++ b/src/entities/en16931/ram/CreditorFinancialInstitutionType.php
@@ -11,14 +11,14 @@ class CreditorFinancialInstitutionType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $bICID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $bICID
      */
     private $bICID = null;
 
     /**
      * Gets as bICID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getBICID()
     {

--- a/src/entities/en16931/ram/DebtorFinancialAccountType.php
+++ b/src/entities/en16931/ram/DebtorFinancialAccountType.php
@@ -11,14 +11,14 @@ class DebtorFinancialAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $iBANID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $iBANID
      */
     private $iBANID = null;
 
     /**
      * Gets as iBANID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getIBANID()
     {

--- a/src/entities/en16931/ram/DocumentContextParameterType.php
+++ b/src/entities/en16931/ram/DocumentContextParameterType.php
@@ -11,14 +11,14 @@ class DocumentContextParameterType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/en16931/ram/DocumentLineDocumentType.php
+++ b/src/entities/en16931/ram/DocumentLineDocumentType.php
@@ -11,19 +11,19 @@ class DocumentLineDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $lineID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $lineID
      */
     private $lineID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\NoteType $includedNote
+     * @var \horstoeko\zugferd\entities\en16931\ram\NoteType|null $includedNote
      */
     private $includedNote = null;
 
     /**
      * Gets as lineID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getLineID()
     {
@@ -45,7 +45,7 @@ class DocumentLineDocumentType
     /**
      * Gets as includedNote
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\NoteType
+     * @return \horstoeko\zugferd\entities\en16931\ram\NoteType|null
      */
     public function getIncludedNote()
     {
@@ -55,7 +55,7 @@ class DocumentLineDocumentType
     /**
      * Sets a new includedNote
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\NoteType $includedNote
+     * @param  \horstoeko\zugferd\entities\en16931\ram\NoteType|null $includedNote
      * @return self
      */
     public function setIncludedNote(?\horstoeko\zugferd\entities\en16931\ram\NoteType $includedNote = null)

--- a/src/entities/en16931/ram/ExchangedDocumentContextType.php
+++ b/src/entities/en16931/ram/ExchangedDocumentContextType.php
@@ -11,19 +11,19 @@ class ExchangedDocumentContextType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      */
     private $businessProcessSpecifiedDocumentContextParameter = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType $guidelineSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType|null $guidelineSpecifiedDocumentContextParameter
      */
     private $guidelineSpecifiedDocumentContextParameter = null;
 
     /**
      * Gets as businessProcessSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType|null
      */
     public function getBusinessProcessSpecifiedDocumentContextParameter()
     {
@@ -33,7 +33,7 @@ class ExchangedDocumentContextType
     /**
      * Sets a new businessProcessSpecifiedDocumentContextParameter
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @param  \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      * @return self
      */
     public function setBusinessProcessSpecifiedDocumentContextParameter(?\horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter = null)
@@ -45,7 +45,7 @@ class ExchangedDocumentContextType
     /**
      * Gets as guidelineSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\en16931\ram\DocumentContextParameterType|null
      */
     public function getGuidelineSpecifiedDocumentContextParameter()
     {

--- a/src/entities/en16931/ram/ExchangedDocumentType.php
+++ b/src/entities/en16931/ram/ExchangedDocumentType.php
@@ -11,17 +11,17 @@ class ExchangedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType $issueDateTime
+     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null $issueDateTime
      */
     private $issueDateTime = null;
 
@@ -35,7 +35,7 @@ class ExchangedDocumentType
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getID()
     {
@@ -57,7 +57,7 @@ class ExchangedDocumentType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -79,7 +79,7 @@ class ExchangedDocumentType
     /**
      * Gets as issueDateTime
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null
      */
     public function getIssueDateTime()
     {
@@ -145,7 +145,7 @@ class ExchangedDocumentType
     /**
      * Sets a new includedNote
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\NoteType[] $includedNote
+     * @param  \horstoeko\zugferd\entities\en16931\ram\NoteType[]|null $includedNote
      * @return self
      */
     public function setIncludedNote(?array $includedNote = null)

--- a/src/entities/en16931/ram/HeaderTradeAgreementType.php
+++ b/src/entities/en16931/ram/HeaderTradeAgreementType.php
@@ -11,37 +11,37 @@ class HeaderTradeAgreementType
 {
 
     /**
-     * @var string $buyerReference
+     * @var string|null $buyerReference
      */
     private $buyerReference = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType $sellerTradeParty
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null $sellerTradeParty
      */
     private $sellerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType $buyerTradeParty
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null $buyerTradeParty
      */
     private $buyerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType $sellerTaxRepresentativeTradeParty
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null $sellerTaxRepresentativeTradeParty
      */
     private $sellerTaxRepresentativeTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $sellerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $sellerOrderReferencedDocument
      */
     private $sellerOrderReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      */
     private $buyerOrderReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $contractReferencedDocument
+     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $contractReferencedDocument
      */
     private $contractReferencedDocument = null;
 
@@ -53,14 +53,14 @@ class HeaderTradeAgreementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ProcuringProjectType $specifiedProcuringProject
+     * @var \horstoeko\zugferd\entities\en16931\ram\ProcuringProjectType|null $specifiedProcuringProject
      */
     private $specifiedProcuringProject = null;
 
     /**
      * Gets as buyerReference
      *
-     * @return string
+     * @return string|null
      */
     public function getBuyerReference()
     {
@@ -82,7 +82,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null
      */
     public function getSellerTradeParty()
     {
@@ -104,7 +104,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null
      */
     public function getBuyerTradeParty()
     {
@@ -126,7 +126,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerTaxRepresentativeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null
      */
     public function getSellerTaxRepresentativeTradeParty()
     {
@@ -136,7 +136,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new sellerTaxRepresentativeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePartyType $sellerTaxRepresentativeTradeParty
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null $sellerTaxRepresentativeTradeParty
      * @return self
      */
     public function setSellerTaxRepresentativeTradeParty(?\horstoeko\zugferd\entities\en16931\ram\TradePartyType $sellerTaxRepresentativeTradeParty = null)
@@ -148,7 +148,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null
      */
     public function getSellerOrderReferencedDocument()
     {
@@ -158,7 +158,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new sellerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $sellerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $sellerOrderReferencedDocument
      * @return self
      */
     public function setSellerOrderReferencedDocument(?\horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $sellerOrderReferencedDocument = null)
@@ -170,7 +170,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null
      */
     public function getBuyerOrderReferencedDocument()
     {
@@ -180,7 +180,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new buyerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      * @return self
      */
     public function setBuyerOrderReferencedDocument(?\horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $buyerOrderReferencedDocument = null)
@@ -192,7 +192,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as contractReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null
      */
     public function getContractReferencedDocument()
     {
@@ -202,7 +202,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new contractReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $contractReferencedDocument
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $contractReferencedDocument
      * @return self
      */
     public function setContractReferencedDocument(?\horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $contractReferencedDocument = null)
@@ -258,7 +258,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new additionalReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType[] $additionalReferencedDocument
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType[]|null $additionalReferencedDocument
      * @return self
      */
     public function setAdditionalReferencedDocument(?array $additionalReferencedDocument = null)
@@ -270,7 +270,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as specifiedProcuringProject
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ProcuringProjectType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ProcuringProjectType|null
      */
     public function getSpecifiedProcuringProject()
     {
@@ -280,7 +280,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new specifiedProcuringProject
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ProcuringProjectType $specifiedProcuringProject
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ProcuringProjectType|null $specifiedProcuringProject
      * @return self
      */
     public function setSpecifiedProcuringProject(?\horstoeko\zugferd\entities\en16931\ram\ProcuringProjectType $specifiedProcuringProject = null)

--- a/src/entities/en16931/ram/HeaderTradeDeliveryType.php
+++ b/src/entities/en16931/ram/HeaderTradeDeliveryType.php
@@ -11,29 +11,29 @@ class HeaderTradeDeliveryType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType $shipToTradeParty
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null $shipToTradeParty
      */
     private $shipToTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @var \horstoeko\zugferd\entities\en16931\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      */
     private $actualDeliverySupplyChainEvent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      */
     private $despatchAdviceReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $receivingAdviceReferencedDocument
+     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $receivingAdviceReferencedDocument
      */
     private $receivingAdviceReferencedDocument = null;
 
     /**
      * Gets as shipToTradeParty
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null
      */
     public function getShipToTradeParty()
     {
@@ -43,7 +43,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new shipToTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePartyType $shipToTradeParty
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null $shipToTradeParty
      * @return self
      */
     public function setShipToTradeParty(?\horstoeko\zugferd\entities\en16931\ram\TradePartyType $shipToTradeParty = null)
@@ -55,7 +55,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as actualDeliverySupplyChainEvent
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\SupplyChainEventType
+     * @return \horstoeko\zugferd\entities\en16931\ram\SupplyChainEventType|null
      */
     public function getActualDeliverySupplyChainEvent()
     {
@@ -65,7 +65,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new actualDeliverySupplyChainEvent
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @param  \horstoeko\zugferd\entities\en16931\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      * @return self
      */
     public function setActualDeliverySupplyChainEvent(?\horstoeko\zugferd\entities\en16931\ram\SupplyChainEventType $actualDeliverySupplyChainEvent = null)
@@ -77,7 +77,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as despatchAdviceReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null
      */
     public function getDespatchAdviceReferencedDocument()
     {
@@ -87,7 +87,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new despatchAdviceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      * @return self
      */
     public function setDespatchAdviceReferencedDocument(?\horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $despatchAdviceReferencedDocument = null)
@@ -99,7 +99,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as receivingAdviceReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null
      */
     public function getReceivingAdviceReferencedDocument()
     {
@@ -109,7 +109,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new receivingAdviceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $receivingAdviceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $receivingAdviceReferencedDocument
      * @return self
      */
     public function setReceivingAdviceReferencedDocument(?\horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $receivingAdviceReferencedDocument = null)

--- a/src/entities/en16931/ram/HeaderTradeSettlementType.php
+++ b/src/entities/en16931/ram/HeaderTradeSettlementType.php
@@ -11,27 +11,27 @@ class HeaderTradeSettlementType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $creditorReferenceID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $creditorReferenceID
      */
     private $creditorReferenceID = null;
 
     /**
-     * @var string $paymentReference
+     * @var string|null $paymentReference
      */
     private $paymentReference = null;
 
     /**
-     * @var string $taxCurrencyCode
+     * @var string|null $taxCurrencyCode
      */
     private $taxCurrencyCode = null;
 
     /**
-     * @var string $invoiceCurrencyCode
+     * @var string|null $invoiceCurrencyCode
      */
     private $invoiceCurrencyCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType $payeeTradeParty
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null $payeeTradeParty
      */
     private $payeeTradeParty = null;
 
@@ -50,7 +50,7 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @var \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      */
     private $billingSpecifiedPeriod = null;
 
@@ -62,12 +62,12 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradePaymentTermsType $specifiedTradePaymentTerms
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradePaymentTermsType|null $specifiedTradePaymentTerms
      */
     private $specifiedTradePaymentTerms = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeSettlementHeaderMonetarySummationType $specifiedTradeSettlementHeaderMonetarySummation
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeSettlementHeaderMonetarySummationType|null $specifiedTradeSettlementHeaderMonetarySummation
      */
     private $specifiedTradeSettlementHeaderMonetarySummation = null;
 
@@ -79,14 +79,14 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType|null $receivableSpecifiedTradeAccountingAccount
      */
     private $receivableSpecifiedTradeAccountingAccount = null;
 
     /**
      * Gets as creditorReferenceID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getCreditorReferenceID()
     {
@@ -96,7 +96,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new creditorReferenceID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $creditorReferenceID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $creditorReferenceID
      * @return self
      */
     public function setCreditorReferenceID(?\horstoeko\zugferd\entities\en16931\udt\IDType $creditorReferenceID = null)
@@ -108,7 +108,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as paymentReference
      *
-     * @return string
+     * @return string|null
      */
     public function getPaymentReference()
     {
@@ -130,7 +130,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as taxCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTaxCurrencyCode()
     {
@@ -152,7 +152,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as invoiceCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getInvoiceCurrencyCode()
     {
@@ -174,7 +174,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as payeeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null
      */
     public function getPayeeTradeParty()
     {
@@ -184,7 +184,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new payeeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePartyType $payeeTradeParty
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePartyType|null $payeeTradeParty
      * @return self
      */
     public function setPayeeTradeParty(?\horstoeko\zugferd\entities\en16931\ram\TradePartyType $payeeTradeParty = null)
@@ -240,7 +240,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradeSettlementPaymentMeans
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeSettlementPaymentMeansType[] $specifiedTradeSettlementPaymentMeans
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeSettlementPaymentMeansType[]|null $specifiedTradeSettlementPaymentMeans
      * @return self
      */
     public function setSpecifiedTradeSettlementPaymentMeans(?array $specifiedTradeSettlementPaymentMeans = null)
@@ -308,7 +308,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as billingSpecifiedPeriod
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType
+     * @return \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType|null
      */
     public function getBillingSpecifiedPeriod()
     {
@@ -318,7 +318,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new billingSpecifiedPeriod
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @param  \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      * @return self
      */
     public function setBillingSpecifiedPeriod(?\horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType $billingSpecifiedPeriod = null)
@@ -374,7 +374,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType[] $specifiedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType[]|null $specifiedTradeAllowanceCharge
      * @return self
      */
     public function setSpecifiedTradeAllowanceCharge(?array $specifiedTradeAllowanceCharge = null)
@@ -386,7 +386,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as specifiedTradePaymentTerms
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradePaymentTermsType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradePaymentTermsType|null
      */
     public function getSpecifiedTradePaymentTerms()
     {
@@ -396,7 +396,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradePaymentTerms
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePaymentTermsType $specifiedTradePaymentTerms
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePaymentTermsType|null $specifiedTradePaymentTerms
      * @return self
      */
     public function setSpecifiedTradePaymentTerms(?\horstoeko\zugferd\entities\en16931\ram\TradePaymentTermsType $specifiedTradePaymentTerms = null)
@@ -408,7 +408,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as specifiedTradeSettlementHeaderMonetarySummation
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeSettlementHeaderMonetarySummationType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeSettlementHeaderMonetarySummationType|null
      */
     public function getSpecifiedTradeSettlementHeaderMonetarySummation()
     {
@@ -474,7 +474,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new invoiceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType[] $invoiceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType[]|null $invoiceReferencedDocument
      * @return self
      */
     public function setInvoiceReferencedDocument(?array $invoiceReferencedDocument = null)
@@ -486,7 +486,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as receivableSpecifiedTradeAccountingAccount
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType|null
      */
     public function getReceivableSpecifiedTradeAccountingAccount()
     {
@@ -496,7 +496,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new receivableSpecifiedTradeAccountingAccount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType|null $receivableSpecifiedTradeAccountingAccount
      * @return self
      */
     public function setReceivableSpecifiedTradeAccountingAccount(?\horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount = null)

--- a/src/entities/en16931/ram/LegalOrganizationType.php
+++ b/src/entities/en16931/ram/LegalOrganizationType.php
@@ -11,19 +11,19 @@ class LegalOrganizationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $tradingBusinessName
+     * @var string|null $tradingBusinessName
      */
     private $tradingBusinessName = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getID()
     {
@@ -33,7 +33,7 @@ class LegalOrganizationType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $iD
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $iD
      * @return self
      */
     public function setID(?\horstoeko\zugferd\entities\en16931\udt\IDType $iD = null)
@@ -45,7 +45,7 @@ class LegalOrganizationType
     /**
      * Gets as tradingBusinessName
      *
-     * @return string
+     * @return string|null
      */
     public function getTradingBusinessName()
     {

--- a/src/entities/en16931/ram/LineTradeAgreementType.php
+++ b/src/entities/en16931/ram/LineTradeAgreementType.php
@@ -11,24 +11,24 @@ class LineTradeAgreementType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      */
     private $buyerOrderReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradePriceType $grossPriceProductTradePrice
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradePriceType|null $grossPriceProductTradePrice
      */
     private $grossPriceProductTradePrice = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradePriceType $netPriceProductTradePrice
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradePriceType|null $netPriceProductTradePrice
      */
     private $netPriceProductTradePrice = null;
 
     /**
      * Gets as buyerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null
      */
     public function getBuyerOrderReferencedDocument()
     {
@@ -38,7 +38,7 @@ class LineTradeAgreementType
     /**
      * Sets a new buyerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      * @return self
      */
     public function setBuyerOrderReferencedDocument(?\horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $buyerOrderReferencedDocument = null)
@@ -50,7 +50,7 @@ class LineTradeAgreementType
     /**
      * Gets as grossPriceProductTradePrice
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradePriceType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradePriceType|null
      */
     public function getGrossPriceProductTradePrice()
     {
@@ -60,7 +60,7 @@ class LineTradeAgreementType
     /**
      * Sets a new grossPriceProductTradePrice
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePriceType $grossPriceProductTradePrice
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradePriceType|null $grossPriceProductTradePrice
      * @return self
      */
     public function setGrossPriceProductTradePrice(?\horstoeko\zugferd\entities\en16931\ram\TradePriceType $grossPriceProductTradePrice = null)
@@ -72,7 +72,7 @@ class LineTradeAgreementType
     /**
      * Gets as netPriceProductTradePrice
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradePriceType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradePriceType|null
      */
     public function getNetPriceProductTradePrice()
     {

--- a/src/entities/en16931/ram/LineTradeDeliveryType.php
+++ b/src/entities/en16931/ram/LineTradeDeliveryType.php
@@ -11,14 +11,14 @@ class LineTradeDeliveryType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\QuantityType $billedQuantity
+     * @var \horstoeko\zugferd\entities\en16931\udt\QuantityType|null $billedQuantity
      */
     private $billedQuantity = null;
 
     /**
      * Gets as billedQuantity
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\en16931\udt\QuantityType|null
      */
     public function getBilledQuantity()
     {

--- a/src/entities/en16931/ram/LineTradeSettlementType.php
+++ b/src/entities/en16931/ram/LineTradeSettlementType.php
@@ -11,12 +11,12 @@ class LineTradeSettlementType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeTaxType $applicableTradeTax
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeTaxType|null $applicableTradeTax
      */
     private $applicableTradeTax = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @var \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      */
     private $billingSpecifiedPeriod = null;
 
@@ -28,24 +28,24 @@ class LineTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeSettlementLineMonetarySummationType $specifiedTradeSettlementLineMonetarySummation
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeSettlementLineMonetarySummationType|null $specifiedTradeSettlementLineMonetarySummation
      */
     private $specifiedTradeSettlementLineMonetarySummation = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $additionalReferencedDocument
+     * @var \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $additionalReferencedDocument
      */
     private $additionalReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType|null $receivableSpecifiedTradeAccountingAccount
      */
     private $receivableSpecifiedTradeAccountingAccount = null;
 
     /**
      * Gets as applicableTradeTax
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeTaxType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeTaxType|null
      */
     public function getApplicableTradeTax()
     {
@@ -67,7 +67,7 @@ class LineTradeSettlementType
     /**
      * Gets as billingSpecifiedPeriod
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType
+     * @return \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType|null
      */
     public function getBillingSpecifiedPeriod()
     {
@@ -77,7 +77,7 @@ class LineTradeSettlementType
     /**
      * Sets a new billingSpecifiedPeriod
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @param  \horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      * @return self
      */
     public function setBillingSpecifiedPeriod(?\horstoeko\zugferd\entities\en16931\ram\SpecifiedPeriodType $billingSpecifiedPeriod = null)
@@ -133,7 +133,7 @@ class LineTradeSettlementType
     /**
      * Sets a new specifiedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType[] $specifiedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType[]|null $specifiedTradeAllowanceCharge
      * @return self
      */
     public function setSpecifiedTradeAllowanceCharge(?array $specifiedTradeAllowanceCharge = null)
@@ -145,7 +145,7 @@ class LineTradeSettlementType
     /**
      * Gets as specifiedTradeSettlementLineMonetarySummation
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeSettlementLineMonetarySummationType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeSettlementLineMonetarySummationType|null
      */
     public function getSpecifiedTradeSettlementLineMonetarySummation()
     {
@@ -167,7 +167,7 @@ class LineTradeSettlementType
     /**
      * Gets as additionalReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null
      */
     public function getAdditionalReferencedDocument()
     {
@@ -177,7 +177,7 @@ class LineTradeSettlementType
     /**
      * Sets a new additionalReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $additionalReferencedDocument
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType|null $additionalReferencedDocument
      * @return self
      */
     public function setAdditionalReferencedDocument(?\horstoeko\zugferd\entities\en16931\ram\ReferencedDocumentType $additionalReferencedDocument = null)
@@ -189,7 +189,7 @@ class LineTradeSettlementType
     /**
      * Gets as receivableSpecifiedTradeAccountingAccount
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType|null
      */
     public function getReceivableSpecifiedTradeAccountingAccount()
     {
@@ -199,7 +199,7 @@ class LineTradeSettlementType
     /**
      * Sets a new receivableSpecifiedTradeAccountingAccount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType|null $receivableSpecifiedTradeAccountingAccount
      * @return self
      */
     public function setReceivableSpecifiedTradeAccountingAccount(?\horstoeko\zugferd\entities\en16931\ram\TradeAccountingAccountType $receivableSpecifiedTradeAccountingAccount = null)

--- a/src/entities/en16931/ram/NoteType.php
+++ b/src/entities/en16931/ram/NoteType.php
@@ -11,19 +11,19 @@ class NoteType
 {
 
     /**
-     * @var string $content
+     * @var string|null $content
      */
     private $content = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\CodeType $subjectCode
+     * @var \horstoeko\zugferd\entities\en16931\udt\CodeType|null $subjectCode
      */
     private $subjectCode = null;
 
     /**
      * Gets as content
      *
-     * @return string
+     * @return string|null
      */
     public function getContent()
     {
@@ -45,7 +45,7 @@ class NoteType
     /**
      * Gets as subjectCode
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\CodeType
+     * @return \horstoeko\zugferd\entities\en16931\udt\CodeType|null
      */
     public function getSubjectCode()
     {
@@ -55,7 +55,7 @@ class NoteType
     /**
      * Sets a new subjectCode
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\CodeType $subjectCode
+     * @param  \horstoeko\zugferd\entities\en16931\udt\CodeType|null $subjectCode
      * @return self
      */
     public function setSubjectCode(?\horstoeko\zugferd\entities\en16931\udt\CodeType $subjectCode = null)

--- a/src/entities/en16931/ram/ProcuringProjectType.php
+++ b/src/entities/en16931/ram/ProcuringProjectType.php
@@ -11,19 +11,19 @@ class ProcuringProjectType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getID()
     {
@@ -45,7 +45,7 @@ class ProcuringProjectType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {

--- a/src/entities/en16931/ram/ProductCharacteristicType.php
+++ b/src/entities/en16931/ram/ProductCharacteristicType.php
@@ -11,19 +11,19 @@ class ProductCharacteristicType
 {
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var string $value
+     * @var string|null $value
      */
     private $value = null;
 
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -45,7 +45,7 @@ class ProductCharacteristicType
     /**
      * Gets as value
      *
-     * @return string
+     * @return string|null
      */
     public function getValue()
     {

--- a/src/entities/en16931/ram/ProductClassificationType.php
+++ b/src/entities/en16931/ram/ProductClassificationType.php
@@ -11,14 +11,14 @@ class ProductClassificationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\CodeType $classCode
+     * @var \horstoeko\zugferd\entities\en16931\udt\CodeType|null $classCode
      */
     private $classCode = null;
 
     /**
      * Gets as classCode
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\CodeType
+     * @return \horstoeko\zugferd\entities\en16931\udt\CodeType|null
      */
     public function getClassCode()
     {
@@ -28,7 +28,7 @@ class ProductClassificationType
     /**
      * Sets a new classCode
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\CodeType $classCode
+     * @param  \horstoeko\zugferd\entities\en16931\udt\CodeType|null $classCode
      * @return self
      */
     public function setClassCode(?\horstoeko\zugferd\entities\en16931\udt\CodeType $classCode = null)

--- a/src/entities/en16931/ram/ReferencedDocumentType.php
+++ b/src/entities/en16931/ram/ReferencedDocumentType.php
@@ -11,49 +11,49 @@ class ReferencedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $issuerAssignedID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $issuerAssignedID
      */
     private $issuerAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $uRIID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $uRIID
      */
     private $uRIID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $lineID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $lineID
      */
     private $lineID = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\BinaryObjectType $attachmentBinaryObject
+     * @var \horstoeko\zugferd\entities\en16931\udt\BinaryObjectType|null $attachmentBinaryObject
      */
     private $attachmentBinaryObject = null;
 
     /**
-     * @var string $referenceTypeCode
+     * @var string|null $referenceTypeCode
      */
     private $referenceTypeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType $formattedIssueDateTime
+     * @var \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType|null $formattedIssueDateTime
      */
     private $formattedIssueDateTime = null;
 
     /**
      * Gets as issuerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getIssuerAssignedID()
     {
@@ -63,7 +63,7 @@ class ReferencedDocumentType
     /**
      * Sets a new issuerAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $issuerAssignedID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $issuerAssignedID
      * @return self
      */
     public function setIssuerAssignedID(?\horstoeko\zugferd\entities\en16931\udt\IDType $issuerAssignedID = null)
@@ -75,7 +75,7 @@ class ReferencedDocumentType
     /**
      * Gets as uRIID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getURIID()
     {
@@ -85,7 +85,7 @@ class ReferencedDocumentType
     /**
      * Sets a new uRIID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $uRIID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $uRIID
      * @return self
      */
     public function setURIID(?\horstoeko\zugferd\entities\en16931\udt\IDType $uRIID = null)
@@ -97,7 +97,7 @@ class ReferencedDocumentType
     /**
      * Gets as lineID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getLineID()
     {
@@ -107,7 +107,7 @@ class ReferencedDocumentType
     /**
      * Sets a new lineID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $lineID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $lineID
      * @return self
      */
     public function setLineID(?\horstoeko\zugferd\entities\en16931\udt\IDType $lineID = null)
@@ -119,7 +119,7 @@ class ReferencedDocumentType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -141,7 +141,7 @@ class ReferencedDocumentType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -163,7 +163,7 @@ class ReferencedDocumentType
     /**
      * Gets as attachmentBinaryObject
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\BinaryObjectType
+     * @return \horstoeko\zugferd\entities\en16931\udt\BinaryObjectType|null
      */
     public function getAttachmentBinaryObject()
     {
@@ -173,7 +173,7 @@ class ReferencedDocumentType
     /**
      * Sets a new attachmentBinaryObject
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\BinaryObjectType $attachmentBinaryObject
+     * @param  \horstoeko\zugferd\entities\en16931\udt\BinaryObjectType|null $attachmentBinaryObject
      * @return self
      */
     public function setAttachmentBinaryObject(?\horstoeko\zugferd\entities\en16931\udt\BinaryObjectType $attachmentBinaryObject = null)
@@ -185,7 +185,7 @@ class ReferencedDocumentType
     /**
      * Gets as referenceTypeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getReferenceTypeCode()
     {
@@ -207,7 +207,7 @@ class ReferencedDocumentType
     /**
      * Gets as formattedIssueDateTime
      *
-     * @return \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType
+     * @return \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType|null
      */
     public function getFormattedIssueDateTime()
     {
@@ -217,7 +217,7 @@ class ReferencedDocumentType
     /**
      * Sets a new formattedIssueDateTime
      *
-     * @param  \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType $formattedIssueDateTime
+     * @param  \horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType|null $formattedIssueDateTime
      * @return self
      */
     public function setFormattedIssueDateTime(?\horstoeko\zugferd\entities\en16931\qdt\FormattedDateTimeType $formattedIssueDateTime = null)

--- a/src/entities/en16931/ram/SpecifiedPeriodType.php
+++ b/src/entities/en16931/ram/SpecifiedPeriodType.php
@@ -11,19 +11,19 @@ class SpecifiedPeriodType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType $startDateTime
+     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null $startDateTime
      */
     private $startDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType $endDateTime
+     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null $endDateTime
      */
     private $endDateTime = null;
 
     /**
      * Gets as startDateTime
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null
      */
     public function getStartDateTime()
     {
@@ -33,7 +33,7 @@ class SpecifiedPeriodType
     /**
      * Sets a new startDateTime
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\DateTimeType $startDateTime
+     * @param  \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null $startDateTime
      * @return self
      */
     public function setStartDateTime(?\horstoeko\zugferd\entities\en16931\udt\DateTimeType $startDateTime = null)
@@ -45,7 +45,7 @@ class SpecifiedPeriodType
     /**
      * Gets as endDateTime
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null
      */
     public function getEndDateTime()
     {
@@ -55,7 +55,7 @@ class SpecifiedPeriodType
     /**
      * Sets a new endDateTime
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\DateTimeType $endDateTime
+     * @param  \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null $endDateTime
      * @return self
      */
     public function setEndDateTime(?\horstoeko\zugferd\entities\en16931\udt\DateTimeType $endDateTime = null)

--- a/src/entities/en16931/ram/SupplyChainEventType.php
+++ b/src/entities/en16931/ram/SupplyChainEventType.php
@@ -11,14 +11,14 @@ class SupplyChainEventType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType $occurrenceDateTime
+     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null $occurrenceDateTime
      */
     private $occurrenceDateTime = null;
 
     /**
      * Gets as occurrenceDateTime
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null
      */
     public function getOccurrenceDateTime()
     {

--- a/src/entities/en16931/ram/SupplyChainTradeLineItemType.php
+++ b/src/entities/en16931/ram/SupplyChainTradeLineItemType.php
@@ -11,34 +11,34 @@ class SupplyChainTradeLineItemType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\DocumentLineDocumentType $associatedDocumentLineDocument
+     * @var \horstoeko\zugferd\entities\en16931\ram\DocumentLineDocumentType|null $associatedDocumentLineDocument
      */
     private $associatedDocumentLineDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeProductType $specifiedTradeProduct
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeProductType|null $specifiedTradeProduct
      */
     private $specifiedTradeProduct = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\LineTradeAgreementType $specifiedLineTradeAgreement
+     * @var \horstoeko\zugferd\entities\en16931\ram\LineTradeAgreementType|null $specifiedLineTradeAgreement
      */
     private $specifiedLineTradeAgreement = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\LineTradeDeliveryType $specifiedLineTradeDelivery
+     * @var \horstoeko\zugferd\entities\en16931\ram\LineTradeDeliveryType|null $specifiedLineTradeDelivery
      */
     private $specifiedLineTradeDelivery = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\LineTradeSettlementType $specifiedLineTradeSettlement
+     * @var \horstoeko\zugferd\entities\en16931\ram\LineTradeSettlementType|null $specifiedLineTradeSettlement
      */
     private $specifiedLineTradeSettlement = null;
 
     /**
      * Gets as associatedDocumentLineDocument
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\DocumentLineDocumentType
+     * @return \horstoeko\zugferd\entities\en16931\ram\DocumentLineDocumentType|null
      */
     public function getAssociatedDocumentLineDocument()
     {
@@ -60,7 +60,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedTradeProduct
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeProductType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeProductType|null
      */
     public function getSpecifiedTradeProduct()
     {
@@ -82,7 +82,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedLineTradeAgreement
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\LineTradeAgreementType
+     * @return \horstoeko\zugferd\entities\en16931\ram\LineTradeAgreementType|null
      */
     public function getSpecifiedLineTradeAgreement()
     {
@@ -104,7 +104,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedLineTradeDelivery
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\LineTradeDeliveryType
+     * @return \horstoeko\zugferd\entities\en16931\ram\LineTradeDeliveryType|null
      */
     public function getSpecifiedLineTradeDelivery()
     {
@@ -126,7 +126,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedLineTradeSettlement
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\LineTradeSettlementType
+     * @return \horstoeko\zugferd\entities\en16931\ram\LineTradeSettlementType|null
      */
     public function getSpecifiedLineTradeSettlement()
     {

--- a/src/entities/en16931/ram/SupplyChainTradeTransactionType.php
+++ b/src/entities/en16931/ram/SupplyChainTradeTransactionType.php
@@ -18,17 +18,17 @@ class SupplyChainTradeTransactionType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\HeaderTradeAgreementType $applicableHeaderTradeAgreement
+     * @var \horstoeko\zugferd\entities\en16931\ram\HeaderTradeAgreementType|null $applicableHeaderTradeAgreement
      */
     private $applicableHeaderTradeAgreement = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\HeaderTradeDeliveryType $applicableHeaderTradeDelivery
+     * @var \horstoeko\zugferd\entities\en16931\ram\HeaderTradeDeliveryType|null $applicableHeaderTradeDelivery
      */
     private $applicableHeaderTradeDelivery = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\HeaderTradeSettlementType $applicableHeaderTradeSettlement
+     * @var \horstoeko\zugferd\entities\en16931\ram\HeaderTradeSettlementType|null $applicableHeaderTradeSettlement
      */
     private $applicableHeaderTradeSettlement = null;
 
@@ -91,7 +91,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeAgreement
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\HeaderTradeAgreementType
+     * @return \horstoeko\zugferd\entities\en16931\ram\HeaderTradeAgreementType|null
      */
     public function getApplicableHeaderTradeAgreement()
     {
@@ -113,7 +113,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeDelivery
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\HeaderTradeDeliveryType
+     * @return \horstoeko\zugferd\entities\en16931\ram\HeaderTradeDeliveryType|null
      */
     public function getApplicableHeaderTradeDelivery()
     {
@@ -135,7 +135,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeSettlement
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\HeaderTradeSettlementType
+     * @return \horstoeko\zugferd\entities\en16931\ram\HeaderTradeSettlementType|null
      */
     public function getApplicableHeaderTradeSettlement()
     {

--- a/src/entities/en16931/ram/TaxRegistrationType.php
+++ b/src/entities/en16931/ram/TaxRegistrationType.php
@@ -11,14 +11,14 @@ class TaxRegistrationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/en16931/ram/TradeAccountingAccountType.php
+++ b/src/entities/en16931/ram/TradeAccountingAccountType.php
@@ -11,14 +11,14 @@ class TradeAccountingAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/en16931/ram/TradeAddressType.php
+++ b/src/entities/en16931/ram/TradeAddressType.php
@@ -11,44 +11,44 @@ class TradeAddressType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\CodeType $postcodeCode
+     * @var \horstoeko\zugferd\entities\en16931\udt\CodeType|null $postcodeCode
      */
     private $postcodeCode = null;
 
     /**
-     * @var string $lineOne
+     * @var string|null $lineOne
      */
     private $lineOne = null;
 
     /**
-     * @var string $lineTwo
+     * @var string|null $lineTwo
      */
     private $lineTwo = null;
 
     /**
-     * @var string $lineThree
+     * @var string|null $lineThree
      */
     private $lineThree = null;
 
     /**
-     * @var string $cityName
+     * @var string|null $cityName
      */
     private $cityName = null;
 
     /**
-     * @var string $countryID
+     * @var string|null $countryID
      */
     private $countryID = null;
 
     /**
-     * @var string $countrySubDivisionName
+     * @var string|null $countrySubDivisionName
      */
     private $countrySubDivisionName = null;
 
     /**
      * Gets as postcodeCode
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\CodeType
+     * @return \horstoeko\zugferd\entities\en16931\udt\CodeType|null
      */
     public function getPostcodeCode()
     {
@@ -58,7 +58,7 @@ class TradeAddressType
     /**
      * Sets a new postcodeCode
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\CodeType $postcodeCode
+     * @param  \horstoeko\zugferd\entities\en16931\udt\CodeType|null $postcodeCode
      * @return self
      */
     public function setPostcodeCode(?\horstoeko\zugferd\entities\en16931\udt\CodeType $postcodeCode = null)
@@ -70,7 +70,7 @@ class TradeAddressType
     /**
      * Gets as lineOne
      *
-     * @return string
+     * @return string|null
      */
     public function getLineOne()
     {
@@ -92,7 +92,7 @@ class TradeAddressType
     /**
      * Gets as lineTwo
      *
-     * @return string
+     * @return string|null
      */
     public function getLineTwo()
     {
@@ -114,7 +114,7 @@ class TradeAddressType
     /**
      * Gets as lineThree
      *
-     * @return string
+     * @return string|null
      */
     public function getLineThree()
     {
@@ -136,7 +136,7 @@ class TradeAddressType
     /**
      * Gets as cityName
      *
-     * @return string
+     * @return string|null
      */
     public function getCityName()
     {
@@ -158,7 +158,7 @@ class TradeAddressType
     /**
      * Gets as countryID
      *
-     * @return string
+     * @return string|null
      */
     public function getCountryID()
     {
@@ -180,7 +180,7 @@ class TradeAddressType
     /**
      * Gets as countrySubDivisionName
      *
-     * @return string
+     * @return string|null
      */
     public function getCountrySubDivisionName()
     {

--- a/src/entities/en16931/ram/TradeAllowanceChargeType.php
+++ b/src/entities/en16931/ram/TradeAllowanceChargeType.php
@@ -11,44 +11,44 @@ class TradeAllowanceChargeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IndicatorType $chargeIndicator
+     * @var \horstoeko\zugferd\entities\en16931\udt\IndicatorType|null $chargeIndicator
      */
     private $chargeIndicator = null;
 
     /**
-     * @var float $calculationPercent
+     * @var float|null $calculationPercent
      */
     private $calculationPercent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $actualAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $actualAmount
      */
     private $actualAmount = null;
 
     /**
-     * @var string $reasonCode
+     * @var string|null $reasonCode
      */
     private $reasonCode = null;
 
     /**
-     * @var string $reason
+     * @var string|null $reason
      */
     private $reason = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeTaxType $categoryTradeTax
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeTaxType|null $categoryTradeTax
      */
     private $categoryTradeTax = null;
 
     /**
      * Gets as chargeIndicator
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IndicatorType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IndicatorType|null
      */
     public function getChargeIndicator()
     {
@@ -70,7 +70,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as calculationPercent
      *
-     * @return float
+     * @return float|null
      */
     public function getCalculationPercent()
     {
@@ -92,7 +92,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -102,7 +102,7 @@ class TradeAllowanceChargeType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\en16931\udt\AmountType $basisAmount = null)
@@ -114,7 +114,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as actualAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getActualAmount()
     {
@@ -136,7 +136,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as reasonCode
      *
-     * @return string
+     * @return string|null
      */
     public function getReasonCode()
     {
@@ -158,7 +158,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as reason
      *
-     * @return string
+     * @return string|null
      */
     public function getReason()
     {
@@ -180,7 +180,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as categoryTradeTax
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeTaxType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeTaxType|null
      */
     public function getCategoryTradeTax()
     {
@@ -190,7 +190,7 @@ class TradeAllowanceChargeType
     /**
      * Sets a new categoryTradeTax
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeTaxType $categoryTradeTax
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeTaxType|null $categoryTradeTax
      * @return self
      */
     public function setCategoryTradeTax(?\horstoeko\zugferd\entities\en16931\ram\TradeTaxType $categoryTradeTax = null)

--- a/src/entities/en16931/ram/TradeContactType.php
+++ b/src/entities/en16931/ram/TradeContactType.php
@@ -11,29 +11,29 @@ class TradeContactType
 {
 
     /**
-     * @var string $personName
+     * @var string|null $personName
      */
     private $personName = null;
 
     /**
-     * @var string $departmentName
+     * @var string|null $departmentName
      */
     private $departmentName = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType $telephoneUniversalCommunication
+     * @var \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType|null $telephoneUniversalCommunication
      */
     private $telephoneUniversalCommunication = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType $emailURIUniversalCommunication
+     * @var \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType|null $emailURIUniversalCommunication
      */
     private $emailURIUniversalCommunication = null;
 
     /**
      * Gets as personName
      *
-     * @return string
+     * @return string|null
      */
     public function getPersonName()
     {
@@ -55,7 +55,7 @@ class TradeContactType
     /**
      * Gets as departmentName
      *
-     * @return string
+     * @return string|null
      */
     public function getDepartmentName()
     {
@@ -77,7 +77,7 @@ class TradeContactType
     /**
      * Gets as telephoneUniversalCommunication
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType
+     * @return \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType|null
      */
     public function getTelephoneUniversalCommunication()
     {
@@ -87,7 +87,7 @@ class TradeContactType
     /**
      * Sets a new telephoneUniversalCommunication
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType $telephoneUniversalCommunication
+     * @param  \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType|null $telephoneUniversalCommunication
      * @return self
      */
     public function setTelephoneUniversalCommunication(?\horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType $telephoneUniversalCommunication = null)
@@ -99,7 +99,7 @@ class TradeContactType
     /**
      * Gets as emailURIUniversalCommunication
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType
+     * @return \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType|null
      */
     public function getEmailURIUniversalCommunication()
     {
@@ -109,7 +109,7 @@ class TradeContactType
     /**
      * Sets a new emailURIUniversalCommunication
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType $emailURIUniversalCommunication
+     * @param  \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType|null $emailURIUniversalCommunication
      * @return self
      */
     public function setEmailURIUniversalCommunication(?\horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType $emailURIUniversalCommunication = null)

--- a/src/entities/en16931/ram/TradeCountryType.php
+++ b/src/entities/en16931/ram/TradeCountryType.php
@@ -11,14 +11,14 @@ class TradeCountryType
 {
 
     /**
-     * @var string $iD
+     * @var string|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return string
+     * @return string|null
      */
     public function getID()
     {

--- a/src/entities/en16931/ram/TradePartyType.php
+++ b/src/entities/en16931/ram/TradePartyType.php
@@ -25,32 +25,32 @@ class TradePartyType
     ];
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @var \horstoeko\zugferd\entities\en16931\ram\LegalOrganizationType|null $specifiedLegalOrganization
      */
     private $specifiedLegalOrganization = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeContactType $definedTradeContact
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeContactType|null $definedTradeContact
      */
     private $definedTradeContact = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeAddressType $postalTradeAddress
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeAddressType|null $postalTradeAddress
      */
     private $postalTradeAddress = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType $uRIUniversalCommunication
+     * @var \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType|null $uRIUniversalCommunication
      */
     private $uRIUniversalCommunication = null;
 
@@ -108,7 +108,7 @@ class TradePartyType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType[] $iD
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType[]|null $iD
      * @return self
      */
     public function setID(?array $iD = null)
@@ -164,7 +164,7 @@ class TradePartyType
     /**
      * Sets a new globalID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType[] $globalID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType[]|null $globalID
      * @return self
      */
     public function setGlobalID(?array $globalID = null)
@@ -176,7 +176,7 @@ class TradePartyType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -198,7 +198,7 @@ class TradePartyType
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -220,7 +220,7 @@ class TradePartyType
     /**
      * Gets as specifiedLegalOrganization
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\LegalOrganizationType
+     * @return \horstoeko\zugferd\entities\en16931\ram\LegalOrganizationType|null
      */
     public function getSpecifiedLegalOrganization()
     {
@@ -230,7 +230,7 @@ class TradePartyType
     /**
      * Sets a new specifiedLegalOrganization
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @param  \horstoeko\zugferd\entities\en16931\ram\LegalOrganizationType|null $specifiedLegalOrganization
      * @return self
      */
     public function setSpecifiedLegalOrganization(?\horstoeko\zugferd\entities\en16931\ram\LegalOrganizationType $specifiedLegalOrganization = null)
@@ -242,7 +242,7 @@ class TradePartyType
     /**
      * Gets as definedTradeContact
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeContactType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeContactType|null
      */
     public function getDefinedTradeContact()
     {
@@ -252,7 +252,7 @@ class TradePartyType
     /**
      * Sets a new definedTradeContact
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeContactType $definedTradeContact
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeContactType|null $definedTradeContact
      * @return self
      */
     public function setDefinedTradeContact(?\horstoeko\zugferd\entities\en16931\ram\TradeContactType $definedTradeContact = null)
@@ -264,7 +264,7 @@ class TradePartyType
     /**
      * Gets as postalTradeAddress
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeAddressType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeAddressType|null
      */
     public function getPostalTradeAddress()
     {
@@ -274,7 +274,7 @@ class TradePartyType
     /**
      * Sets a new postalTradeAddress
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAddressType $postalTradeAddress
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAddressType|null $postalTradeAddress
      * @return self
      */
     public function setPostalTradeAddress(?\horstoeko\zugferd\entities\en16931\ram\TradeAddressType $postalTradeAddress = null)
@@ -286,7 +286,7 @@ class TradePartyType
     /**
      * Gets as uRIUniversalCommunication
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType
+     * @return \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType|null
      */
     public function getURIUniversalCommunication()
     {
@@ -296,7 +296,7 @@ class TradePartyType
     /**
      * Sets a new uRIUniversalCommunication
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType $uRIUniversalCommunication
+     * @param  \horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType|null $uRIUniversalCommunication
      * @return self
      */
     public function setURIUniversalCommunication(?\horstoeko\zugferd\entities\en16931\ram\UniversalCommunicationType $uRIUniversalCommunication = null)
@@ -352,7 +352,7 @@ class TradePartyType
     /**
      * Sets a new specifiedTaxRegistration
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TaxRegistrationType[] $specifiedTaxRegistration
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TaxRegistrationType[]|null $specifiedTaxRegistration
      * @return self
      */
     public function setSpecifiedTaxRegistration(?array $specifiedTaxRegistration = null)

--- a/src/entities/en16931/ram/TradePaymentTermsType.php
+++ b/src/entities/en16931/ram/TradePaymentTermsType.php
@@ -11,24 +11,24 @@ class TradePaymentTermsType
 {
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType $dueDateDateTime
+     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null $dueDateDateTime
      */
     private $dueDateDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $directDebitMandateID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $directDebitMandateID
      */
     private $directDebitMandateID = null;
 
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -50,7 +50,7 @@ class TradePaymentTermsType
     /**
      * Gets as dueDateDateTime
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null
      */
     public function getDueDateDateTime()
     {
@@ -60,7 +60,7 @@ class TradePaymentTermsType
     /**
      * Sets a new dueDateDateTime
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\DateTimeType $dueDateDateTime
+     * @param  \horstoeko\zugferd\entities\en16931\udt\DateTimeType|null $dueDateDateTime
      * @return self
      */
     public function setDueDateDateTime(?\horstoeko\zugferd\entities\en16931\udt\DateTimeType $dueDateDateTime = null)
@@ -72,7 +72,7 @@ class TradePaymentTermsType
     /**
      * Gets as directDebitMandateID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getDirectDebitMandateID()
     {
@@ -82,7 +82,7 @@ class TradePaymentTermsType
     /**
      * Sets a new directDebitMandateID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $directDebitMandateID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $directDebitMandateID
      * @return self
      */
     public function setDirectDebitMandateID(?\horstoeko\zugferd\entities\en16931\udt\IDType $directDebitMandateID = null)

--- a/src/entities/en16931/ram/TradePriceType.php
+++ b/src/entities/en16931/ram/TradePriceType.php
@@ -11,24 +11,24 @@ class TradePriceType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $chargeAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $chargeAmount
      */
     private $chargeAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\QuantityType $basisQuantity
+     * @var \horstoeko\zugferd\entities\en16931\udt\QuantityType|null $basisQuantity
      */
     private $basisQuantity = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType $appliedTradeAllowanceCharge
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType|null $appliedTradeAllowanceCharge
      */
     private $appliedTradeAllowanceCharge = null;
 
     /**
      * Gets as chargeAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getChargeAmount()
     {
@@ -50,7 +50,7 @@ class TradePriceType
     /**
      * Gets as basisQuantity
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\en16931\udt\QuantityType|null
      */
     public function getBasisQuantity()
     {
@@ -60,7 +60,7 @@ class TradePriceType
     /**
      * Sets a new basisQuantity
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\QuantityType $basisQuantity
+     * @param  \horstoeko\zugferd\entities\en16931\udt\QuantityType|null $basisQuantity
      * @return self
      */
     public function setBasisQuantity(?\horstoeko\zugferd\entities\en16931\udt\QuantityType $basisQuantity = null)
@@ -72,7 +72,7 @@ class TradePriceType
     /**
      * Gets as appliedTradeAllowanceCharge
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType|null
      */
     public function getAppliedTradeAllowanceCharge()
     {
@@ -82,7 +82,7 @@ class TradePriceType
     /**
      * Sets a new appliedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType $appliedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType|null $appliedTradeAllowanceCharge
      * @return self
      */
     public function setAppliedTradeAllowanceCharge(?\horstoeko\zugferd\entities\en16931\ram\TradeAllowanceChargeType $appliedTradeAllowanceCharge = null)

--- a/src/entities/en16931/ram/TradeProductType.php
+++ b/src/entities/en16931/ram/TradeProductType.php
@@ -11,27 +11,27 @@ class TradeProductType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $globalID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $globalID
      */
     private $globalID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $sellerAssignedID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $sellerAssignedID
      */
     private $sellerAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $buyerAssignedID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $buyerAssignedID
      */
     private $buyerAssignedID = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
@@ -50,14 +50,14 @@ class TradeProductType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeCountryType $originTradeCountry
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeCountryType|null $originTradeCountry
      */
     private $originTradeCountry = null;
 
     /**
      * Gets as globalID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getGlobalID()
     {
@@ -67,7 +67,7 @@ class TradeProductType
     /**
      * Sets a new globalID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $globalID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $globalID
      * @return self
      */
     public function setGlobalID(?\horstoeko\zugferd\entities\en16931\udt\IDType $globalID = null)
@@ -79,7 +79,7 @@ class TradeProductType
     /**
      * Gets as sellerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getSellerAssignedID()
     {
@@ -89,7 +89,7 @@ class TradeProductType
     /**
      * Sets a new sellerAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $sellerAssignedID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $sellerAssignedID
      * @return self
      */
     public function setSellerAssignedID(?\horstoeko\zugferd\entities\en16931\udt\IDType $sellerAssignedID = null)
@@ -101,7 +101,7 @@ class TradeProductType
     /**
      * Gets as buyerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getBuyerAssignedID()
     {
@@ -111,7 +111,7 @@ class TradeProductType
     /**
      * Sets a new buyerAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $buyerAssignedID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $buyerAssignedID
      * @return self
      */
     public function setBuyerAssignedID(?\horstoeko\zugferd\entities\en16931\udt\IDType $buyerAssignedID = null)
@@ -123,7 +123,7 @@ class TradeProductType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -145,7 +145,7 @@ class TradeProductType
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -211,7 +211,7 @@ class TradeProductType
     /**
      * Sets a new applicableProductCharacteristic
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ProductCharacteristicType[] $applicableProductCharacteristic
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ProductCharacteristicType[]|null $applicableProductCharacteristic
      * @return self
      */
     public function setApplicableProductCharacteristic(?array $applicableProductCharacteristic = null)
@@ -267,7 +267,7 @@ class TradeProductType
     /**
      * Sets a new designatedProductClassification
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\ProductClassificationType[] $designatedProductClassification
+     * @param  \horstoeko\zugferd\entities\en16931\ram\ProductClassificationType[]|null $designatedProductClassification
      * @return self
      */
     public function setDesignatedProductClassification(?array $designatedProductClassification = null)
@@ -279,7 +279,7 @@ class TradeProductType
     /**
      * Gets as originTradeCountry
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeCountryType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeCountryType|null
      */
     public function getOriginTradeCountry()
     {
@@ -289,7 +289,7 @@ class TradeProductType
     /**
      * Sets a new originTradeCountry
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeCountryType $originTradeCountry
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeCountryType|null $originTradeCountry
      * @return self
      */
     public function setOriginTradeCountry(?\horstoeko\zugferd\entities\en16931\ram\TradeCountryType $originTradeCountry = null)

--- a/src/entities/en16931/ram/TradeSettlementFinancialCardType.php
+++ b/src/entities/en16931/ram/TradeSettlementFinancialCardType.php
@@ -11,19 +11,19 @@ class TradeSettlementFinancialCardType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $cardholderName
+     * @var string|null $cardholderName
      */
     private $cardholderName = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getID()
     {
@@ -45,7 +45,7 @@ class TradeSettlementFinancialCardType
     /**
      * Gets as cardholderName
      *
-     * @return string
+     * @return string|null
      */
     public function getCardholderName()
     {

--- a/src/entities/en16931/ram/TradeSettlementHeaderMonetarySummationType.php
+++ b/src/entities/en16931/ram/TradeSettlementHeaderMonetarySummationType.php
@@ -11,22 +11,22 @@ class TradeSettlementHeaderMonetarySummationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $lineTotalAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $lineTotalAmount
      */
     private $lineTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $chargeTotalAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $chargeTotalAmount
      */
     private $chargeTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $allowanceTotalAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $allowanceTotalAmount
      */
     private $allowanceTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $taxBasisTotalAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $taxBasisTotalAmount
      */
     private $taxBasisTotalAmount = null;
 
@@ -38,29 +38,29 @@ class TradeSettlementHeaderMonetarySummationType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $roundingAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $roundingAmount
      */
     private $roundingAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $grandTotalAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $grandTotalAmount
      */
     private $grandTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $totalPrepaidAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $totalPrepaidAmount
      */
     private $totalPrepaidAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $duePayableAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $duePayableAmount
      */
     private $duePayableAmount = null;
 
     /**
      * Gets as lineTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getLineTotalAmount()
     {
@@ -82,7 +82,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as chargeTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getChargeTotalAmount()
     {
@@ -92,7 +92,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new chargeTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType $chargeTotalAmount
+     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType|null $chargeTotalAmount
      * @return self
      */
     public function setChargeTotalAmount(?\horstoeko\zugferd\entities\en16931\udt\AmountType $chargeTotalAmount = null)
@@ -104,7 +104,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as allowanceTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getAllowanceTotalAmount()
     {
@@ -114,7 +114,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new allowanceTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType $allowanceTotalAmount
+     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType|null $allowanceTotalAmount
      * @return self
      */
     public function setAllowanceTotalAmount(?\horstoeko\zugferd\entities\en16931\udt\AmountType $allowanceTotalAmount = null)
@@ -126,7 +126,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as taxBasisTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getTaxBasisTotalAmount()
     {
@@ -192,7 +192,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new taxTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType[] $taxTotalAmount
+     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType[]|null $taxTotalAmount
      * @return self
      */
     public function setTaxTotalAmount(?array $taxTotalAmount = null)
@@ -204,7 +204,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as roundingAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getRoundingAmount()
     {
@@ -214,7 +214,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new roundingAmount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType $roundingAmount
+     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType|null $roundingAmount
      * @return self
      */
     public function setRoundingAmount(?\horstoeko\zugferd\entities\en16931\udt\AmountType $roundingAmount = null)
@@ -226,7 +226,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as grandTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getGrandTotalAmount()
     {
@@ -248,7 +248,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as totalPrepaidAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getTotalPrepaidAmount()
     {
@@ -258,7 +258,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new totalPrepaidAmount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType $totalPrepaidAmount
+     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType|null $totalPrepaidAmount
      * @return self
      */
     public function setTotalPrepaidAmount(?\horstoeko\zugferd\entities\en16931\udt\AmountType $totalPrepaidAmount = null)
@@ -270,7 +270,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as duePayableAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getDuePayableAmount()
     {

--- a/src/entities/en16931/ram/TradeSettlementLineMonetarySummationType.php
+++ b/src/entities/en16931/ram/TradeSettlementLineMonetarySummationType.php
@@ -11,14 +11,14 @@ class TradeSettlementLineMonetarySummationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $lineTotalAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $lineTotalAmount
      */
     private $lineTotalAmount = null;
 
     /**
      * Gets as lineTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getLineTotalAmount()
     {

--- a/src/entities/en16931/ram/TradeSettlementPaymentMeansType.php
+++ b/src/entities/en16931/ram/TradeSettlementPaymentMeansType.php
@@ -11,39 +11,39 @@ class TradeSettlementPaymentMeansType
 {
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var string $information
+     * @var string|null $information
      */
     private $information = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\TradeSettlementFinancialCardType $applicableTradeSettlementFinancialCard
+     * @var \horstoeko\zugferd\entities\en16931\ram\TradeSettlementFinancialCardType|null $applicableTradeSettlementFinancialCard
      */
     private $applicableTradeSettlementFinancialCard = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount
+     * @var \horstoeko\zugferd\entities\en16931\ram\DebtorFinancialAccountType|null $payerPartyDebtorFinancialAccount
      */
     private $payerPartyDebtorFinancialAccount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount
+     * @var \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialAccountType|null $payeePartyCreditorFinancialAccount
      */
     private $payeePartyCreditorFinancialAccount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialInstitutionType $payeeSpecifiedCreditorFinancialInstitution
+     * @var \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialInstitutionType|null $payeeSpecifiedCreditorFinancialInstitution
      */
     private $payeeSpecifiedCreditorFinancialInstitution = null;
 
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -65,7 +65,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as information
      *
-     * @return string
+     * @return string|null
      */
     public function getInformation()
     {
@@ -87,7 +87,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as applicableTradeSettlementFinancialCard
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\TradeSettlementFinancialCardType
+     * @return \horstoeko\zugferd\entities\en16931\ram\TradeSettlementFinancialCardType|null
      */
     public function getApplicableTradeSettlementFinancialCard()
     {
@@ -97,7 +97,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new applicableTradeSettlementFinancialCard
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeSettlementFinancialCardType $applicableTradeSettlementFinancialCard
+     * @param  \horstoeko\zugferd\entities\en16931\ram\TradeSettlementFinancialCardType|null $applicableTradeSettlementFinancialCard
      * @return self
      */
     public function setApplicableTradeSettlementFinancialCard(?\horstoeko\zugferd\entities\en16931\ram\TradeSettlementFinancialCardType $applicableTradeSettlementFinancialCard = null)
@@ -109,7 +109,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payerPartyDebtorFinancialAccount
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\DebtorFinancialAccountType
+     * @return \horstoeko\zugferd\entities\en16931\ram\DebtorFinancialAccountType|null
      */
     public function getPayerPartyDebtorFinancialAccount()
     {
@@ -119,7 +119,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payerPartyDebtorFinancialAccount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount
+     * @param  \horstoeko\zugferd\entities\en16931\ram\DebtorFinancialAccountType|null $payerPartyDebtorFinancialAccount
      * @return self
      */
     public function setPayerPartyDebtorFinancialAccount(?\horstoeko\zugferd\entities\en16931\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount = null)
@@ -131,7 +131,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payeePartyCreditorFinancialAccount
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialAccountType
+     * @return \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialAccountType|null
      */
     public function getPayeePartyCreditorFinancialAccount()
     {
@@ -141,7 +141,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payeePartyCreditorFinancialAccount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount
+     * @param  \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialAccountType|null $payeePartyCreditorFinancialAccount
      * @return self
      */
     public function setPayeePartyCreditorFinancialAccount(?\horstoeko\zugferd\entities\en16931\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount = null)
@@ -153,7 +153,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payeeSpecifiedCreditorFinancialInstitution
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialInstitutionType
+     * @return \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialInstitutionType|null
      */
     public function getPayeeSpecifiedCreditorFinancialInstitution()
     {
@@ -163,7 +163,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payeeSpecifiedCreditorFinancialInstitution
      *
-     * @param  \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialInstitutionType $payeeSpecifiedCreditorFinancialInstitution
+     * @param  \horstoeko\zugferd\entities\en16931\ram\CreditorFinancialInstitutionType|null $payeeSpecifiedCreditorFinancialInstitution
      * @return self
      */
     public function setPayeeSpecifiedCreditorFinancialInstitution(?\horstoeko\zugferd\entities\en16931\ram\CreditorFinancialInstitutionType $payeeSpecifiedCreditorFinancialInstitution = null)

--- a/src/entities/en16931/ram/TradeTaxType.php
+++ b/src/entities/en16931/ram/TradeTaxType.php
@@ -11,54 +11,54 @@ class TradeTaxType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $calculatedAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $calculatedAmount
      */
     private $calculatedAmount = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var string $exemptionReason
+     * @var string|null $exemptionReason
      */
     private $exemptionReason = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\en16931\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var string $categoryCode
+     * @var string|null $categoryCode
      */
     private $categoryCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\CodeType $exemptionReasonCode
+     * @var \horstoeko\zugferd\entities\en16931\udt\CodeType|null $exemptionReasonCode
      */
     private $exemptionReasonCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\DateType $taxPointDate
+     * @var \horstoeko\zugferd\entities\en16931\udt\DateType|null $taxPointDate
      */
     private $taxPointDate = null;
 
     /**
-     * @var string $dueDateTypeCode
+     * @var string|null $dueDateTypeCode
      */
     private $dueDateTypeCode = null;
 
     /**
-     * @var float $rateApplicablePercent
+     * @var float|null $rateApplicablePercent
      */
     private $rateApplicablePercent = null;
 
     /**
      * Gets as calculatedAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getCalculatedAmount()
     {
@@ -68,7 +68,7 @@ class TradeTaxType
     /**
      * Sets a new calculatedAmount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType $calculatedAmount
+     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType|null $calculatedAmount
      * @return self
      */
     public function setCalculatedAmount(?\horstoeko\zugferd\entities\en16931\udt\AmountType $calculatedAmount = null)
@@ -80,7 +80,7 @@ class TradeTaxType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -102,7 +102,7 @@ class TradeTaxType
     /**
      * Gets as exemptionReason
      *
-     * @return string
+     * @return string|null
      */
     public function getExemptionReason()
     {
@@ -124,7 +124,7 @@ class TradeTaxType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType
+     * @return \horstoeko\zugferd\entities\en16931\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -134,7 +134,7 @@ class TradeTaxType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\en16931\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\en16931\udt\AmountType $basisAmount = null)
@@ -146,7 +146,7 @@ class TradeTaxType
     /**
      * Gets as categoryCode
      *
-     * @return string
+     * @return string|null
      */
     public function getCategoryCode()
     {
@@ -168,7 +168,7 @@ class TradeTaxType
     /**
      * Gets as exemptionReasonCode
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\CodeType
+     * @return \horstoeko\zugferd\entities\en16931\udt\CodeType|null
      */
     public function getExemptionReasonCode()
     {
@@ -178,7 +178,7 @@ class TradeTaxType
     /**
      * Sets a new exemptionReasonCode
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\CodeType $exemptionReasonCode
+     * @param  \horstoeko\zugferd\entities\en16931\udt\CodeType|null $exemptionReasonCode
      * @return self
      */
     public function setExemptionReasonCode(?\horstoeko\zugferd\entities\en16931\udt\CodeType $exemptionReasonCode = null)
@@ -190,7 +190,7 @@ class TradeTaxType
     /**
      * Gets as taxPointDate
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\DateType
+     * @return \horstoeko\zugferd\entities\en16931\udt\DateType|null
      */
     public function getTaxPointDate()
     {
@@ -200,7 +200,7 @@ class TradeTaxType
     /**
      * Sets a new taxPointDate
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\DateType $taxPointDate
+     * @param  \horstoeko\zugferd\entities\en16931\udt\DateType|null $taxPointDate
      * @return self
      */
     public function setTaxPointDate(?\horstoeko\zugferd\entities\en16931\udt\DateType $taxPointDate = null)
@@ -212,7 +212,7 @@ class TradeTaxType
     /**
      * Gets as dueDateTypeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getDueDateTypeCode()
     {
@@ -234,7 +234,7 @@ class TradeTaxType
     /**
      * Gets as rateApplicablePercent
      *
-     * @return float
+     * @return float|null
      */
     public function getRateApplicablePercent()
     {

--- a/src/entities/en16931/ram/UniversalCommunicationType.php
+++ b/src/entities/en16931/ram/UniversalCommunicationType.php
@@ -11,19 +11,19 @@ class UniversalCommunicationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\IDType $uRIID
+     * @var \horstoeko\zugferd\entities\en16931\udt\IDType|null $uRIID
      */
     private $uRIID = null;
 
     /**
-     * @var string $completeNumber
+     * @var string|null $completeNumber
      */
     private $completeNumber = null;
 
     /**
      * Gets as uRIID
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\IDType
+     * @return \horstoeko\zugferd\entities\en16931\udt\IDType|null
      */
     public function getURIID()
     {
@@ -33,7 +33,7 @@ class UniversalCommunicationType
     /**
      * Sets a new uRIID
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType $uRIID
+     * @param  \horstoeko\zugferd\entities\en16931\udt\IDType|null $uRIID
      * @return self
      */
     public function setURIID(?\horstoeko\zugferd\entities\en16931\udt\IDType $uRIID = null)
@@ -45,7 +45,7 @@ class UniversalCommunicationType
     /**
      * Gets as completeNumber
      *
-     * @return string
+     * @return string|null
      */
     public function getCompleteNumber()
     {

--- a/src/entities/en16931/rsm/CrossIndustryInvoiceType.php
+++ b/src/entities/en16931/rsm/CrossIndustryInvoiceType.php
@@ -11,24 +11,24 @@ class CrossIndustryInvoiceType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ExchangedDocumentContextType $exchangedDocumentContext
+     * @var \horstoeko\zugferd\entities\en16931\ram\ExchangedDocumentContextType|null $exchangedDocumentContext
      */
     private $exchangedDocumentContext = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\ExchangedDocumentType $exchangedDocument
+     * @var \horstoeko\zugferd\entities\en16931\ram\ExchangedDocumentType|null $exchangedDocument
      */
     private $exchangedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\ram\SupplyChainTradeTransactionType $supplyChainTradeTransaction
+     * @var \horstoeko\zugferd\entities\en16931\ram\SupplyChainTradeTransactionType|null $supplyChainTradeTransaction
      */
     private $supplyChainTradeTransaction = null;
 
     /**
      * Gets as exchangedDocumentContext
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ExchangedDocumentContextType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ExchangedDocumentContextType|null
      */
     public function getExchangedDocumentContext()
     {
@@ -50,7 +50,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as exchangedDocument
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\ExchangedDocumentType
+     * @return \horstoeko\zugferd\entities\en16931\ram\ExchangedDocumentType|null
      */
     public function getExchangedDocument()
     {
@@ -72,7 +72,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as supplyChainTradeTransaction
      *
-     * @return \horstoeko\zugferd\entities\en16931\ram\SupplyChainTradeTransactionType
+     * @return \horstoeko\zugferd\entities\en16931\ram\SupplyChainTradeTransactionType|null
      */
     public function getSupplyChainTradeTransaction()
     {

--- a/src/entities/en16931/udt/AmountType.php
+++ b/src/entities/en16931/udt/AmountType.php
@@ -11,12 +11,12 @@ class AmountType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $currencyID
+     * @var string|null $currencyID
      */
     private $currencyID = null;
 
@@ -34,7 +34,7 @@ class AmountType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class AmountType
     /**
      * Gets as currencyID
      *
-     * @return string
+     * @return string|null
      */
     public function getCurrencyID()
     {

--- a/src/entities/en16931/udt/BinaryObjectType.php
+++ b/src/entities/en16931/udt/BinaryObjectType.php
@@ -11,17 +11,17 @@ class BinaryObjectType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $mimeCode
+     * @var string|null $mimeCode
      */
     private $mimeCode = null;
 
     /**
-     * @var string $filename
+     * @var string|null $filename
      */
     private $filename = null;
 
@@ -39,7 +39,7 @@ class BinaryObjectType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -62,7 +62,7 @@ class BinaryObjectType
     /**
      * Gets as mimeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getMimeCode()
     {
@@ -84,7 +84,7 @@ class BinaryObjectType
     /**
      * Gets as filename
      *
-     * @return string
+     * @return string|null
      */
     public function getFilename()
     {

--- a/src/entities/en16931/udt/CodeType.php
+++ b/src/entities/en16931/udt/CodeType.php
@@ -11,17 +11,17 @@ class CodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $listID
+     * @var string|null $listID
      */
     private $listID = null;
 
     /**
-     * @var string $listVersionID
+     * @var string|null $listVersionID
      */
     private $listVersionID = null;
 
@@ -39,7 +39,7 @@ class CodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -62,7 +62,7 @@ class CodeType
     /**
      * Gets as listID
      *
-     * @return string
+     * @return string|null
      */
     public function getListID()
     {
@@ -84,7 +84,7 @@ class CodeType
     /**
      * Gets as listVersionID
      *
-     * @return string
+     * @return string|null
      */
     public function getListVersionID()
     {

--- a/src/entities/en16931/udt/DateTimeType.php
+++ b/src/entities/en16931/udt/DateTimeType.php
@@ -11,14 +11,14 @@ class DateTimeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @var \horstoeko\zugferd\entities\en16931\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      */
     private $dateTimeString = null;
 
     /**
      * Gets as dateTimeString
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType\DateTimeStringAType
+     * @return \horstoeko\zugferd\entities\en16931\udt\DateTimeType\DateTimeStringAType|null
      */
     public function getDateTimeString()
     {
@@ -28,7 +28,7 @@ class DateTimeType
     /**
      * Sets a new dateTimeString
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @param  \horstoeko\zugferd\entities\en16931\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      * @return self
      */
     public function setDateTimeString(?\horstoeko\zugferd\entities\en16931\udt\DateTimeType\DateTimeStringAType $dateTimeString = null)

--- a/src/entities/en16931/udt/DateTimeType/DateTimeStringAType.php
+++ b/src/entities/en16931/udt/DateTimeType/DateTimeStringAType.php
@@ -9,12 +9,12 @@ class DateTimeStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateTimeStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateTimeStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/en16931/udt/DateType.php
+++ b/src/entities/en16931/udt/DateType.php
@@ -11,14 +11,14 @@ class DateType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\en16931\udt\DateType\DateStringAType $dateString
+     * @var \horstoeko\zugferd\entities\en16931\udt\DateType\DateStringAType|null $dateString
      */
     private $dateString = null;
 
     /**
      * Gets as dateString
      *
-     * @return \horstoeko\zugferd\entities\en16931\udt\DateType\DateStringAType
+     * @return \horstoeko\zugferd\entities\en16931\udt\DateType\DateStringAType|null
      */
     public function getDateString()
     {
@@ -28,7 +28,7 @@ class DateType
     /**
      * Sets a new dateString
      *
-     * @param  \horstoeko\zugferd\entities\en16931\udt\DateType\DateStringAType $dateString
+     * @param  \horstoeko\zugferd\entities\en16931\udt\DateType\DateStringAType|null $dateString
      * @return self
      */
     public function setDateString(?\horstoeko\zugferd\entities\en16931\udt\DateType\DateStringAType $dateString = null)

--- a/src/entities/en16931/udt/DateType/DateStringAType.php
+++ b/src/entities/en16931/udt/DateType/DateStringAType.php
@@ -9,12 +9,12 @@ class DateStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/en16931/udt/IDType.php
+++ b/src/entities/en16931/udt/IDType.php
@@ -11,12 +11,12 @@ class IDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $schemeID
+     * @var string|null $schemeID
      */
     private $schemeID = null;
 
@@ -34,7 +34,7 @@ class IDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class IDType
     /**
      * Gets as schemeID
      *
-     * @return string
+     * @return string|null
      */
     public function getSchemeID()
     {

--- a/src/entities/en16931/udt/IndicatorType.php
+++ b/src/entities/en16931/udt/IndicatorType.php
@@ -11,14 +11,14 @@ class IndicatorType
 {
 
     /**
-     * @var bool $indicator
+     * @var bool|null $indicator
      */
     private $indicator = null;
 
     /**
      * Gets as indicator
      *
-     * @return bool
+     * @return bool|null
      */
     public function getIndicator()
     {

--- a/src/entities/en16931/udt/PercentType.php
+++ b/src/entities/en16931/udt/PercentType.php
@@ -11,7 +11,7 @@ class PercentType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class PercentType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {

--- a/src/entities/en16931/udt/QuantityType.php
+++ b/src/entities/en16931/udt/QuantityType.php
@@ -11,12 +11,12 @@ class QuantityType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $unitCode
+     * @var string|null $unitCode
      */
     private $unitCode = null;
 
@@ -34,7 +34,7 @@ class QuantityType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class QuantityType
     /**
      * Gets as unitCode
      *
-     * @return string
+     * @return string|null
      */
     public function getUnitCode()
     {

--- a/src/entities/en16931/udt/TextType.php
+++ b/src/entities/en16931/udt/TextType.php
@@ -11,7 +11,7 @@ class TextType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TextType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/AccountingAccountTypeCodeType.php
+++ b/src/entities/extended/qdt/AccountingAccountTypeCodeType.php
@@ -11,7 +11,7 @@ class AccountingAccountTypeCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class AccountingAccountTypeCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/AllowanceChargeReasonCodeType.php
+++ b/src/entities/extended/qdt/AllowanceChargeReasonCodeType.php
@@ -11,7 +11,7 @@ class AllowanceChargeReasonCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -34,7 +34,7 @@ class AllowanceChargeReasonCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/ContactTypeCodeType.php
+++ b/src/entities/extended/qdt/ContactTypeCodeType.php
@@ -11,7 +11,7 @@ class ContactTypeCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class ContactTypeCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/CountryIDType.php
+++ b/src/entities/extended/qdt/CountryIDType.php
@@ -11,7 +11,7 @@ class CountryIDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CountryIDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/CurrencyCodeType.php
+++ b/src/entities/extended/qdt/CurrencyCodeType.php
@@ -11,7 +11,7 @@ class CurrencyCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CurrencyCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/DeliveryTermsCodeType.php
+++ b/src/entities/extended/qdt/DeliveryTermsCodeType.php
@@ -11,7 +11,7 @@ class DeliveryTermsCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class DeliveryTermsCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/DocumentCodeType.php
+++ b/src/entities/extended/qdt/DocumentCodeType.php
@@ -11,7 +11,7 @@ class DocumentCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class DocumentCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/FormattedDateTimeType.php
+++ b/src/entities/extended/qdt/FormattedDateTimeType.php
@@ -11,14 +11,14 @@ class FormattedDateTimeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType\DateTimeStringAType $dateTimeString
+     * @var \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType\DateTimeStringAType|null $dateTimeString
      */
     private $dateTimeString = null;
 
     /**
      * Gets as dateTimeString
      *
-     * @return \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType\DateTimeStringAType
+     * @return \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType\DateTimeStringAType|null
      */
     public function getDateTimeString()
     {

--- a/src/entities/extended/qdt/FormattedDateTimeType/DateTimeStringAType.php
+++ b/src/entities/extended/qdt/FormattedDateTimeType/DateTimeStringAType.php
@@ -9,12 +9,12 @@ class DateTimeStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateTimeStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateTimeStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/extended/qdt/LineStatusCodeType.php
+++ b/src/entities/extended/qdt/LineStatusCodeType.php
@@ -11,7 +11,7 @@ class LineStatusCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class LineStatusCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/PartyRoleCodeType.php
+++ b/src/entities/extended/qdt/PartyRoleCodeType.php
@@ -11,7 +11,7 @@ class PartyRoleCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class PartyRoleCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/PaymentMeansCodeType.php
+++ b/src/entities/extended/qdt/PaymentMeansCodeType.php
@@ -11,7 +11,7 @@ class PaymentMeansCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class PaymentMeansCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/ReferenceCodeType.php
+++ b/src/entities/extended/qdt/ReferenceCodeType.php
@@ -11,7 +11,7 @@ class ReferenceCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class ReferenceCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/TaxCategoryCodeType.php
+++ b/src/entities/extended/qdt/TaxCategoryCodeType.php
@@ -11,7 +11,7 @@ class TaxCategoryCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TaxCategoryCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/TaxTypeCodeType.php
+++ b/src/entities/extended/qdt/TaxTypeCodeType.php
@@ -11,7 +11,7 @@ class TaxTypeCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TaxTypeCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/TimeReferenceCodeType.php
+++ b/src/entities/extended/qdt/TimeReferenceCodeType.php
@@ -11,7 +11,7 @@ class TimeReferenceCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TimeReferenceCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/qdt/TransportModeCodeType.php
+++ b/src/entities/extended/qdt/TransportModeCodeType.php
@@ -11,7 +11,7 @@ class TransportModeCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TransportModeCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/extended/ram/AdvancePaymentType.php
+++ b/src/entities/extended/ram/AdvancePaymentType.php
@@ -11,12 +11,12 @@ class AdvancePaymentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $paidAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $paidAmount
      */
     private $paidAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType $formattedReceivedDateTime
+     * @var \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType|null $formattedReceivedDateTime
      */
     private $formattedReceivedDateTime = null;
 
@@ -28,14 +28,14 @@ class AdvancePaymentType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $invoiceSpecifiedReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $invoiceSpecifiedReferencedDocument
      */
     private $invoiceSpecifiedReferencedDocument = null;
 
     /**
      * Gets as paidAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getPaidAmount()
     {
@@ -57,7 +57,7 @@ class AdvancePaymentType
     /**
      * Gets as formattedReceivedDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType
+     * @return \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType|null
      */
     public function getFormattedReceivedDateTime()
     {
@@ -67,7 +67,7 @@ class AdvancePaymentType
     /**
      * Sets a new formattedReceivedDateTime
      *
-     * @param  \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType $formattedReceivedDateTime
+     * @param  \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType|null $formattedReceivedDateTime
      * @return self
      */
     public function setFormattedReceivedDateTime(?\horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType $formattedReceivedDateTime = null)
@@ -135,7 +135,7 @@ class AdvancePaymentType
     /**
      * Gets as invoiceSpecifiedReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getInvoiceSpecifiedReferencedDocument()
     {
@@ -145,7 +145,7 @@ class AdvancePaymentType
     /**
      * Sets a new invoiceSpecifiedReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $invoiceSpecifiedReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $invoiceSpecifiedReferencedDocument
      * @return self
      */
     public function setInvoiceSpecifiedReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $invoiceSpecifiedReferencedDocument = null)

--- a/src/entities/extended/ram/CreditorFinancialAccountType.php
+++ b/src/entities/extended/ram/CreditorFinancialAccountType.php
@@ -11,24 +11,24 @@ class CreditorFinancialAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iBANID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iBANID
      */
     private $iBANID = null;
 
     /**
-     * @var string $accountName
+     * @var string|null $accountName
      */
     private $accountName = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $proprietaryID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $proprietaryID
      */
     private $proprietaryID = null;
 
     /**
      * Gets as iBANID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getIBANID()
     {
@@ -38,7 +38,7 @@ class CreditorFinancialAccountType
     /**
      * Sets a new iBANID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $iBANID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $iBANID
      * @return self
      */
     public function setIBANID(?\horstoeko\zugferd\entities\extended\udt\IDType $iBANID = null)
@@ -50,7 +50,7 @@ class CreditorFinancialAccountType
     /**
      * Gets as accountName
      *
-     * @return string
+     * @return string|null
      */
     public function getAccountName()
     {
@@ -72,7 +72,7 @@ class CreditorFinancialAccountType
     /**
      * Gets as proprietaryID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getProprietaryID()
     {
@@ -82,7 +82,7 @@ class CreditorFinancialAccountType
     /**
      * Sets a new proprietaryID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $proprietaryID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $proprietaryID
      * @return self
      */
     public function setProprietaryID(?\horstoeko\zugferd\entities\extended\udt\IDType $proprietaryID = null)

--- a/src/entities/extended/ram/CreditorFinancialInstitutionType.php
+++ b/src/entities/extended/ram/CreditorFinancialInstitutionType.php
@@ -11,14 +11,14 @@ class CreditorFinancialInstitutionType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $bICID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $bICID
      */
     private $bICID = null;
 
     /**
      * Gets as bICID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getBICID()
     {

--- a/src/entities/extended/ram/DebtorFinancialAccountType.php
+++ b/src/entities/extended/ram/DebtorFinancialAccountType.php
@@ -11,19 +11,19 @@ class DebtorFinancialAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iBANID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iBANID
      */
     private $iBANID = null;
 
     /**
-     * @var string $accountName
+     * @var string|null $accountName
      */
     private $accountName = null;
 
     /**
      * Gets as iBANID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getIBANID()
     {
@@ -45,7 +45,7 @@ class DebtorFinancialAccountType
     /**
      * Gets as accountName
      *
-     * @return string
+     * @return string|null
      */
     public function getAccountName()
     {

--- a/src/entities/extended/ram/DebtorFinancialInstitutionType.php
+++ b/src/entities/extended/ram/DebtorFinancialInstitutionType.php
@@ -11,14 +11,14 @@ class DebtorFinancialInstitutionType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $bICID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $bICID
      */
     private $bICID = null;
 
     /**
      * Gets as bICID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getBICID()
     {
@@ -28,7 +28,7 @@ class DebtorFinancialInstitutionType
     /**
      * Sets a new bICID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $bICID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $bICID
      * @return self
      */
     public function setBICID(?\horstoeko\zugferd\entities\extended\udt\IDType $bICID = null)

--- a/src/entities/extended/ram/DocumentContextParameterType.php
+++ b/src/entities/extended/ram/DocumentContextParameterType.php
@@ -11,14 +11,14 @@ class DocumentContextParameterType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/extended/ram/DocumentLineDocumentType.php
+++ b/src/entities/extended/ram/DocumentLineDocumentType.php
@@ -11,22 +11,22 @@ class DocumentLineDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $lineID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $lineID
      */
     private $lineID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $parentLineID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $parentLineID
      */
     private $parentLineID = null;
 
     /**
-     * @var string $lineStatusCode
+     * @var string|null $lineStatusCode
      */
     private $lineStatusCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\CodeType $lineStatusReasonCode
+     * @var \horstoeko\zugferd\entities\extended\udt\CodeType|null $lineStatusReasonCode
      */
     private $lineStatusReasonCode = null;
 
@@ -40,7 +40,7 @@ class DocumentLineDocumentType
     /**
      * Gets as lineID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getLineID()
     {
@@ -62,7 +62,7 @@ class DocumentLineDocumentType
     /**
      * Gets as parentLineID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getParentLineID()
     {
@@ -72,7 +72,7 @@ class DocumentLineDocumentType
     /**
      * Sets a new parentLineID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $parentLineID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $parentLineID
      * @return self
      */
     public function setParentLineID(?\horstoeko\zugferd\entities\extended\udt\IDType $parentLineID = null)
@@ -84,7 +84,7 @@ class DocumentLineDocumentType
     /**
      * Gets as lineStatusCode
      *
-     * @return string
+     * @return string|null
      */
     public function getLineStatusCode()
     {
@@ -106,7 +106,7 @@ class DocumentLineDocumentType
     /**
      * Gets as lineStatusReasonCode
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\CodeType
+     * @return \horstoeko\zugferd\entities\extended\udt\CodeType|null
      */
     public function getLineStatusReasonCode()
     {
@@ -116,7 +116,7 @@ class DocumentLineDocumentType
     /**
      * Sets a new lineStatusReasonCode
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType $lineStatusReasonCode
+     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType|null $lineStatusReasonCode
      * @return self
      */
     public function setLineStatusReasonCode(?\horstoeko\zugferd\entities\extended\udt\CodeType $lineStatusReasonCode = null)
@@ -172,7 +172,7 @@ class DocumentLineDocumentType
     /**
      * Sets a new includedNote
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\NoteType[] $includedNote
+     * @param  \horstoeko\zugferd\entities\extended\ram\NoteType[]|null $includedNote
      * @return self
      */
     public function setIncludedNote(?array $includedNote = null)

--- a/src/entities/extended/ram/ExchangedDocumentContextType.php
+++ b/src/entities/extended/ram/ExchangedDocumentContextType.php
@@ -11,24 +11,24 @@ class ExchangedDocumentContextType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IndicatorType $testIndicator
+     * @var \horstoeko\zugferd\entities\extended\udt\IndicatorType|null $testIndicator
      */
     private $testIndicator = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      */
     private $businessProcessSpecifiedDocumentContextParameter = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType $guidelineSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType|null $guidelineSpecifiedDocumentContextParameter
      */
     private $guidelineSpecifiedDocumentContextParameter = null;
 
     /**
      * Gets as testIndicator
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IndicatorType
+     * @return \horstoeko\zugferd\entities\extended\udt\IndicatorType|null
      */
     public function getTestIndicator()
     {
@@ -38,7 +38,7 @@ class ExchangedDocumentContextType
     /**
      * Sets a new testIndicator
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IndicatorType $testIndicator
+     * @param  \horstoeko\zugferd\entities\extended\udt\IndicatorType|null $testIndicator
      * @return self
      */
     public function setTestIndicator(?\horstoeko\zugferd\entities\extended\udt\IndicatorType $testIndicator = null)
@@ -50,7 +50,7 @@ class ExchangedDocumentContextType
     /**
      * Gets as businessProcessSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType|null
      */
     public function getBusinessProcessSpecifiedDocumentContextParameter()
     {
@@ -60,7 +60,7 @@ class ExchangedDocumentContextType
     /**
      * Sets a new businessProcessSpecifiedDocumentContextParameter
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @param  \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      * @return self
      */
     public function setBusinessProcessSpecifiedDocumentContextParameter(?\horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter = null)
@@ -72,7 +72,7 @@ class ExchangedDocumentContextType
     /**
      * Gets as guidelineSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\extended\ram\DocumentContextParameterType|null
      */
     public function getGuidelineSpecifiedDocumentContextParameter()
     {

--- a/src/entities/extended/ram/ExchangedDocumentType.php
+++ b/src/entities/extended/ram/ExchangedDocumentType.php
@@ -11,32 +11,32 @@ class ExchangedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType $issueDateTime
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $issueDateTime
      */
     private $issueDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IndicatorType $copyIndicator
+     * @var \horstoeko\zugferd\entities\extended\udt\IndicatorType|null $copyIndicator
      */
     private $copyIndicator = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $languageID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $languageID
      */
     private $languageID = null;
 
@@ -48,14 +48,14 @@ class ExchangedDocumentType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType $effectiveSpecifiedPeriod
+     * @var \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType|null $effectiveSpecifiedPeriod
      */
     private $effectiveSpecifiedPeriod = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getID()
     {
@@ -77,7 +77,7 @@ class ExchangedDocumentType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -99,7 +99,7 @@ class ExchangedDocumentType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -121,7 +121,7 @@ class ExchangedDocumentType
     /**
      * Gets as issueDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType|null
      */
     public function getIssueDateTime()
     {
@@ -143,7 +143,7 @@ class ExchangedDocumentType
     /**
      * Gets as copyIndicator
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IndicatorType
+     * @return \horstoeko\zugferd\entities\extended\udt\IndicatorType|null
      */
     public function getCopyIndicator()
     {
@@ -153,7 +153,7 @@ class ExchangedDocumentType
     /**
      * Sets a new copyIndicator
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IndicatorType $copyIndicator
+     * @param  \horstoeko\zugferd\entities\extended\udt\IndicatorType|null $copyIndicator
      * @return self
      */
     public function setCopyIndicator(?\horstoeko\zugferd\entities\extended\udt\IndicatorType $copyIndicator = null)
@@ -165,7 +165,7 @@ class ExchangedDocumentType
     /**
      * Gets as languageID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getLanguageID()
     {
@@ -175,7 +175,7 @@ class ExchangedDocumentType
     /**
      * Sets a new languageID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $languageID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $languageID
      * @return self
      */
     public function setLanguageID(?\horstoeko\zugferd\entities\extended\udt\IDType $languageID = null)
@@ -231,7 +231,7 @@ class ExchangedDocumentType
     /**
      * Sets a new includedNote
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\NoteType[] $includedNote
+     * @param  \horstoeko\zugferd\entities\extended\ram\NoteType[]|null $includedNote
      * @return self
      */
     public function setIncludedNote(?array $includedNote = null)
@@ -243,7 +243,7 @@ class ExchangedDocumentType
     /**
      * Gets as effectiveSpecifiedPeriod
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType
+     * @return \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType|null
      */
     public function getEffectiveSpecifiedPeriod()
     {
@@ -253,7 +253,7 @@ class ExchangedDocumentType
     /**
      * Sets a new effectiveSpecifiedPeriod
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType $effectiveSpecifiedPeriod
+     * @param  \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType|null $effectiveSpecifiedPeriod
      * @return self
      */
     public function setEffectiveSpecifiedPeriod(?\horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType $effectiveSpecifiedPeriod = null)

--- a/src/entities/extended/ram/FinancialAdjustmentType.php
+++ b/src/entities/extended/ram/FinancialAdjustmentType.php
@@ -11,19 +11,19 @@ class FinancialAdjustmentType
 {
 
     /**
-     * @var string $reason
+     * @var string|null $reason
      */
     private $reason = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $actualAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $actualAmount
      */
     private $actualAmount = null;
 
     /**
      * Gets as reason
      *
-     * @return string
+     * @return string|null
      */
     public function getReason()
     {
@@ -45,7 +45,7 @@ class FinancialAdjustmentType
     /**
      * Gets as actualAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getActualAmount()
     {

--- a/src/entities/extended/ram/HeaderTradeAgreementType.php
+++ b/src/entities/extended/ram/HeaderTradeAgreementType.php
@@ -11,62 +11,62 @@ class HeaderTradeAgreementType
 {
 
     /**
-     * @var string $buyerReference
+     * @var string|null $buyerReference
      */
     private $buyerReference = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $sellerTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $sellerTradeParty
      */
     private $sellerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $buyerTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $buyerTradeParty
      */
     private $buyerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $salesAgentTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $salesAgentTradeParty
      */
     private $salesAgentTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $buyerTaxRepresentativeTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $buyerTaxRepresentativeTradeParty
      */
     private $buyerTaxRepresentativeTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $sellerTaxRepresentativeTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $sellerTaxRepresentativeTradeParty
      */
     private $sellerTaxRepresentativeTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $productEndUserTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $productEndUserTradeParty
      */
     private $productEndUserTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType $applicableTradeDeliveryTerms
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType|null $applicableTradeDeliveryTerms
      */
     private $applicableTradeDeliveryTerms = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $sellerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $sellerOrderReferencedDocument
      */
     private $sellerOrderReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      */
     private $buyerOrderReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $quotationReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $quotationReferencedDocument
      */
     private $quotationReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $contractReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $contractReferencedDocument
      */
     private $contractReferencedDocument = null;
 
@@ -78,12 +78,12 @@ class HeaderTradeAgreementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $buyerAgentTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $buyerAgentTradeParty
      */
     private $buyerAgentTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ProcuringProjectType $specifiedProcuringProject
+     * @var \horstoeko\zugferd\entities\extended\ram\ProcuringProjectType|null $specifiedProcuringProject
      */
     private $specifiedProcuringProject = null;
 
@@ -97,7 +97,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerReference
      *
-     * @return string
+     * @return string|null
      */
     public function getBuyerReference()
     {
@@ -119,7 +119,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getSellerTradeParty()
     {
@@ -141,7 +141,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getBuyerTradeParty()
     {
@@ -163,7 +163,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as salesAgentTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getSalesAgentTradeParty()
     {
@@ -173,7 +173,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new salesAgentTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $salesAgentTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $salesAgentTradeParty
      * @return self
      */
     public function setSalesAgentTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $salesAgentTradeParty = null)
@@ -185,7 +185,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerTaxRepresentativeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getBuyerTaxRepresentativeTradeParty()
     {
@@ -195,7 +195,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new buyerTaxRepresentativeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $buyerTaxRepresentativeTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $buyerTaxRepresentativeTradeParty
      * @return self
      */
     public function setBuyerTaxRepresentativeTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $buyerTaxRepresentativeTradeParty = null)
@@ -207,7 +207,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerTaxRepresentativeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getSellerTaxRepresentativeTradeParty()
     {
@@ -217,7 +217,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new sellerTaxRepresentativeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $sellerTaxRepresentativeTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $sellerTaxRepresentativeTradeParty
      * @return self
      */
     public function setSellerTaxRepresentativeTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $sellerTaxRepresentativeTradeParty = null)
@@ -229,7 +229,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as productEndUserTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getProductEndUserTradeParty()
     {
@@ -239,7 +239,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new productEndUserTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $productEndUserTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $productEndUserTradeParty
      * @return self
      */
     public function setProductEndUserTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $productEndUserTradeParty = null)
@@ -251,7 +251,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as applicableTradeDeliveryTerms
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType|null
      */
     public function getApplicableTradeDeliveryTerms()
     {
@@ -261,7 +261,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new applicableTradeDeliveryTerms
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType $applicableTradeDeliveryTerms
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType|null $applicableTradeDeliveryTerms
      * @return self
      */
     public function setApplicableTradeDeliveryTerms(?\horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType $applicableTradeDeliveryTerms = null)
@@ -273,7 +273,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getSellerOrderReferencedDocument()
     {
@@ -283,7 +283,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new sellerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $sellerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $sellerOrderReferencedDocument
      * @return self
      */
     public function setSellerOrderReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $sellerOrderReferencedDocument = null)
@@ -295,7 +295,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getBuyerOrderReferencedDocument()
     {
@@ -305,7 +305,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new buyerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      * @return self
      */
     public function setBuyerOrderReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $buyerOrderReferencedDocument = null)
@@ -317,7 +317,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as quotationReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getQuotationReferencedDocument()
     {
@@ -327,7 +327,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new quotationReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $quotationReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $quotationReferencedDocument
      * @return self
      */
     public function setQuotationReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $quotationReferencedDocument = null)
@@ -339,7 +339,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as contractReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getContractReferencedDocument()
     {
@@ -349,7 +349,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new contractReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $contractReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $contractReferencedDocument
      * @return self
      */
     public function setContractReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $contractReferencedDocument = null)
@@ -405,7 +405,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new additionalReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[] $additionalReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[]|null $additionalReferencedDocument
      * @return self
      */
     public function setAdditionalReferencedDocument(?array $additionalReferencedDocument = null)
@@ -417,7 +417,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerAgentTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getBuyerAgentTradeParty()
     {
@@ -427,7 +427,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new buyerAgentTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $buyerAgentTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $buyerAgentTradeParty
      * @return self
      */
     public function setBuyerAgentTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $buyerAgentTradeParty = null)
@@ -439,7 +439,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as specifiedProcuringProject
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ProcuringProjectType
+     * @return \horstoeko\zugferd\entities\extended\ram\ProcuringProjectType|null
      */
     public function getSpecifiedProcuringProject()
     {
@@ -449,7 +449,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new specifiedProcuringProject
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ProcuringProjectType $specifiedProcuringProject
+     * @param  \horstoeko\zugferd\entities\extended\ram\ProcuringProjectType|null $specifiedProcuringProject
      * @return self
      */
     public function setSpecifiedProcuringProject(?\horstoeko\zugferd\entities\extended\ram\ProcuringProjectType $specifiedProcuringProject = null)
@@ -505,7 +505,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new ultimateCustomerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[] $ultimateCustomerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[]|null $ultimateCustomerOrderReferencedDocument
      * @return self
      */
     public function setUltimateCustomerOrderReferencedDocument(?array $ultimateCustomerOrderReferencedDocument = null)

--- a/src/entities/extended/ram/HeaderTradeDeliveryType.php
+++ b/src/entities/extended/ram/HeaderTradeDeliveryType.php
@@ -11,42 +11,42 @@ class HeaderTradeDeliveryType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\LogisticsTransportMovementType[] $relatedSupplyChainConsignment
+     * @var \horstoeko\zugferd\entities\extended\ram\LogisticsTransportMovementType[]|null $relatedSupplyChainConsignment
      */
     private $relatedSupplyChainConsignment = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $shipToTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $shipToTradeParty
      */
     private $shipToTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $ultimateShipToTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $ultimateShipToTradeParty
      */
     private $ultimateShipToTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $shipFromTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $shipFromTradeParty
      */
     private $shipFromTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @var \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      */
     private $actualDeliverySupplyChainEvent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      */
     private $despatchAdviceReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $receivingAdviceReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $receivingAdviceReferencedDocument
      */
     private $receivingAdviceReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $deliveryNoteReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $deliveryNoteReferencedDocument
      */
     private $deliveryNoteReferencedDocument = null;
 
@@ -87,7 +87,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as relatedSupplyChainConsignment
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\LogisticsTransportMovementType[]
+     * @return \horstoeko\zugferd\entities\extended\ram\LogisticsTransportMovementType[]|null
      */
     public function getRelatedSupplyChainConsignment()
     {
@@ -97,7 +97,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new relatedSupplyChainConsignment
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\LogisticsTransportMovementType[] $relatedSupplyChainConsignment
+     * @param  \horstoeko\zugferd\entities\extended\ram\LogisticsTransportMovementType[]|null $relatedSupplyChainConsignment
      * @return self
      */
     public function setRelatedSupplyChainConsignment(?array $relatedSupplyChainConsignment = null)
@@ -109,7 +109,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as shipToTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getShipToTradeParty()
     {
@@ -119,7 +119,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new shipToTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $shipToTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $shipToTradeParty
      * @return self
      */
     public function setShipToTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $shipToTradeParty = null)
@@ -131,7 +131,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as ultimateShipToTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getUltimateShipToTradeParty()
     {
@@ -141,7 +141,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new ultimateShipToTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $ultimateShipToTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $ultimateShipToTradeParty
      * @return self
      */
     public function setUltimateShipToTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $ultimateShipToTradeParty = null)
@@ -153,7 +153,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as shipFromTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getShipFromTradeParty()
     {
@@ -163,7 +163,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new shipFromTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $shipFromTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $shipFromTradeParty
      * @return self
      */
     public function setShipFromTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $shipFromTradeParty = null)
@@ -175,7 +175,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as actualDeliverySupplyChainEvent
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType
+     * @return \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType|null
      */
     public function getActualDeliverySupplyChainEvent()
     {
@@ -185,7 +185,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new actualDeliverySupplyChainEvent
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @param  \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      * @return self
      */
     public function setActualDeliverySupplyChainEvent(?\horstoeko\zugferd\entities\extended\ram\SupplyChainEventType $actualDeliverySupplyChainEvent = null)
@@ -197,7 +197,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as despatchAdviceReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getDespatchAdviceReferencedDocument()
     {
@@ -207,7 +207,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new despatchAdviceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      * @return self
      */
     public function setDespatchAdviceReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $despatchAdviceReferencedDocument = null)
@@ -219,7 +219,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as receivingAdviceReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getReceivingAdviceReferencedDocument()
     {
@@ -229,7 +229,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new receivingAdviceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $receivingAdviceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $receivingAdviceReferencedDocument
      * @return self
      */
     public function setReceivingAdviceReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $receivingAdviceReferencedDocument = null)
@@ -241,7 +241,7 @@ class HeaderTradeDeliveryType
     /**
      * Gets as deliveryNoteReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getDeliveryNoteReferencedDocument()
     {
@@ -251,7 +251,7 @@ class HeaderTradeDeliveryType
     /**
      * Sets a new deliveryNoteReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $deliveryNoteReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $deliveryNoteReferencedDocument
      * @return self
      */
     public function setDeliveryNoteReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $deliveryNoteReferencedDocument = null)

--- a/src/entities/extended/ram/HeaderTradeSettlementType.php
+++ b/src/entities/extended/ram/HeaderTradeSettlementType.php
@@ -11,52 +11,52 @@ class HeaderTradeSettlementType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $creditorReferenceID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $creditorReferenceID
      */
     private $creditorReferenceID = null;
 
     /**
-     * @var string $paymentReference
+     * @var string|null $paymentReference
      */
     private $paymentReference = null;
 
     /**
-     * @var string $taxCurrencyCode
+     * @var string|null $taxCurrencyCode
      */
     private $taxCurrencyCode = null;
 
     /**
-     * @var string $invoiceCurrencyCode
+     * @var string|null $invoiceCurrencyCode
      */
     private $invoiceCurrencyCode = null;
 
     /**
-     * @var string $invoiceIssuerReference
+     * @var string|null $invoiceIssuerReference
      */
     private $invoiceIssuerReference = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $invoicerTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $invoicerTradeParty
      */
     private $invoicerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $invoiceeTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $invoiceeTradeParty
      */
     private $invoiceeTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $payeeTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $payeeTradeParty
      */
     private $payeeTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $payerTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $payerTradeParty
      */
     private $payerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeCurrencyExchangeType $taxApplicableTradeCurrencyExchange
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeCurrencyExchangeType|null $taxApplicableTradeCurrencyExchange
      */
     private $taxApplicableTradeCurrencyExchange = null;
 
@@ -75,7 +75,7 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @var \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      */
     private $billingSpecifiedPeriod = null;
 
@@ -101,7 +101,7 @@ class HeaderTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeSettlementHeaderMonetarySummationType $specifiedTradeSettlementHeaderMonetarySummation
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeSettlementHeaderMonetarySummationType|null $specifiedTradeSettlementHeaderMonetarySummation
      */
     private $specifiedTradeSettlementHeaderMonetarySummation = null;
 
@@ -136,7 +136,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as creditorReferenceID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getCreditorReferenceID()
     {
@@ -146,7 +146,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new creditorReferenceID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $creditorReferenceID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $creditorReferenceID
      * @return self
      */
     public function setCreditorReferenceID(?\horstoeko\zugferd\entities\extended\udt\IDType $creditorReferenceID = null)
@@ -158,7 +158,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as paymentReference
      *
-     * @return string
+     * @return string|null
      */
     public function getPaymentReference()
     {
@@ -180,7 +180,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as taxCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTaxCurrencyCode()
     {
@@ -202,7 +202,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as invoiceCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getInvoiceCurrencyCode()
     {
@@ -224,7 +224,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as invoiceIssuerReference
      *
-     * @return string
+     * @return string|null
      */
     public function getInvoiceIssuerReference()
     {
@@ -246,7 +246,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as invoicerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getInvoicerTradeParty()
     {
@@ -256,7 +256,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new invoicerTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $invoicerTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $invoicerTradeParty
      * @return self
      */
     public function setInvoicerTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $invoicerTradeParty = null)
@@ -268,7 +268,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as invoiceeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getInvoiceeTradeParty()
     {
@@ -278,7 +278,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new invoiceeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $invoiceeTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $invoiceeTradeParty
      * @return self
      */
     public function setInvoiceeTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $invoiceeTradeParty = null)
@@ -290,7 +290,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as payeeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getPayeeTradeParty()
     {
@@ -300,7 +300,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new payeeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $payeeTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $payeeTradeParty
      * @return self
      */
     public function setPayeeTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $payeeTradeParty = null)
@@ -312,7 +312,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as payerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getPayerTradeParty()
     {
@@ -322,7 +322,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new payerTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $payerTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $payerTradeParty
      * @return self
      */
     public function setPayerTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $payerTradeParty = null)
@@ -334,7 +334,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as taxApplicableTradeCurrencyExchange
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeCurrencyExchangeType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeCurrencyExchangeType|null
      */
     public function getTaxApplicableTradeCurrencyExchange()
     {
@@ -344,7 +344,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new taxApplicableTradeCurrencyExchange
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeCurrencyExchangeType $taxApplicableTradeCurrencyExchange
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeCurrencyExchangeType|null $taxApplicableTradeCurrencyExchange
      * @return self
      */
     public function setTaxApplicableTradeCurrencyExchange(?\horstoeko\zugferd\entities\extended\ram\TradeCurrencyExchangeType $taxApplicableTradeCurrencyExchange = null)
@@ -400,7 +400,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradeSettlementPaymentMeans
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeSettlementPaymentMeansType[] $specifiedTradeSettlementPaymentMeans
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeSettlementPaymentMeansType[]|null $specifiedTradeSettlementPaymentMeans
      * @return self
      */
     public function setSpecifiedTradeSettlementPaymentMeans(?array $specifiedTradeSettlementPaymentMeans = null)
@@ -468,7 +468,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as billingSpecifiedPeriod
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType
+     * @return \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType|null
      */
     public function getBillingSpecifiedPeriod()
     {
@@ -478,7 +478,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new billingSpecifiedPeriod
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @param  \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      * @return self
      */
     public function setBillingSpecifiedPeriod(?\horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType $billingSpecifiedPeriod = null)
@@ -534,7 +534,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAllowanceChargeType[] $specifiedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAllowanceChargeType[]|null $specifiedTradeAllowanceCharge
      * @return self
      */
     public function setSpecifiedTradeAllowanceCharge(?array $specifiedTradeAllowanceCharge = null)
@@ -590,7 +590,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedLogisticsServiceCharge
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\LogisticsServiceChargeType[] $specifiedLogisticsServiceCharge
+     * @param  \horstoeko\zugferd\entities\extended\ram\LogisticsServiceChargeType[]|null $specifiedLogisticsServiceCharge
      * @return self
      */
     public function setSpecifiedLogisticsServiceCharge(?array $specifiedLogisticsServiceCharge = null)
@@ -646,7 +646,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedTradePaymentTerms
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePaymentTermsType[] $specifiedTradePaymentTerms
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePaymentTermsType[]|null $specifiedTradePaymentTerms
      * @return self
      */
     public function setSpecifiedTradePaymentTerms(?array $specifiedTradePaymentTerms = null)
@@ -658,7 +658,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as specifiedTradeSettlementHeaderMonetarySummation
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeSettlementHeaderMonetarySummationType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeSettlementHeaderMonetarySummationType|null
      */
     public function getSpecifiedTradeSettlementHeaderMonetarySummation()
     {
@@ -724,7 +724,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedFinancialAdjustment
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\FinancialAdjustmentType[] $specifiedFinancialAdjustment
+     * @param  \horstoeko\zugferd\entities\extended\ram\FinancialAdjustmentType[]|null $specifiedFinancialAdjustment
      * @return self
      */
     public function setSpecifiedFinancialAdjustment(?array $specifiedFinancialAdjustment = null)
@@ -780,7 +780,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new invoiceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[] $invoiceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[]|null $invoiceReferencedDocument
      * @return self
      */
     public function setInvoiceReferencedDocument(?array $invoiceReferencedDocument = null)
@@ -836,7 +836,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new receivableSpecifiedTradeAccountingAccount
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAccountingAccountType[] $receivableSpecifiedTradeAccountingAccount
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAccountingAccountType[]|null $receivableSpecifiedTradeAccountingAccount
      * @return self
      */
     public function setReceivableSpecifiedTradeAccountingAccount(?array $receivableSpecifiedTradeAccountingAccount = null)
@@ -892,7 +892,7 @@ class HeaderTradeSettlementType
     /**
      * Sets a new specifiedAdvancePayment
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\AdvancePaymentType[] $specifiedAdvancePayment
+     * @param  \horstoeko\zugferd\entities\extended\ram\AdvancePaymentType[]|null $specifiedAdvancePayment
      * @return self
      */
     public function setSpecifiedAdvancePayment(?array $specifiedAdvancePayment = null)

--- a/src/entities/extended/ram/LegalOrganizationType.php
+++ b/src/entities/extended/ram/LegalOrganizationType.php
@@ -11,24 +11,24 @@ class LegalOrganizationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $tradingBusinessName
+     * @var string|null $tradingBusinessName
      */
     private $tradingBusinessName = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeAddressType $postalTradeAddress
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeAddressType|null $postalTradeAddress
      */
     private $postalTradeAddress = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getID()
     {
@@ -38,7 +38,7 @@ class LegalOrganizationType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      * @return self
      */
     public function setID(?\horstoeko\zugferd\entities\extended\udt\IDType $iD = null)
@@ -50,7 +50,7 @@ class LegalOrganizationType
     /**
      * Gets as tradingBusinessName
      *
-     * @return string
+     * @return string|null
      */
     public function getTradingBusinessName()
     {
@@ -72,7 +72,7 @@ class LegalOrganizationType
     /**
      * Gets as postalTradeAddress
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeAddressType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeAddressType|null
      */
     public function getPostalTradeAddress()
     {
@@ -82,7 +82,7 @@ class LegalOrganizationType
     /**
      * Sets a new postalTradeAddress
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAddressType $postalTradeAddress
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAddressType|null $postalTradeAddress
      * @return self
      */
     public function setPostalTradeAddress(?\horstoeko\zugferd\entities\extended\ram\TradeAddressType $postalTradeAddress = null)

--- a/src/entities/extended/ram/LineTradeAgreementType.php
+++ b/src/entities/extended/ram/LineTradeAgreementType.php
@@ -11,27 +11,27 @@ class LineTradeAgreementType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType $applicableTradeDeliveryTerms
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType|null $applicableTradeDeliveryTerms
      */
     private $applicableTradeDeliveryTerms = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $sellerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $sellerOrderReferencedDocument
      */
     private $sellerOrderReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      */
     private $buyerOrderReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $quotationReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $quotationReferencedDocument
      */
     private $quotationReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $contractReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $contractReferencedDocument
      */
     private $contractReferencedDocument = null;
 
@@ -43,17 +43,17 @@ class LineTradeAgreementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePriceType $grossPriceProductTradePrice
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePriceType|null $grossPriceProductTradePrice
      */
     private $grossPriceProductTradePrice = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePriceType $netPriceProductTradePrice
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePriceType|null $netPriceProductTradePrice
      */
     private $netPriceProductTradePrice = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $itemSellerTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $itemSellerTradeParty
      */
     private $itemSellerTradeParty = null;
 
@@ -67,7 +67,7 @@ class LineTradeAgreementType
     /**
      * Gets as applicableTradeDeliveryTerms
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType|null
      */
     public function getApplicableTradeDeliveryTerms()
     {
@@ -77,7 +77,7 @@ class LineTradeAgreementType
     /**
      * Sets a new applicableTradeDeliveryTerms
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType $applicableTradeDeliveryTerms
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType|null $applicableTradeDeliveryTerms
      * @return self
      */
     public function setApplicableTradeDeliveryTerms(?\horstoeko\zugferd\entities\extended\ram\TradeDeliveryTermsType $applicableTradeDeliveryTerms = null)
@@ -89,7 +89,7 @@ class LineTradeAgreementType
     /**
      * Gets as sellerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getSellerOrderReferencedDocument()
     {
@@ -99,7 +99,7 @@ class LineTradeAgreementType
     /**
      * Sets a new sellerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $sellerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $sellerOrderReferencedDocument
      * @return self
      */
     public function setSellerOrderReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $sellerOrderReferencedDocument = null)
@@ -111,7 +111,7 @@ class LineTradeAgreementType
     /**
      * Gets as buyerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getBuyerOrderReferencedDocument()
     {
@@ -121,7 +121,7 @@ class LineTradeAgreementType
     /**
      * Sets a new buyerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      * @return self
      */
     public function setBuyerOrderReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $buyerOrderReferencedDocument = null)
@@ -133,7 +133,7 @@ class LineTradeAgreementType
     /**
      * Gets as quotationReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getQuotationReferencedDocument()
     {
@@ -143,7 +143,7 @@ class LineTradeAgreementType
     /**
      * Sets a new quotationReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $quotationReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $quotationReferencedDocument
      * @return self
      */
     public function setQuotationReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $quotationReferencedDocument = null)
@@ -155,7 +155,7 @@ class LineTradeAgreementType
     /**
      * Gets as contractReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getContractReferencedDocument()
     {
@@ -165,7 +165,7 @@ class LineTradeAgreementType
     /**
      * Sets a new contractReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $contractReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $contractReferencedDocument
      * @return self
      */
     public function setContractReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $contractReferencedDocument = null)
@@ -221,7 +221,7 @@ class LineTradeAgreementType
     /**
      * Sets a new additionalReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[] $additionalReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[]|null $additionalReferencedDocument
      * @return self
      */
     public function setAdditionalReferencedDocument(?array $additionalReferencedDocument = null)
@@ -233,7 +233,7 @@ class LineTradeAgreementType
     /**
      * Gets as grossPriceProductTradePrice
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePriceType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePriceType|null
      */
     public function getGrossPriceProductTradePrice()
     {
@@ -243,7 +243,7 @@ class LineTradeAgreementType
     /**
      * Sets a new grossPriceProductTradePrice
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePriceType $grossPriceProductTradePrice
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePriceType|null $grossPriceProductTradePrice
      * @return self
      */
     public function setGrossPriceProductTradePrice(?\horstoeko\zugferd\entities\extended\ram\TradePriceType $grossPriceProductTradePrice = null)
@@ -255,7 +255,7 @@ class LineTradeAgreementType
     /**
      * Gets as netPriceProductTradePrice
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePriceType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePriceType|null
      */
     public function getNetPriceProductTradePrice()
     {
@@ -265,7 +265,7 @@ class LineTradeAgreementType
     /**
      * Sets a new netPriceProductTradePrice
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePriceType $netPriceProductTradePrice
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePriceType|null $netPriceProductTradePrice
      * @return self
      */
     public function setNetPriceProductTradePrice(?\horstoeko\zugferd\entities\extended\ram\TradePriceType $netPriceProductTradePrice = null)
@@ -277,7 +277,7 @@ class LineTradeAgreementType
     /**
      * Gets as itemSellerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getItemSellerTradeParty()
     {
@@ -287,7 +287,7 @@ class LineTradeAgreementType
     /**
      * Sets a new itemSellerTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $itemSellerTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $itemSellerTradeParty
      * @return self
      */
     public function setItemSellerTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $itemSellerTradeParty = null)
@@ -343,7 +343,7 @@ class LineTradeAgreementType
     /**
      * Sets a new ultimateCustomerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[] $ultimateCustomerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[]|null $ultimateCustomerOrderReferencedDocument
      * @return self
      */
     public function setUltimateCustomerOrderReferencedDocument(?array $ultimateCustomerOrderReferencedDocument = null)

--- a/src/entities/extended/ram/LineTradeDeliveryType.php
+++ b/src/entities/extended/ram/LineTradeDeliveryType.php
@@ -11,59 +11,59 @@ class LineTradeDeliveryType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType $billedQuantity
+     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType|null $billedQuantity
      */
     private $billedQuantity = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType $chargeFreeQuantity
+     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType|null $chargeFreeQuantity
      */
     private $chargeFreeQuantity = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType $packageQuantity
+     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType|null $packageQuantity
      */
     private $packageQuantity = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType $perPackageUnitQuantity
+     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType|null $perPackageUnitQuantity
      */
     private $perPackageUnitQuantity = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $shipToTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $shipToTradeParty
      */
     private $shipToTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $ultimateShipToTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $ultimateShipToTradeParty
      */
     private $ultimateShipToTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @var \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      */
     private $actualDeliverySupplyChainEvent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      */
     private $despatchAdviceReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $receivingAdviceReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $receivingAdviceReferencedDocument
      */
     private $receivingAdviceReferencedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $deliveryNoteReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $deliveryNoteReferencedDocument
      */
     private $deliveryNoteReferencedDocument = null;
 
     /**
      * Gets as billedQuantity
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType|null
      */
     public function getBilledQuantity()
     {
@@ -73,7 +73,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new billedQuantity
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType $billedQuantity
+     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType|null $billedQuantity
      * @return self
      */
     public function setBilledQuantity(?\horstoeko\zugferd\entities\extended\udt\QuantityType $billedQuantity = null)
@@ -85,7 +85,7 @@ class LineTradeDeliveryType
     /**
      * Gets as chargeFreeQuantity
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType|null
      */
     public function getChargeFreeQuantity()
     {
@@ -95,7 +95,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new chargeFreeQuantity
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType $chargeFreeQuantity
+     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType|null $chargeFreeQuantity
      * @return self
      */
     public function setChargeFreeQuantity(?\horstoeko\zugferd\entities\extended\udt\QuantityType $chargeFreeQuantity = null)
@@ -107,7 +107,7 @@ class LineTradeDeliveryType
     /**
      * Gets as packageQuantity
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType|null
      */
     public function getPackageQuantity()
     {
@@ -117,7 +117,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new packageQuantity
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType $packageQuantity
+     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType|null $packageQuantity
      * @return self
      */
     public function setPackageQuantity(?\horstoeko\zugferd\entities\extended\udt\QuantityType $packageQuantity = null)
@@ -129,7 +129,7 @@ class LineTradeDeliveryType
     /**
      * Gets as perPackageUnitQuantity
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType|null
      */
     public function getPerPackageUnitQuantity()
     {
@@ -139,7 +139,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new perPackageUnitQuantity
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType $perPackageUnitQuantity
+     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType|null $perPackageUnitQuantity
      * @return self
      */
     public function setPerPackageUnitQuantity(?\horstoeko\zugferd\entities\extended\udt\QuantityType $perPackageUnitQuantity = null)
@@ -151,7 +151,7 @@ class LineTradeDeliveryType
     /**
      * Gets as shipToTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getShipToTradeParty()
     {
@@ -161,7 +161,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new shipToTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $shipToTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $shipToTradeParty
      * @return self
      */
     public function setShipToTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $shipToTradeParty = null)
@@ -173,7 +173,7 @@ class LineTradeDeliveryType
     /**
      * Gets as ultimateShipToTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getUltimateShipToTradeParty()
     {
@@ -183,7 +183,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new ultimateShipToTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $ultimateShipToTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $ultimateShipToTradeParty
      * @return self
      */
     public function setUltimateShipToTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $ultimateShipToTradeParty = null)
@@ -195,7 +195,7 @@ class LineTradeDeliveryType
     /**
      * Gets as actualDeliverySupplyChainEvent
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType
+     * @return \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType|null
      */
     public function getActualDeliverySupplyChainEvent()
     {
@@ -205,7 +205,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new actualDeliverySupplyChainEvent
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType $actualDeliverySupplyChainEvent
+     * @param  \horstoeko\zugferd\entities\extended\ram\SupplyChainEventType|null $actualDeliverySupplyChainEvent
      * @return self
      */
     public function setActualDeliverySupplyChainEvent(?\horstoeko\zugferd\entities\extended\ram\SupplyChainEventType $actualDeliverySupplyChainEvent = null)
@@ -217,7 +217,7 @@ class LineTradeDeliveryType
     /**
      * Gets as despatchAdviceReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getDespatchAdviceReferencedDocument()
     {
@@ -227,7 +227,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new despatchAdviceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $despatchAdviceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $despatchAdviceReferencedDocument
      * @return self
      */
     public function setDespatchAdviceReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $despatchAdviceReferencedDocument = null)
@@ -239,7 +239,7 @@ class LineTradeDeliveryType
     /**
      * Gets as receivingAdviceReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getReceivingAdviceReferencedDocument()
     {
@@ -249,7 +249,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new receivingAdviceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $receivingAdviceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $receivingAdviceReferencedDocument
      * @return self
      */
     public function setReceivingAdviceReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $receivingAdviceReferencedDocument = null)
@@ -261,7 +261,7 @@ class LineTradeDeliveryType
     /**
      * Gets as deliveryNoteReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getDeliveryNoteReferencedDocument()
     {
@@ -271,7 +271,7 @@ class LineTradeDeliveryType
     /**
      * Sets a new deliveryNoteReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $deliveryNoteReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $deliveryNoteReferencedDocument
      * @return self
      */
     public function setDeliveryNoteReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $deliveryNoteReferencedDocument = null)

--- a/src/entities/extended/ram/LineTradeSettlementType.php
+++ b/src/entities/extended/ram/LineTradeSettlementType.php
@@ -18,7 +18,7 @@ class LineTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @var \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      */
     private $billingSpecifiedPeriod = null;
 
@@ -30,12 +30,12 @@ class LineTradeSettlementType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeSettlementLineMonetarySummationType $specifiedTradeSettlementLineMonetarySummation
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeSettlementLineMonetarySummationType|null $specifiedTradeSettlementLineMonetarySummation
      */
     private $specifiedTradeSettlementLineMonetarySummation = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $invoiceReferencedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $invoiceReferencedDocument
      */
     private $invoiceReferencedDocument = null;
 
@@ -100,7 +100,7 @@ class LineTradeSettlementType
     /**
      * Sets a new applicableTradeTax
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeTaxType[] $applicableTradeTax
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeTaxType[]|null $applicableTradeTax
      * @return self
      */
     public function setApplicableTradeTax(?array $applicableTradeTax = null)
@@ -112,7 +112,7 @@ class LineTradeSettlementType
     /**
      * Gets as billingSpecifiedPeriod
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType
+     * @return \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType|null
      */
     public function getBillingSpecifiedPeriod()
     {
@@ -122,7 +122,7 @@ class LineTradeSettlementType
     /**
      * Sets a new billingSpecifiedPeriod
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType $billingSpecifiedPeriod
+     * @param  \horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType|null $billingSpecifiedPeriod
      * @return self
      */
     public function setBillingSpecifiedPeriod(?\horstoeko\zugferd\entities\extended\ram\SpecifiedPeriodType $billingSpecifiedPeriod = null)
@@ -178,7 +178,7 @@ class LineTradeSettlementType
     /**
      * Sets a new specifiedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAllowanceChargeType[] $specifiedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAllowanceChargeType[]|null $specifiedTradeAllowanceCharge
      * @return self
      */
     public function setSpecifiedTradeAllowanceCharge(?array $specifiedTradeAllowanceCharge = null)
@@ -190,7 +190,7 @@ class LineTradeSettlementType
     /**
      * Gets as specifiedTradeSettlementLineMonetarySummation
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeSettlementLineMonetarySummationType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeSettlementLineMonetarySummationType|null
      */
     public function getSpecifiedTradeSettlementLineMonetarySummation()
     {
@@ -200,7 +200,7 @@ class LineTradeSettlementType
     /**
      * Sets a new specifiedTradeSettlementLineMonetarySummation
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeSettlementLineMonetarySummationType $specifiedTradeSettlementLineMonetarySummation
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeSettlementLineMonetarySummationType|null $specifiedTradeSettlementLineMonetarySummation
      * @return self
      */
     public function setSpecifiedTradeSettlementLineMonetarySummation(?\horstoeko\zugferd\entities\extended\ram\TradeSettlementLineMonetarySummationType $specifiedTradeSettlementLineMonetarySummation = null)
@@ -212,7 +212,7 @@ class LineTradeSettlementType
     /**
      * Gets as invoiceReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null
      */
     public function getInvoiceReferencedDocument()
     {
@@ -222,7 +222,7 @@ class LineTradeSettlementType
     /**
      * Sets a new invoiceReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $invoiceReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType|null $invoiceReferencedDocument
      * @return self
      */
     public function setInvoiceReferencedDocument(?\horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType $invoiceReferencedDocument = null)
@@ -278,7 +278,7 @@ class LineTradeSettlementType
     /**
      * Sets a new additionalReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[] $additionalReferencedDocument
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedDocumentType[]|null $additionalReferencedDocument
      * @return self
      */
     public function setAdditionalReferencedDocument(?array $additionalReferencedDocument = null)

--- a/src/entities/extended/ram/LogisticsServiceChargeType.php
+++ b/src/entities/extended/ram/LogisticsServiceChargeType.php
@@ -11,12 +11,12 @@ class LogisticsServiceChargeType
 {
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $appliedAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $appliedAmount
      */
     private $appliedAmount = null;
 
@@ -30,7 +30,7 @@ class LogisticsServiceChargeType
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -52,7 +52,7 @@ class LogisticsServiceChargeType
     /**
      * Gets as appliedAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getAppliedAmount()
     {

--- a/src/entities/extended/ram/LogisticsTransportMovementType.php
+++ b/src/entities/extended/ram/LogisticsTransportMovementType.php
@@ -11,14 +11,14 @@ class LogisticsTransportMovementType
 {
 
     /**
-     * @var string $modeCode
+     * @var string|null $modeCode
      */
     private $modeCode = null;
 
     /**
      * Gets as modeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getModeCode()
     {

--- a/src/entities/extended/ram/NoteType.php
+++ b/src/entities/extended/ram/NoteType.php
@@ -11,24 +11,24 @@ class NoteType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\CodeType $contentCode
+     * @var \horstoeko\zugferd\entities\extended\udt\CodeType|null $contentCode
      */
     private $contentCode = null;
 
     /**
-     * @var string $content
+     * @var string|null $content
      */
     private $content = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\CodeType $subjectCode
+     * @var \horstoeko\zugferd\entities\extended\udt\CodeType|null $subjectCode
      */
     private $subjectCode = null;
 
     /**
      * Gets as contentCode
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\CodeType
+     * @return \horstoeko\zugferd\entities\extended\udt\CodeType|null
      */
     public function getContentCode()
     {
@@ -38,7 +38,7 @@ class NoteType
     /**
      * Sets a new contentCode
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType $contentCode
+     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType|null $contentCode
      * @return self
      */
     public function setContentCode(?\horstoeko\zugferd\entities\extended\udt\CodeType $contentCode = null)
@@ -50,7 +50,7 @@ class NoteType
     /**
      * Gets as content
      *
-     * @return string
+     * @return string|null
      */
     public function getContent()
     {
@@ -72,7 +72,7 @@ class NoteType
     /**
      * Gets as subjectCode
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\CodeType
+     * @return \horstoeko\zugferd\entities\extended\udt\CodeType|null
      */
     public function getSubjectCode()
     {
@@ -82,7 +82,7 @@ class NoteType
     /**
      * Sets a new subjectCode
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType $subjectCode
+     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType|null $subjectCode
      * @return self
      */
     public function setSubjectCode(?\horstoeko\zugferd\entities\extended\udt\CodeType $subjectCode = null)

--- a/src/entities/extended/ram/ProcuringProjectType.php
+++ b/src/entities/extended/ram/ProcuringProjectType.php
@@ -11,19 +11,19 @@ class ProcuringProjectType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getID()
     {
@@ -45,7 +45,7 @@ class ProcuringProjectType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {

--- a/src/entities/extended/ram/ProductCharacteristicType.php
+++ b/src/entities/extended/ram/ProductCharacteristicType.php
@@ -11,29 +11,29 @@ class ProductCharacteristicType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\CodeType $typeCode
+     * @var \horstoeko\zugferd\entities\extended\udt\CodeType|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\MeasureType $valueMeasure
+     * @var \horstoeko\zugferd\entities\extended\udt\MeasureType|null $valueMeasure
      */
     private $valueMeasure = null;
 
     /**
-     * @var string $value
+     * @var string|null $value
      */
     private $value = null;
 
     /**
      * Gets as typeCode
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\CodeType
+     * @return \horstoeko\zugferd\entities\extended\udt\CodeType|null
      */
     public function getTypeCode()
     {
@@ -43,7 +43,7 @@ class ProductCharacteristicType
     /**
      * Sets a new typeCode
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType $typeCode
+     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType|null $typeCode
      * @return self
      */
     public function setTypeCode(?\horstoeko\zugferd\entities\extended\udt\CodeType $typeCode = null)
@@ -55,7 +55,7 @@ class ProductCharacteristicType
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -77,7 +77,7 @@ class ProductCharacteristicType
     /**
      * Gets as valueMeasure
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\MeasureType
+     * @return \horstoeko\zugferd\entities\extended\udt\MeasureType|null
      */
     public function getValueMeasure()
     {
@@ -87,7 +87,7 @@ class ProductCharacteristicType
     /**
      * Sets a new valueMeasure
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\MeasureType $valueMeasure
+     * @param  \horstoeko\zugferd\entities\extended\udt\MeasureType|null $valueMeasure
      * @return self
      */
     public function setValueMeasure(?\horstoeko\zugferd\entities\extended\udt\MeasureType $valueMeasure = null)
@@ -99,7 +99,7 @@ class ProductCharacteristicType
     /**
      * Gets as value
      *
-     * @return string
+     * @return string|null
      */
     public function getValue()
     {

--- a/src/entities/extended/ram/ProductClassificationType.php
+++ b/src/entities/extended/ram/ProductClassificationType.php
@@ -11,19 +11,19 @@ class ProductClassificationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\CodeType $classCode
+     * @var \horstoeko\zugferd\entities\extended\udt\CodeType|null $classCode
      */
     private $classCode = null;
 
     /**
-     * @var string $className
+     * @var string|null $className
      */
     private $className = null;
 
     /**
      * Gets as classCode
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\CodeType
+     * @return \horstoeko\zugferd\entities\extended\udt\CodeType|null
      */
     public function getClassCode()
     {
@@ -33,7 +33,7 @@ class ProductClassificationType
     /**
      * Sets a new classCode
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType $classCode
+     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType|null $classCode
      * @return self
      */
     public function setClassCode(?\horstoeko\zugferd\entities\extended\udt\CodeType $classCode = null)
@@ -45,7 +45,7 @@ class ProductClassificationType
     /**
      * Gets as className
      *
-     * @return string
+     * @return string|null
      */
     public function getClassName()
     {

--- a/src/entities/extended/ram/ReferencedDocumentType.php
+++ b/src/entities/extended/ram/ReferencedDocumentType.php
@@ -11,49 +11,49 @@ class ReferencedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $issuerAssignedID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $issuerAssignedID
      */
     private $issuerAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $uRIID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $uRIID
      */
     private $uRIID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $lineID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $lineID
      */
     private $lineID = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\BinaryObjectType $attachmentBinaryObject
+     * @var \horstoeko\zugferd\entities\extended\udt\BinaryObjectType|null $attachmentBinaryObject
      */
     private $attachmentBinaryObject = null;
 
     /**
-     * @var string $referenceTypeCode
+     * @var string|null $referenceTypeCode
      */
     private $referenceTypeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType $formattedIssueDateTime
+     * @var \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType|null $formattedIssueDateTime
      */
     private $formattedIssueDateTime = null;
 
     /**
      * Gets as issuerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getIssuerAssignedID()
     {
@@ -63,7 +63,7 @@ class ReferencedDocumentType
     /**
      * Sets a new issuerAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $issuerAssignedID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $issuerAssignedID
      * @return self
      */
     public function setIssuerAssignedID(?\horstoeko\zugferd\entities\extended\udt\IDType $issuerAssignedID = null)
@@ -75,7 +75,7 @@ class ReferencedDocumentType
     /**
      * Gets as uRIID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getURIID()
     {
@@ -85,7 +85,7 @@ class ReferencedDocumentType
     /**
      * Sets a new uRIID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $uRIID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $uRIID
      * @return self
      */
     public function setURIID(?\horstoeko\zugferd\entities\extended\udt\IDType $uRIID = null)
@@ -97,7 +97,7 @@ class ReferencedDocumentType
     /**
      * Gets as lineID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getLineID()
     {
@@ -107,7 +107,7 @@ class ReferencedDocumentType
     /**
      * Sets a new lineID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $lineID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $lineID
      * @return self
      */
     public function setLineID(?\horstoeko\zugferd\entities\extended\udt\IDType $lineID = null)
@@ -119,7 +119,7 @@ class ReferencedDocumentType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -141,7 +141,7 @@ class ReferencedDocumentType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -163,7 +163,7 @@ class ReferencedDocumentType
     /**
      * Gets as attachmentBinaryObject
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\BinaryObjectType
+     * @return \horstoeko\zugferd\entities\extended\udt\BinaryObjectType|null
      */
     public function getAttachmentBinaryObject()
     {
@@ -173,7 +173,7 @@ class ReferencedDocumentType
     /**
      * Sets a new attachmentBinaryObject
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\BinaryObjectType $attachmentBinaryObject
+     * @param  \horstoeko\zugferd\entities\extended\udt\BinaryObjectType|null $attachmentBinaryObject
      * @return self
      */
     public function setAttachmentBinaryObject(?\horstoeko\zugferd\entities\extended\udt\BinaryObjectType $attachmentBinaryObject = null)
@@ -185,7 +185,7 @@ class ReferencedDocumentType
     /**
      * Gets as referenceTypeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getReferenceTypeCode()
     {
@@ -207,7 +207,7 @@ class ReferencedDocumentType
     /**
      * Gets as formattedIssueDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType
+     * @return \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType|null
      */
     public function getFormattedIssueDateTime()
     {
@@ -217,7 +217,7 @@ class ReferencedDocumentType
     /**
      * Sets a new formattedIssueDateTime
      *
-     * @param  \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType $formattedIssueDateTime
+     * @param  \horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType|null $formattedIssueDateTime
      * @return self
      */
     public function setFormattedIssueDateTime(?\horstoeko\zugferd\entities\extended\qdt\FormattedDateTimeType $formattedIssueDateTime = null)

--- a/src/entities/extended/ram/ReferencedProductType.php
+++ b/src/entities/extended/ram/ReferencedProductType.php
@@ -11,7 +11,7 @@ class ReferencedProductType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      */
     private $iD = null;
 
@@ -23,39 +23,39 @@ class ReferencedProductType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $sellerAssignedID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $sellerAssignedID
      */
     private $sellerAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $buyerAssignedID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $buyerAssignedID
      */
     private $buyerAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $industryAssignedID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $industryAssignedID
      */
     private $industryAssignedID = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType $unitQuantity
+     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType|null $unitQuantity
      */
     private $unitQuantity = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getID()
     {
@@ -65,7 +65,7 @@ class ReferencedProductType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      * @return self
      */
     public function setID(?\horstoeko\zugferd\entities\extended\udt\IDType $iD = null)
@@ -121,7 +121,7 @@ class ReferencedProductType
     /**
      * Sets a new globalID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType[] $globalID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType[]|null $globalID
      * @return self
      */
     public function setGlobalID(?array $globalID = null)
@@ -133,7 +133,7 @@ class ReferencedProductType
     /**
      * Gets as sellerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getSellerAssignedID()
     {
@@ -143,7 +143,7 @@ class ReferencedProductType
     /**
      * Sets a new sellerAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $sellerAssignedID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $sellerAssignedID
      * @return self
      */
     public function setSellerAssignedID(?\horstoeko\zugferd\entities\extended\udt\IDType $sellerAssignedID = null)
@@ -155,7 +155,7 @@ class ReferencedProductType
     /**
      * Gets as buyerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getBuyerAssignedID()
     {
@@ -165,7 +165,7 @@ class ReferencedProductType
     /**
      * Sets a new buyerAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $buyerAssignedID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $buyerAssignedID
      * @return self
      */
     public function setBuyerAssignedID(?\horstoeko\zugferd\entities\extended\udt\IDType $buyerAssignedID = null)
@@ -177,7 +177,7 @@ class ReferencedProductType
     /**
      * Gets as industryAssignedID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getIndustryAssignedID()
     {
@@ -187,7 +187,7 @@ class ReferencedProductType
     /**
      * Sets a new industryAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $industryAssignedID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $industryAssignedID
      * @return self
      */
     public function setIndustryAssignedID(?\horstoeko\zugferd\entities\extended\udt\IDType $industryAssignedID = null)
@@ -199,7 +199,7 @@ class ReferencedProductType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -221,7 +221,7 @@ class ReferencedProductType
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -243,7 +243,7 @@ class ReferencedProductType
     /**
      * Gets as unitQuantity
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType|null
      */
     public function getUnitQuantity()
     {
@@ -253,7 +253,7 @@ class ReferencedProductType
     /**
      * Sets a new unitQuantity
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType $unitQuantity
+     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType|null $unitQuantity
      * @return self
      */
     public function setUnitQuantity(?\horstoeko\zugferd\entities\extended\udt\QuantityType $unitQuantity = null)

--- a/src/entities/extended/ram/SpecifiedPeriodType.php
+++ b/src/entities/extended/ram/SpecifiedPeriodType.php
@@ -11,29 +11,29 @@ class SpecifiedPeriodType
 {
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType $startDateTime
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $startDateTime
      */
     private $startDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType $endDateTime
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $endDateTime
      */
     private $endDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType $completeDateTime
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $completeDateTime
      */
     private $completeDateTime = null;
 
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -55,7 +55,7 @@ class SpecifiedPeriodType
     /**
      * Gets as startDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType|null
      */
     public function getStartDateTime()
     {
@@ -65,7 +65,7 @@ class SpecifiedPeriodType
     /**
      * Sets a new startDateTime
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType $startDateTime
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $startDateTime
      * @return self
      */
     public function setStartDateTime(?\horstoeko\zugferd\entities\extended\udt\DateTimeType $startDateTime = null)
@@ -77,7 +77,7 @@ class SpecifiedPeriodType
     /**
      * Gets as endDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType|null
      */
     public function getEndDateTime()
     {
@@ -87,7 +87,7 @@ class SpecifiedPeriodType
     /**
      * Sets a new endDateTime
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType $endDateTime
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $endDateTime
      * @return self
      */
     public function setEndDateTime(?\horstoeko\zugferd\entities\extended\udt\DateTimeType $endDateTime = null)
@@ -99,7 +99,7 @@ class SpecifiedPeriodType
     /**
      * Gets as completeDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType|null
      */
     public function getCompleteDateTime()
     {
@@ -109,7 +109,7 @@ class SpecifiedPeriodType
     /**
      * Sets a new completeDateTime
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType $completeDateTime
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $completeDateTime
      * @return self
      */
     public function setCompleteDateTime(?\horstoeko\zugferd\entities\extended\udt\DateTimeType $completeDateTime = null)

--- a/src/entities/extended/ram/SupplyChainConsignmentType.php
+++ b/src/entities/extended/ram/SupplyChainConsignmentType.php
@@ -64,7 +64,7 @@ class SupplyChainConsignmentType
     /**
      * Sets a new specifiedLogisticsTransportMovement
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\LogisticsTransportMovementType[] $specifiedLogisticsTransportMovement
+     * @param  \horstoeko\zugferd\entities\extended\ram\LogisticsTransportMovementType[]|null $specifiedLogisticsTransportMovement
      * @return self
      */
     public function setSpecifiedLogisticsTransportMovement(?array $specifiedLogisticsTransportMovement = null)

--- a/src/entities/extended/ram/SupplyChainEventType.php
+++ b/src/entities/extended/ram/SupplyChainEventType.php
@@ -11,14 +11,14 @@ class SupplyChainEventType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType $occurrenceDateTime
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $occurrenceDateTime
      */
     private $occurrenceDateTime = null;
 
     /**
      * Gets as occurrenceDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType|null
      */
     public function getOccurrenceDateTime()
     {

--- a/src/entities/extended/ram/SupplyChainTradeLineItemType.php
+++ b/src/entities/extended/ram/SupplyChainTradeLineItemType.php
@@ -11,34 +11,34 @@ class SupplyChainTradeLineItemType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\DocumentLineDocumentType $associatedDocumentLineDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\DocumentLineDocumentType|null $associatedDocumentLineDocument
      */
     private $associatedDocumentLineDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeProductType $specifiedTradeProduct
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeProductType|null $specifiedTradeProduct
      */
     private $specifiedTradeProduct = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\LineTradeAgreementType $specifiedLineTradeAgreement
+     * @var \horstoeko\zugferd\entities\extended\ram\LineTradeAgreementType|null $specifiedLineTradeAgreement
      */
     private $specifiedLineTradeAgreement = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\LineTradeDeliveryType $specifiedLineTradeDelivery
+     * @var \horstoeko\zugferd\entities\extended\ram\LineTradeDeliveryType|null $specifiedLineTradeDelivery
      */
     private $specifiedLineTradeDelivery = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\LineTradeSettlementType $specifiedLineTradeSettlement
+     * @var \horstoeko\zugferd\entities\extended\ram\LineTradeSettlementType|null $specifiedLineTradeSettlement
      */
     private $specifiedLineTradeSettlement = null;
 
     /**
      * Gets as associatedDocumentLineDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\DocumentLineDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\DocumentLineDocumentType|null
      */
     public function getAssociatedDocumentLineDocument()
     {
@@ -60,7 +60,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedTradeProduct
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeProductType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeProductType|null
      */
     public function getSpecifiedTradeProduct()
     {
@@ -82,7 +82,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedLineTradeAgreement
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\LineTradeAgreementType
+     * @return \horstoeko\zugferd\entities\extended\ram\LineTradeAgreementType|null
      */
     public function getSpecifiedLineTradeAgreement()
     {
@@ -92,7 +92,7 @@ class SupplyChainTradeLineItemType
     /**
      * Sets a new specifiedLineTradeAgreement
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\LineTradeAgreementType $specifiedLineTradeAgreement
+     * @param  \horstoeko\zugferd\entities\extended\ram\LineTradeAgreementType|null $specifiedLineTradeAgreement
      * @return self
      */
     public function setSpecifiedLineTradeAgreement(?\horstoeko\zugferd\entities\extended\ram\LineTradeAgreementType $specifiedLineTradeAgreement = null)
@@ -104,7 +104,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedLineTradeDelivery
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\LineTradeDeliveryType
+     * @return \horstoeko\zugferd\entities\extended\ram\LineTradeDeliveryType|null
      */
     public function getSpecifiedLineTradeDelivery()
     {
@@ -114,7 +114,7 @@ class SupplyChainTradeLineItemType
     /**
      * Sets a new specifiedLineTradeDelivery
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\LineTradeDeliveryType $specifiedLineTradeDelivery
+     * @param  \horstoeko\zugferd\entities\extended\ram\LineTradeDeliveryType|null $specifiedLineTradeDelivery
      * @return self
      */
     public function setSpecifiedLineTradeDelivery(?\horstoeko\zugferd\entities\extended\ram\LineTradeDeliveryType $specifiedLineTradeDelivery = null)
@@ -126,7 +126,7 @@ class SupplyChainTradeLineItemType
     /**
      * Gets as specifiedLineTradeSettlement
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\LineTradeSettlementType
+     * @return \horstoeko\zugferd\entities\extended\ram\LineTradeSettlementType|null
      */
     public function getSpecifiedLineTradeSettlement()
     {

--- a/src/entities/extended/ram/SupplyChainTradeTransactionType.php
+++ b/src/entities/extended/ram/SupplyChainTradeTransactionType.php
@@ -18,17 +18,17 @@ class SupplyChainTradeTransactionType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\HeaderTradeAgreementType $applicableHeaderTradeAgreement
+     * @var \horstoeko\zugferd\entities\extended\ram\HeaderTradeAgreementType|null $applicableHeaderTradeAgreement
      */
     private $applicableHeaderTradeAgreement = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\HeaderTradeDeliveryType $applicableHeaderTradeDelivery
+     * @var \horstoeko\zugferd\entities\extended\ram\HeaderTradeDeliveryType|null $applicableHeaderTradeDelivery
      */
     private $applicableHeaderTradeDelivery = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\HeaderTradeSettlementType $applicableHeaderTradeSettlement
+     * @var \horstoeko\zugferd\entities\extended\ram\HeaderTradeSettlementType|null $applicableHeaderTradeSettlement
      */
     private $applicableHeaderTradeSettlement = null;
 
@@ -91,7 +91,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeAgreement
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\HeaderTradeAgreementType
+     * @return \horstoeko\zugferd\entities\extended\ram\HeaderTradeAgreementType|null
      */
     public function getApplicableHeaderTradeAgreement()
     {
@@ -113,7 +113,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeDelivery
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\HeaderTradeDeliveryType
+     * @return \horstoeko\zugferd\entities\extended\ram\HeaderTradeDeliveryType|null
      */
     public function getApplicableHeaderTradeDelivery()
     {
@@ -135,7 +135,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeSettlement
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\HeaderTradeSettlementType
+     * @return \horstoeko\zugferd\entities\extended\ram\HeaderTradeSettlementType|null
      */
     public function getApplicableHeaderTradeSettlement()
     {

--- a/src/entities/extended/ram/TaxRegistrationType.php
+++ b/src/entities/extended/ram/TaxRegistrationType.php
@@ -11,14 +11,14 @@ class TaxRegistrationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/extended/ram/TradeAccountingAccountType.php
+++ b/src/entities/extended/ram/TradeAccountingAccountType.php
@@ -11,19 +11,19 @@ class TradeAccountingAccountType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getID()
     {
@@ -45,7 +45,7 @@ class TradeAccountingAccountType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {

--- a/src/entities/extended/ram/TradeAddressType.php
+++ b/src/entities/extended/ram/TradeAddressType.php
@@ -11,44 +11,44 @@ class TradeAddressType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\CodeType $postcodeCode
+     * @var \horstoeko\zugferd\entities\extended\udt\CodeType|null $postcodeCode
      */
     private $postcodeCode = null;
 
     /**
-     * @var string $lineOne
+     * @var string|null $lineOne
      */
     private $lineOne = null;
 
     /**
-     * @var string $lineTwo
+     * @var string|null $lineTwo
      */
     private $lineTwo = null;
 
     /**
-     * @var string $lineThree
+     * @var string|null $lineThree
      */
     private $lineThree = null;
 
     /**
-     * @var string $cityName
+     * @var string|null $cityName
      */
     private $cityName = null;
 
     /**
-     * @var string $countryID
+     * @var string|null $countryID
      */
     private $countryID = null;
 
     /**
-     * @var string $countrySubDivisionName
+     * @var string|null $countrySubDivisionName
      */
     private $countrySubDivisionName = null;
 
     /**
      * Gets as postcodeCode
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\CodeType
+     * @return \horstoeko\zugferd\entities\extended\udt\CodeType|null
      */
     public function getPostcodeCode()
     {
@@ -58,7 +58,7 @@ class TradeAddressType
     /**
      * Sets a new postcodeCode
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType $postcodeCode
+     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType|null $postcodeCode
      * @return self
      */
     public function setPostcodeCode(?\horstoeko\zugferd\entities\extended\udt\CodeType $postcodeCode = null)
@@ -70,7 +70,7 @@ class TradeAddressType
     /**
      * Gets as lineOne
      *
-     * @return string
+     * @return string|null
      */
     public function getLineOne()
     {
@@ -92,7 +92,7 @@ class TradeAddressType
     /**
      * Gets as lineTwo
      *
-     * @return string
+     * @return string|null
      */
     public function getLineTwo()
     {
@@ -114,7 +114,7 @@ class TradeAddressType
     /**
      * Gets as lineThree
      *
-     * @return string
+     * @return string|null
      */
     public function getLineThree()
     {
@@ -136,7 +136,7 @@ class TradeAddressType
     /**
      * Gets as cityName
      *
-     * @return string
+     * @return string|null
      */
     public function getCityName()
     {
@@ -158,7 +158,7 @@ class TradeAddressType
     /**
      * Gets as countryID
      *
-     * @return string
+     * @return string|null
      */
     public function getCountryID()
     {
@@ -180,7 +180,7 @@ class TradeAddressType
     /**
      * Gets as countrySubDivisionName
      *
-     * @return string
+     * @return string|null
      */
     public function getCountrySubDivisionName()
     {

--- a/src/entities/extended/ram/TradeAllowanceChargeType.php
+++ b/src/entities/extended/ram/TradeAllowanceChargeType.php
@@ -11,54 +11,54 @@ class TradeAllowanceChargeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IndicatorType $chargeIndicator
+     * @var \horstoeko\zugferd\entities\extended\udt\IndicatorType|null $chargeIndicator
      */
     private $chargeIndicator = null;
 
     /**
-     * @var float $sequenceNumeric
+     * @var float|null $sequenceNumeric
      */
     private $sequenceNumeric = null;
 
     /**
-     * @var float $calculationPercent
+     * @var float|null $calculationPercent
      */
     private $calculationPercent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType $basisQuantity
+     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType|null $basisQuantity
      */
     private $basisQuantity = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $actualAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $actualAmount
      */
     private $actualAmount = null;
 
     /**
-     * @var string $reasonCode
+     * @var string|null $reasonCode
      */
     private $reasonCode = null;
 
     /**
-     * @var string $reason
+     * @var string|null $reason
      */
     private $reason = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeTaxType $categoryTradeTax
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeTaxType|null $categoryTradeTax
      */
     private $categoryTradeTax = null;
 
     /**
      * Gets as chargeIndicator
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IndicatorType
+     * @return \horstoeko\zugferd\entities\extended\udt\IndicatorType|null
      */
     public function getChargeIndicator()
     {
@@ -80,7 +80,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as sequenceNumeric
      *
-     * @return float
+     * @return float|null
      */
     public function getSequenceNumeric()
     {
@@ -102,7 +102,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as calculationPercent
      *
-     * @return float
+     * @return float|null
      */
     public function getCalculationPercent()
     {
@@ -124,7 +124,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -134,7 +134,7 @@ class TradeAllowanceChargeType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount = null)
@@ -146,7 +146,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as basisQuantity
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType|null
      */
     public function getBasisQuantity()
     {
@@ -156,7 +156,7 @@ class TradeAllowanceChargeType
     /**
      * Sets a new basisQuantity
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType $basisQuantity
+     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType|null $basisQuantity
      * @return self
      */
     public function setBasisQuantity(?\horstoeko\zugferd\entities\extended\udt\QuantityType $basisQuantity = null)
@@ -168,7 +168,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as actualAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getActualAmount()
     {
@@ -190,7 +190,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as reasonCode
      *
-     * @return string
+     * @return string|null
      */
     public function getReasonCode()
     {
@@ -212,7 +212,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as reason
      *
-     * @return string
+     * @return string|null
      */
     public function getReason()
     {
@@ -234,7 +234,7 @@ class TradeAllowanceChargeType
     /**
      * Gets as categoryTradeTax
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeTaxType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeTaxType|null
      */
     public function getCategoryTradeTax()
     {
@@ -244,7 +244,7 @@ class TradeAllowanceChargeType
     /**
      * Sets a new categoryTradeTax
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeTaxType $categoryTradeTax
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeTaxType|null $categoryTradeTax
      * @return self
      */
     public function setCategoryTradeTax(?\horstoeko\zugferd\entities\extended\ram\TradeTaxType $categoryTradeTax = null)

--- a/src/entities/extended/ram/TradeContactType.php
+++ b/src/entities/extended/ram/TradeContactType.php
@@ -11,39 +11,39 @@ class TradeContactType
 {
 
     /**
-     * @var string $personName
+     * @var string|null $personName
      */
     private $personName = null;
 
     /**
-     * @var string $departmentName
+     * @var string|null $departmentName
      */
     private $departmentName = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $telephoneUniversalCommunication
+     * @var \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null $telephoneUniversalCommunication
      */
     private $telephoneUniversalCommunication = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $faxUniversalCommunication
+     * @var \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null $faxUniversalCommunication
      */
     private $faxUniversalCommunication = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $emailURIUniversalCommunication
+     * @var \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null $emailURIUniversalCommunication
      */
     private $emailURIUniversalCommunication = null;
 
     /**
      * Gets as personName
      *
-     * @return string
+     * @return string|null
      */
     public function getPersonName()
     {
@@ -65,7 +65,7 @@ class TradeContactType
     /**
      * Gets as departmentName
      *
-     * @return string
+     * @return string|null
      */
     public function getDepartmentName()
     {
@@ -87,7 +87,7 @@ class TradeContactType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -109,7 +109,7 @@ class TradeContactType
     /**
      * Gets as telephoneUniversalCommunication
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType
+     * @return \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null
      */
     public function getTelephoneUniversalCommunication()
     {
@@ -119,7 +119,7 @@ class TradeContactType
     /**
      * Sets a new telephoneUniversalCommunication
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $telephoneUniversalCommunication
+     * @param  \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null $telephoneUniversalCommunication
      * @return self
      */
     public function setTelephoneUniversalCommunication(?\horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $telephoneUniversalCommunication = null)
@@ -131,7 +131,7 @@ class TradeContactType
     /**
      * Gets as faxUniversalCommunication
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType
+     * @return \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null
      */
     public function getFaxUniversalCommunication()
     {
@@ -141,7 +141,7 @@ class TradeContactType
     /**
      * Sets a new faxUniversalCommunication
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $faxUniversalCommunication
+     * @param  \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null $faxUniversalCommunication
      * @return self
      */
     public function setFaxUniversalCommunication(?\horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $faxUniversalCommunication = null)
@@ -153,7 +153,7 @@ class TradeContactType
     /**
      * Gets as emailURIUniversalCommunication
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType
+     * @return \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null
      */
     public function getEmailURIUniversalCommunication()
     {
@@ -163,7 +163,7 @@ class TradeContactType
     /**
      * Sets a new emailURIUniversalCommunication
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $emailURIUniversalCommunication
+     * @param  \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null $emailURIUniversalCommunication
      * @return self
      */
     public function setEmailURIUniversalCommunication(?\horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $emailURIUniversalCommunication = null)

--- a/src/entities/extended/ram/TradeCountryType.php
+++ b/src/entities/extended/ram/TradeCountryType.php
@@ -11,14 +11,14 @@ class TradeCountryType
 {
 
     /**
-     * @var string $iD
+     * @var string|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return string
+     * @return string|null
      */
     public function getID()
     {

--- a/src/entities/extended/ram/TradeCurrencyExchangeType.php
+++ b/src/entities/extended/ram/TradeCurrencyExchangeType.php
@@ -11,29 +11,29 @@ class TradeCurrencyExchangeType
 {
 
     /**
-     * @var string $sourceCurrencyCode
+     * @var string|null $sourceCurrencyCode
      */
     private $sourceCurrencyCode = null;
 
     /**
-     * @var string $targetCurrencyCode
+     * @var string|null $targetCurrencyCode
      */
     private $targetCurrencyCode = null;
 
     /**
-     * @var float $conversionRate
+     * @var float|null $conversionRate
      */
     private $conversionRate = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType $conversionRateDateTime
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $conversionRateDateTime
      */
     private $conversionRateDateTime = null;
 
     /**
      * Gets as sourceCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getSourceCurrencyCode()
     {
@@ -55,7 +55,7 @@ class TradeCurrencyExchangeType
     /**
      * Gets as targetCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTargetCurrencyCode()
     {
@@ -77,7 +77,7 @@ class TradeCurrencyExchangeType
     /**
      * Gets as conversionRate
      *
-     * @return float
+     * @return float|null
      */
     public function getConversionRate()
     {
@@ -99,7 +99,7 @@ class TradeCurrencyExchangeType
     /**
      * Gets as conversionRateDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType|null
      */
     public function getConversionRateDateTime()
     {
@@ -109,7 +109,7 @@ class TradeCurrencyExchangeType
     /**
      * Sets a new conversionRateDateTime
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType $conversionRateDateTime
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $conversionRateDateTime
      * @return self
      */
     public function setConversionRateDateTime(?\horstoeko\zugferd\entities\extended\udt\DateTimeType $conversionRateDateTime = null)

--- a/src/entities/extended/ram/TradeDeliveryTermsType.php
+++ b/src/entities/extended/ram/TradeDeliveryTermsType.php
@@ -11,19 +11,19 @@ class TradeDeliveryTermsType
 {
 
     /**
-     * @var string $deliveryTypeCode
+     * @var string|null $deliveryTypeCode
      */
     private $deliveryTypeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeLocationType $relevantTradeLocation
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeLocationType|null $relevantTradeLocation
      */
     private $relevantTradeLocation = null;
 
     /**
      * Gets as deliveryTypeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getDeliveryTypeCode()
     {
@@ -45,7 +45,7 @@ class TradeDeliveryTermsType
     /**
      * Gets as relevantTradeLocation
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeLocationType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeLocationType|null
      */
     public function getRelevantTradeLocation()
     {
@@ -55,7 +55,7 @@ class TradeDeliveryTermsType
     /**
      * Sets a new relevantTradeLocation
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeLocationType $relevantTradeLocation
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeLocationType|null $relevantTradeLocation
      * @return self
      */
     public function setRelevantTradeLocation(?\horstoeko\zugferd\entities\extended\ram\TradeLocationType $relevantTradeLocation = null)

--- a/src/entities/extended/ram/TradeLocationType.php
+++ b/src/entities/extended/ram/TradeLocationType.php
@@ -11,19 +11,19 @@ class TradeLocationType
 {
 
     /**
-     * @var string $countryID
+     * @var string|null $countryID
      */
     private $countryID = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
      * Gets as countryID
      *
-     * @return string
+     * @return string|null
      */
     public function getCountryID()
     {
@@ -45,7 +45,7 @@ class TradeLocationType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {

--- a/src/entities/extended/ram/TradePartyType.php
+++ b/src/entities/extended/ram/TradePartyType.php
@@ -25,22 +25,22 @@ class TradePartyType
     ];
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var string $roleCode
+     * @var string|null $roleCode
      */
     private $roleCode = null;
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @var \horstoeko\zugferd\entities\extended\ram\LegalOrganizationType|null $specifiedLegalOrganization
      */
     private $specifiedLegalOrganization = null;
 
@@ -52,12 +52,12 @@ class TradePartyType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeAddressType $postalTradeAddress
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeAddressType|null $postalTradeAddress
      */
     private $postalTradeAddress = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $uRIUniversalCommunication
+     * @var \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null $uRIUniversalCommunication
      */
     private $uRIUniversalCommunication = null;
 
@@ -115,7 +115,7 @@ class TradePartyType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType[] $iD
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType[]|null $iD
      * @return self
      */
     public function setID(?array $iD = null)
@@ -171,7 +171,7 @@ class TradePartyType
     /**
      * Sets a new globalID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType[] $globalID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType[]|null $globalID
      * @return self
      */
     public function setGlobalID(?array $globalID = null)
@@ -183,7 +183,7 @@ class TradePartyType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -205,7 +205,7 @@ class TradePartyType
     /**
      * Gets as roleCode
      *
-     * @return string
+     * @return string|null
      */
     public function getRoleCode()
     {
@@ -227,7 +227,7 @@ class TradePartyType
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -249,7 +249,7 @@ class TradePartyType
     /**
      * Gets as specifiedLegalOrganization
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\LegalOrganizationType
+     * @return \horstoeko\zugferd\entities\extended\ram\LegalOrganizationType|null
      */
     public function getSpecifiedLegalOrganization()
     {
@@ -259,7 +259,7 @@ class TradePartyType
     /**
      * Sets a new specifiedLegalOrganization
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @param  \horstoeko\zugferd\entities\extended\ram\LegalOrganizationType|null $specifiedLegalOrganization
      * @return self
      */
     public function setSpecifiedLegalOrganization(?\horstoeko\zugferd\entities\extended\ram\LegalOrganizationType $specifiedLegalOrganization = null)
@@ -315,7 +315,7 @@ class TradePartyType
     /**
      * Sets a new definedTradeContact
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeContactType[] $definedTradeContact
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeContactType[]|null $definedTradeContact
      * @return self
      */
     public function setDefinedTradeContact(?array $definedTradeContact = null)
@@ -327,7 +327,7 @@ class TradePartyType
     /**
      * Gets as postalTradeAddress
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeAddressType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeAddressType|null
      */
     public function getPostalTradeAddress()
     {
@@ -337,7 +337,7 @@ class TradePartyType
     /**
      * Sets a new postalTradeAddress
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAddressType $postalTradeAddress
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAddressType|null $postalTradeAddress
      * @return self
      */
     public function setPostalTradeAddress(?\horstoeko\zugferd\entities\extended\ram\TradeAddressType $postalTradeAddress = null)
@@ -349,7 +349,7 @@ class TradePartyType
     /**
      * Gets as uRIUniversalCommunication
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType
+     * @return \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null
      */
     public function getURIUniversalCommunication()
     {
@@ -359,7 +359,7 @@ class TradePartyType
     /**
      * Sets a new uRIUniversalCommunication
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $uRIUniversalCommunication
+     * @param  \horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType|null $uRIUniversalCommunication
      * @return self
      */
     public function setURIUniversalCommunication(?\horstoeko\zugferd\entities\extended\ram\UniversalCommunicationType $uRIUniversalCommunication = null)
@@ -415,7 +415,7 @@ class TradePartyType
     /**
      * Sets a new specifiedTaxRegistration
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TaxRegistrationType[] $specifiedTaxRegistration
+     * @param  \horstoeko\zugferd\entities\extended\ram\TaxRegistrationType[]|null $specifiedTaxRegistration
      * @return self
      */
     public function setSpecifiedTaxRegistration(?array $specifiedTaxRegistration = null)

--- a/src/entities/extended/ram/TradePaymentDiscountTermsType.php
+++ b/src/entities/extended/ram/TradePaymentDiscountTermsType.php
@@ -11,34 +11,34 @@ class TradePaymentDiscountTermsType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType $basisDateTime
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $basisDateTime
      */
     private $basisDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\MeasureType $basisPeriodMeasure
+     * @var \horstoeko\zugferd\entities\extended\udt\MeasureType|null $basisPeriodMeasure
      */
     private $basisPeriodMeasure = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var float $calculationPercent
+     * @var float|null $calculationPercent
      */
     private $calculationPercent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $actualDiscountAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $actualDiscountAmount
      */
     private $actualDiscountAmount = null;
 
     /**
      * Gets as basisDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType|null
      */
     public function getBasisDateTime()
     {
@@ -48,7 +48,7 @@ class TradePaymentDiscountTermsType
     /**
      * Sets a new basisDateTime
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType $basisDateTime
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $basisDateTime
      * @return self
      */
     public function setBasisDateTime(?\horstoeko\zugferd\entities\extended\udt\DateTimeType $basisDateTime = null)
@@ -60,7 +60,7 @@ class TradePaymentDiscountTermsType
     /**
      * Gets as basisPeriodMeasure
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\MeasureType
+     * @return \horstoeko\zugferd\entities\extended\udt\MeasureType|null
      */
     public function getBasisPeriodMeasure()
     {
@@ -70,7 +70,7 @@ class TradePaymentDiscountTermsType
     /**
      * Sets a new basisPeriodMeasure
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\MeasureType $basisPeriodMeasure
+     * @param  \horstoeko\zugferd\entities\extended\udt\MeasureType|null $basisPeriodMeasure
      * @return self
      */
     public function setBasisPeriodMeasure(?\horstoeko\zugferd\entities\extended\udt\MeasureType $basisPeriodMeasure = null)
@@ -82,7 +82,7 @@ class TradePaymentDiscountTermsType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -92,7 +92,7 @@ class TradePaymentDiscountTermsType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount = null)
@@ -104,7 +104,7 @@ class TradePaymentDiscountTermsType
     /**
      * Gets as calculationPercent
      *
-     * @return float
+     * @return float|null
      */
     public function getCalculationPercent()
     {
@@ -126,7 +126,7 @@ class TradePaymentDiscountTermsType
     /**
      * Gets as actualDiscountAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getActualDiscountAmount()
     {
@@ -136,7 +136,7 @@ class TradePaymentDiscountTermsType
     /**
      * Sets a new actualDiscountAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $actualDiscountAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $actualDiscountAmount
      * @return self
      */
     public function setActualDiscountAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $actualDiscountAmount = null)

--- a/src/entities/extended/ram/TradePaymentPenaltyTermsType.php
+++ b/src/entities/extended/ram/TradePaymentPenaltyTermsType.php
@@ -11,34 +11,34 @@ class TradePaymentPenaltyTermsType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType $basisDateTime
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $basisDateTime
      */
     private $basisDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\MeasureType $basisPeriodMeasure
+     * @var \horstoeko\zugferd\entities\extended\udt\MeasureType|null $basisPeriodMeasure
      */
     private $basisPeriodMeasure = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var float $calculationPercent
+     * @var float|null $calculationPercent
      */
     private $calculationPercent = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $actualPenaltyAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $actualPenaltyAmount
      */
     private $actualPenaltyAmount = null;
 
     /**
      * Gets as basisDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType|null
      */
     public function getBasisDateTime()
     {
@@ -48,7 +48,7 @@ class TradePaymentPenaltyTermsType
     /**
      * Sets a new basisDateTime
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType $basisDateTime
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $basisDateTime
      * @return self
      */
     public function setBasisDateTime(?\horstoeko\zugferd\entities\extended\udt\DateTimeType $basisDateTime = null)
@@ -60,7 +60,7 @@ class TradePaymentPenaltyTermsType
     /**
      * Gets as basisPeriodMeasure
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\MeasureType
+     * @return \horstoeko\zugferd\entities\extended\udt\MeasureType|null
      */
     public function getBasisPeriodMeasure()
     {
@@ -70,7 +70,7 @@ class TradePaymentPenaltyTermsType
     /**
      * Sets a new basisPeriodMeasure
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\MeasureType $basisPeriodMeasure
+     * @param  \horstoeko\zugferd\entities\extended\udt\MeasureType|null $basisPeriodMeasure
      * @return self
      */
     public function setBasisPeriodMeasure(?\horstoeko\zugferd\entities\extended\udt\MeasureType $basisPeriodMeasure = null)
@@ -82,7 +82,7 @@ class TradePaymentPenaltyTermsType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -92,7 +92,7 @@ class TradePaymentPenaltyTermsType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount = null)
@@ -104,7 +104,7 @@ class TradePaymentPenaltyTermsType
     /**
      * Gets as calculationPercent
      *
-     * @return float
+     * @return float|null
      */
     public function getCalculationPercent()
     {
@@ -126,7 +126,7 @@ class TradePaymentPenaltyTermsType
     /**
      * Gets as actualPenaltyAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getActualPenaltyAmount()
     {
@@ -136,7 +136,7 @@ class TradePaymentPenaltyTermsType
     /**
      * Sets a new actualPenaltyAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $actualPenaltyAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $actualPenaltyAmount
      * @return self
      */
     public function setActualPenaltyAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $actualPenaltyAmount = null)

--- a/src/entities/extended/ram/TradePaymentTermsType.php
+++ b/src/entities/extended/ram/TradePaymentTermsType.php
@@ -11,44 +11,44 @@ class TradePaymentTermsType
 {
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType $dueDateDateTime
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $dueDateDateTime
      */
     private $dueDateDateTime = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $directDebitMandateID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $directDebitMandateID
      */
     private $directDebitMandateID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $partialPaymentAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $partialPaymentAmount
      */
     private $partialPaymentAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType $applicableTradePaymentPenaltyTerms
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType|null $applicableTradePaymentPenaltyTerms
      */
     private $applicableTradePaymentPenaltyTerms = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePaymentDiscountTermsType $applicableTradePaymentDiscountTerms
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePaymentDiscountTermsType|null $applicableTradePaymentDiscountTerms
      */
     private $applicableTradePaymentDiscountTerms = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $payeeTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $payeeTradeParty
      */
     private $payeeTradeParty = null;
 
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -70,7 +70,7 @@ class TradePaymentTermsType
     /**
      * Gets as dueDateDateTime
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType|null
      */
     public function getDueDateDateTime()
     {
@@ -80,7 +80,7 @@ class TradePaymentTermsType
     /**
      * Sets a new dueDateDateTime
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType $dueDateDateTime
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType|null $dueDateDateTime
      * @return self
      */
     public function setDueDateDateTime(?\horstoeko\zugferd\entities\extended\udt\DateTimeType $dueDateDateTime = null)
@@ -92,7 +92,7 @@ class TradePaymentTermsType
     /**
      * Gets as directDebitMandateID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getDirectDebitMandateID()
     {
@@ -102,7 +102,7 @@ class TradePaymentTermsType
     /**
      * Sets a new directDebitMandateID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $directDebitMandateID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $directDebitMandateID
      * @return self
      */
     public function setDirectDebitMandateID(?\horstoeko\zugferd\entities\extended\udt\IDType $directDebitMandateID = null)
@@ -114,7 +114,7 @@ class TradePaymentTermsType
     /**
      * Gets as partialPaymentAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getPartialPaymentAmount()
     {
@@ -124,7 +124,7 @@ class TradePaymentTermsType
     /**
      * Sets a new partialPaymentAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $partialPaymentAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $partialPaymentAmount
      * @return self
      */
     public function setPartialPaymentAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $partialPaymentAmount = null)
@@ -136,7 +136,7 @@ class TradePaymentTermsType
     /**
      * Gets as applicableTradePaymentPenaltyTerms
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType|null
      */
     public function getApplicableTradePaymentPenaltyTerms()
     {
@@ -146,7 +146,7 @@ class TradePaymentTermsType
     /**
      * Sets a new applicableTradePaymentPenaltyTerms
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType $applicableTradePaymentPenaltyTerms
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType|null $applicableTradePaymentPenaltyTerms
      * @return self
      */
     public function setApplicableTradePaymentPenaltyTerms(?\horstoeko\zugferd\entities\extended\ram\TradePaymentPenaltyTermsType $applicableTradePaymentPenaltyTerms = null)
@@ -158,7 +158,7 @@ class TradePaymentTermsType
     /**
      * Gets as applicableTradePaymentDiscountTerms
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePaymentDiscountTermsType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePaymentDiscountTermsType|null
      */
     public function getApplicableTradePaymentDiscountTerms()
     {
@@ -168,7 +168,7 @@ class TradePaymentTermsType
     /**
      * Sets a new applicableTradePaymentDiscountTerms
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePaymentDiscountTermsType $applicableTradePaymentDiscountTerms
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePaymentDiscountTermsType|null $applicableTradePaymentDiscountTerms
      * @return self
      */
     public function setApplicableTradePaymentDiscountTerms(?\horstoeko\zugferd\entities\extended\ram\TradePaymentDiscountTermsType $applicableTradePaymentDiscountTerms = null)
@@ -180,7 +180,7 @@ class TradePaymentTermsType
     /**
      * Gets as payeeTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getPayeeTradeParty()
     {
@@ -190,7 +190,7 @@ class TradePaymentTermsType
     /**
      * Sets a new payeeTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $payeeTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $payeeTradeParty
      * @return self
      */
     public function setPayeeTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $payeeTradeParty = null)

--- a/src/entities/extended/ram/TradePriceType.php
+++ b/src/entities/extended/ram/TradePriceType.php
@@ -11,12 +11,12 @@ class TradePriceType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $chargeAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $chargeAmount
      */
     private $chargeAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType $basisQuantity
+     * @var \horstoeko\zugferd\entities\extended\udt\QuantityType|null $basisQuantity
      */
     private $basisQuantity = null;
 
@@ -28,14 +28,14 @@ class TradePriceType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeTaxType $includedTradeTax
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeTaxType|null $includedTradeTax
      */
     private $includedTradeTax = null;
 
     /**
      * Gets as chargeAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getChargeAmount()
     {
@@ -57,7 +57,7 @@ class TradePriceType
     /**
      * Gets as basisQuantity
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType
+     * @return \horstoeko\zugferd\entities\extended\udt\QuantityType|null
      */
     public function getBasisQuantity()
     {
@@ -67,7 +67,7 @@ class TradePriceType
     /**
      * Sets a new basisQuantity
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType $basisQuantity
+     * @param  \horstoeko\zugferd\entities\extended\udt\QuantityType|null $basisQuantity
      * @return self
      */
     public function setBasisQuantity(?\horstoeko\zugferd\entities\extended\udt\QuantityType $basisQuantity = null)
@@ -123,7 +123,7 @@ class TradePriceType
     /**
      * Sets a new appliedTradeAllowanceCharge
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAllowanceChargeType[] $appliedTradeAllowanceCharge
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeAllowanceChargeType[]|null $appliedTradeAllowanceCharge
      * @return self
      */
     public function setAppliedTradeAllowanceCharge(?array $appliedTradeAllowanceCharge = null)
@@ -135,7 +135,7 @@ class TradePriceType
     /**
      * Gets as includedTradeTax
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeTaxType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeTaxType|null
      */
     public function getIncludedTradeTax()
     {
@@ -145,7 +145,7 @@ class TradePriceType
     /**
      * Sets a new includedTradeTax
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeTaxType $includedTradeTax
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeTaxType|null $includedTradeTax
      * @return self
      */
     public function setIncludedTradeTax(?\horstoeko\zugferd\entities\extended\ram\TradeTaxType $includedTradeTax = null)

--- a/src/entities/extended/ram/TradeProductInstanceType.php
+++ b/src/entities/extended/ram/TradeProductInstanceType.php
@@ -11,19 +11,19 @@ class TradeProductInstanceType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $batchID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $batchID
      */
     private $batchID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $supplierAssignedSerialID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $supplierAssignedSerialID
      */
     private $supplierAssignedSerialID = null;
 
     /**
      * Gets as batchID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getBatchID()
     {
@@ -33,7 +33,7 @@ class TradeProductInstanceType
     /**
      * Sets a new batchID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $batchID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $batchID
      * @return self
      */
     public function setBatchID(?\horstoeko\zugferd\entities\extended\udt\IDType $batchID = null)
@@ -45,7 +45,7 @@ class TradeProductInstanceType
     /**
      * Gets as supplierAssignedSerialID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getSupplierAssignedSerialID()
     {
@@ -55,7 +55,7 @@ class TradeProductInstanceType
     /**
      * Sets a new supplierAssignedSerialID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $supplierAssignedSerialID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $supplierAssignedSerialID
      * @return self
      */
     public function setSupplierAssignedSerialID(?\horstoeko\zugferd\entities\extended\udt\IDType $supplierAssignedSerialID = null)

--- a/src/entities/extended/ram/TradeProductType.php
+++ b/src/entities/extended/ram/TradeProductType.php
@@ -11,42 +11,42 @@ class TradeProductType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $globalID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $globalID
      */
     private $globalID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $sellerAssignedID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $sellerAssignedID
      */
     private $sellerAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $buyerAssignedID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $buyerAssignedID
      */
     private $buyerAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $industryAssignedID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $industryAssignedID
      */
     private $industryAssignedID = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $modelID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $modelID
      */
     private $modelID = null;
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var string $description
+     * @var string|null $description
      */
     private $description = null;
 
@@ -58,12 +58,12 @@ class TradeProductType
     ];
 
     /**
-     * @var string $brandName
+     * @var string|null $brandName
      */
     private $brandName = null;
 
     /**
-     * @var string $modelName
+     * @var string|null $modelName
      */
     private $modelName = null;
 
@@ -89,12 +89,12 @@ class TradeProductType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeCountryType $originTradeCountry
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeCountryType|null $originTradeCountry
      */
     private $originTradeCountry = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType $manufacturerTradeParty
+     * @var \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $manufacturerTradeParty
      */
     private $manufacturerTradeParty = null;
 
@@ -108,7 +108,7 @@ class TradeProductType
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getID()
     {
@@ -118,7 +118,7 @@ class TradeProductType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      * @return self
      */
     public function setID(?\horstoeko\zugferd\entities\extended\udt\IDType $iD = null)
@@ -130,7 +130,7 @@ class TradeProductType
     /**
      * Gets as globalID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getGlobalID()
     {
@@ -140,7 +140,7 @@ class TradeProductType
     /**
      * Sets a new globalID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $globalID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $globalID
      * @return self
      */
     public function setGlobalID(?\horstoeko\zugferd\entities\extended\udt\IDType $globalID = null)
@@ -152,7 +152,7 @@ class TradeProductType
     /**
      * Gets as sellerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getSellerAssignedID()
     {
@@ -162,7 +162,7 @@ class TradeProductType
     /**
      * Sets a new sellerAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $sellerAssignedID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $sellerAssignedID
      * @return self
      */
     public function setSellerAssignedID(?\horstoeko\zugferd\entities\extended\udt\IDType $sellerAssignedID = null)
@@ -174,7 +174,7 @@ class TradeProductType
     /**
      * Gets as buyerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getBuyerAssignedID()
     {
@@ -184,7 +184,7 @@ class TradeProductType
     /**
      * Sets a new buyerAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $buyerAssignedID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $buyerAssignedID
      * @return self
      */
     public function setBuyerAssignedID(?\horstoeko\zugferd\entities\extended\udt\IDType $buyerAssignedID = null)
@@ -196,7 +196,7 @@ class TradeProductType
     /**
      * Gets as industryAssignedID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getIndustryAssignedID()
     {
@@ -206,7 +206,7 @@ class TradeProductType
     /**
      * Sets a new industryAssignedID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $industryAssignedID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $industryAssignedID
      * @return self
      */
     public function setIndustryAssignedID(?\horstoeko\zugferd\entities\extended\udt\IDType $industryAssignedID = null)
@@ -218,7 +218,7 @@ class TradeProductType
     /**
      * Gets as modelID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getModelID()
     {
@@ -228,7 +228,7 @@ class TradeProductType
     /**
      * Sets a new modelID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $modelID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $modelID
      * @return self
      */
     public function setModelID(?\horstoeko\zugferd\entities\extended\udt\IDType $modelID = null)
@@ -240,7 +240,7 @@ class TradeProductType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -262,7 +262,7 @@ class TradeProductType
     /**
      * Gets as description
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -328,7 +328,7 @@ class TradeProductType
     /**
      * Sets a new batchID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType[] $batchID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType[]|null $batchID
      * @return self
      */
     public function setBatchID(?array $batchID = null)
@@ -340,7 +340,7 @@ class TradeProductType
     /**
      * Gets as brandName
      *
-     * @return string
+     * @return string|null
      */
     public function getBrandName()
     {
@@ -362,7 +362,7 @@ class TradeProductType
     /**
      * Gets as modelName
      *
-     * @return string
+     * @return string|null
      */
     public function getModelName()
     {
@@ -428,7 +428,7 @@ class TradeProductType
     /**
      * Sets a new applicableProductCharacteristic
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ProductCharacteristicType[] $applicableProductCharacteristic
+     * @param  \horstoeko\zugferd\entities\extended\ram\ProductCharacteristicType[]|null $applicableProductCharacteristic
      * @return self
      */
     public function setApplicableProductCharacteristic(?array $applicableProductCharacteristic = null)
@@ -484,7 +484,7 @@ class TradeProductType
     /**
      * Sets a new designatedProductClassification
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ProductClassificationType[] $designatedProductClassification
+     * @param  \horstoeko\zugferd\entities\extended\ram\ProductClassificationType[]|null $designatedProductClassification
      * @return self
      */
     public function setDesignatedProductClassification(?array $designatedProductClassification = null)
@@ -540,7 +540,7 @@ class TradeProductType
     /**
      * Sets a new individualTradeProductInstance
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeProductInstanceType[] $individualTradeProductInstance
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeProductInstanceType[]|null $individualTradeProductInstance
      * @return self
      */
     public function setIndividualTradeProductInstance(?array $individualTradeProductInstance = null)
@@ -552,7 +552,7 @@ class TradeProductType
     /**
      * Gets as originTradeCountry
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeCountryType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeCountryType|null
      */
     public function getOriginTradeCountry()
     {
@@ -562,7 +562,7 @@ class TradeProductType
     /**
      * Sets a new originTradeCountry
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeCountryType $originTradeCountry
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeCountryType|null $originTradeCountry
      * @return self
      */
     public function setOriginTradeCountry(?\horstoeko\zugferd\entities\extended\ram\TradeCountryType $originTradeCountry = null)
@@ -574,7 +574,7 @@ class TradeProductType
     /**
      * Gets as manufacturerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradePartyType|null
      */
     public function getManufacturerTradeParty()
     {
@@ -584,7 +584,7 @@ class TradeProductType
     /**
      * Sets a new manufacturerTradeParty
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType $manufacturerTradeParty
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradePartyType|null $manufacturerTradeParty
      * @return self
      */
     public function setManufacturerTradeParty(?\horstoeko\zugferd\entities\extended\ram\TradePartyType $manufacturerTradeParty = null)
@@ -640,7 +640,7 @@ class TradeProductType
     /**
      * Sets a new includedReferencedProduct
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedProductType[] $includedReferencedProduct
+     * @param  \horstoeko\zugferd\entities\extended\ram\ReferencedProductType[]|null $includedReferencedProduct
      * @return self
      */
     public function setIncludedReferencedProduct(?array $includedReferencedProduct = null)

--- a/src/entities/extended/ram/TradeSettlementFinancialCardType.php
+++ b/src/entities/extended/ram/TradeSettlementFinancialCardType.php
@@ -11,19 +11,19 @@ class TradeSettlementFinancialCardType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $cardholderName
+     * @var string|null $cardholderName
      */
     private $cardholderName = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getID()
     {
@@ -45,7 +45,7 @@ class TradeSettlementFinancialCardType
     /**
      * Gets as cardholderName
      *
-     * @return string
+     * @return string|null
      */
     public function getCardholderName()
     {

--- a/src/entities/extended/ram/TradeSettlementHeaderMonetarySummationType.php
+++ b/src/entities/extended/ram/TradeSettlementHeaderMonetarySummationType.php
@@ -11,22 +11,22 @@ class TradeSettlementHeaderMonetarySummationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $lineTotalAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $lineTotalAmount
      */
     private $lineTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $chargeTotalAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $chargeTotalAmount
      */
     private $chargeTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $allowanceTotalAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $allowanceTotalAmount
      */
     private $allowanceTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $taxBasisTotalAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $taxBasisTotalAmount
      */
     private $taxBasisTotalAmount = null;
 
@@ -38,29 +38,29 @@ class TradeSettlementHeaderMonetarySummationType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $roundingAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $roundingAmount
      */
     private $roundingAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $grandTotalAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $grandTotalAmount
      */
     private $grandTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $totalPrepaidAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $totalPrepaidAmount
      */
     private $totalPrepaidAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $duePayableAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $duePayableAmount
      */
     private $duePayableAmount = null;
 
     /**
      * Gets as lineTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getLineTotalAmount()
     {
@@ -82,7 +82,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as chargeTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getChargeTotalAmount()
     {
@@ -92,7 +92,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new chargeTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $chargeTotalAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $chargeTotalAmount
      * @return self
      */
     public function setChargeTotalAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $chargeTotalAmount = null)
@@ -104,7 +104,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as allowanceTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getAllowanceTotalAmount()
     {
@@ -114,7 +114,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new allowanceTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $allowanceTotalAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $allowanceTotalAmount
      * @return self
      */
     public function setAllowanceTotalAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $allowanceTotalAmount = null)
@@ -126,7 +126,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as taxBasisTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getTaxBasisTotalAmount()
     {
@@ -192,7 +192,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new taxTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType[] $taxTotalAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType[]|null $taxTotalAmount
      * @return self
      */
     public function setTaxTotalAmount(?array $taxTotalAmount = null)
@@ -204,7 +204,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as roundingAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getRoundingAmount()
     {
@@ -214,7 +214,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new roundingAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $roundingAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $roundingAmount
      * @return self
      */
     public function setRoundingAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $roundingAmount = null)
@@ -226,7 +226,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as grandTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getGrandTotalAmount()
     {
@@ -248,7 +248,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as totalPrepaidAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getTotalPrepaidAmount()
     {
@@ -258,7 +258,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new totalPrepaidAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $totalPrepaidAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $totalPrepaidAmount
      * @return self
      */
     public function setTotalPrepaidAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $totalPrepaidAmount = null)
@@ -270,7 +270,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as duePayableAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getDuePayableAmount()
     {

--- a/src/entities/extended/ram/TradeSettlementLineMonetarySummationType.php
+++ b/src/entities/extended/ram/TradeSettlementLineMonetarySummationType.php
@@ -11,17 +11,17 @@ class TradeSettlementLineMonetarySummationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $lineTotalAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $lineTotalAmount
      */
     private $lineTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $chargeTotalAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $chargeTotalAmount
      */
     private $chargeTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $allowanceTotalAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $allowanceTotalAmount
      */
     private $allowanceTotalAmount = null;
 
@@ -33,19 +33,19 @@ class TradeSettlementLineMonetarySummationType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $grandTotalAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $grandTotalAmount
      */
     private $grandTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $totalAllowanceChargeAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $totalAllowanceChargeAmount
      */
     private $totalAllowanceChargeAmount = null;
 
     /**
      * Gets as lineTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getLineTotalAmount()
     {
@@ -55,7 +55,7 @@ class TradeSettlementLineMonetarySummationType
     /**
      * Sets a new lineTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $lineTotalAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $lineTotalAmount
      * @return self
      */
     public function setLineTotalAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $lineTotalAmount = null)
@@ -67,7 +67,7 @@ class TradeSettlementLineMonetarySummationType
     /**
      * Gets as chargeTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getChargeTotalAmount()
     {
@@ -77,7 +77,7 @@ class TradeSettlementLineMonetarySummationType
     /**
      * Sets a new chargeTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $chargeTotalAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $chargeTotalAmount
      * @return self
      */
     public function setChargeTotalAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $chargeTotalAmount = null)
@@ -89,7 +89,7 @@ class TradeSettlementLineMonetarySummationType
     /**
      * Gets as allowanceTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getAllowanceTotalAmount()
     {
@@ -99,7 +99,7 @@ class TradeSettlementLineMonetarySummationType
     /**
      * Sets a new allowanceTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $allowanceTotalAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $allowanceTotalAmount
      * @return self
      */
     public function setAllowanceTotalAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $allowanceTotalAmount = null)
@@ -174,7 +174,7 @@ class TradeSettlementLineMonetarySummationType
     /**
      * Gets as grandTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getGrandTotalAmount()
     {
@@ -184,7 +184,7 @@ class TradeSettlementLineMonetarySummationType
     /**
      * Sets a new grandTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $grandTotalAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $grandTotalAmount
      * @return self
      */
     public function setGrandTotalAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $grandTotalAmount = null)
@@ -196,7 +196,7 @@ class TradeSettlementLineMonetarySummationType
     /**
      * Gets as totalAllowanceChargeAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getTotalAllowanceChargeAmount()
     {
@@ -206,7 +206,7 @@ class TradeSettlementLineMonetarySummationType
     /**
      * Sets a new totalAllowanceChargeAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $totalAllowanceChargeAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $totalAllowanceChargeAmount
      * @return self
      */
     public function setTotalAllowanceChargeAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $totalAllowanceChargeAmount = null)

--- a/src/entities/extended/ram/TradeSettlementPaymentMeansType.php
+++ b/src/entities/extended/ram/TradeSettlementPaymentMeansType.php
@@ -11,44 +11,44 @@ class TradeSettlementPaymentMeansType
 {
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var string $information
+     * @var string|null $information
      */
     private $information = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\TradeSettlementFinancialCardType $applicableTradeSettlementFinancialCard
+     * @var \horstoeko\zugferd\entities\extended\ram\TradeSettlementFinancialCardType|null $applicableTradeSettlementFinancialCard
      */
     private $applicableTradeSettlementFinancialCard = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount
+     * @var \horstoeko\zugferd\entities\extended\ram\DebtorFinancialAccountType|null $payerPartyDebtorFinancialAccount
      */
     private $payerPartyDebtorFinancialAccount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount
+     * @var \horstoeko\zugferd\entities\extended\ram\CreditorFinancialAccountType|null $payeePartyCreditorFinancialAccount
      */
     private $payeePartyCreditorFinancialAccount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\DebtorFinancialInstitutionType $payerSpecifiedDebtorFinancialInstitution
+     * @var \horstoeko\zugferd\entities\extended\ram\DebtorFinancialInstitutionType|null $payerSpecifiedDebtorFinancialInstitution
      */
     private $payerSpecifiedDebtorFinancialInstitution = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\CreditorFinancialInstitutionType $payeeSpecifiedCreditorFinancialInstitution
+     * @var \horstoeko\zugferd\entities\extended\ram\CreditorFinancialInstitutionType|null $payeeSpecifiedCreditorFinancialInstitution
      */
     private $payeeSpecifiedCreditorFinancialInstitution = null;
 
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -70,7 +70,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as information
      *
-     * @return string
+     * @return string|null
      */
     public function getInformation()
     {
@@ -92,7 +92,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as applicableTradeSettlementFinancialCard
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\TradeSettlementFinancialCardType
+     * @return \horstoeko\zugferd\entities\extended\ram\TradeSettlementFinancialCardType|null
      */
     public function getApplicableTradeSettlementFinancialCard()
     {
@@ -102,7 +102,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new applicableTradeSettlementFinancialCard
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\TradeSettlementFinancialCardType $applicableTradeSettlementFinancialCard
+     * @param  \horstoeko\zugferd\entities\extended\ram\TradeSettlementFinancialCardType|null $applicableTradeSettlementFinancialCard
      * @return self
      */
     public function setApplicableTradeSettlementFinancialCard(?\horstoeko\zugferd\entities\extended\ram\TradeSettlementFinancialCardType $applicableTradeSettlementFinancialCard = null)
@@ -114,7 +114,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payerPartyDebtorFinancialAccount
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\DebtorFinancialAccountType
+     * @return \horstoeko\zugferd\entities\extended\ram\DebtorFinancialAccountType|null
      */
     public function getPayerPartyDebtorFinancialAccount()
     {
@@ -124,7 +124,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payerPartyDebtorFinancialAccount
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount
+     * @param  \horstoeko\zugferd\entities\extended\ram\DebtorFinancialAccountType|null $payerPartyDebtorFinancialAccount
      * @return self
      */
     public function setPayerPartyDebtorFinancialAccount(?\horstoeko\zugferd\entities\extended\ram\DebtorFinancialAccountType $payerPartyDebtorFinancialAccount = null)
@@ -136,7 +136,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payeePartyCreditorFinancialAccount
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\CreditorFinancialAccountType
+     * @return \horstoeko\zugferd\entities\extended\ram\CreditorFinancialAccountType|null
      */
     public function getPayeePartyCreditorFinancialAccount()
     {
@@ -146,7 +146,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payeePartyCreditorFinancialAccount
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount
+     * @param  \horstoeko\zugferd\entities\extended\ram\CreditorFinancialAccountType|null $payeePartyCreditorFinancialAccount
      * @return self
      */
     public function setPayeePartyCreditorFinancialAccount(?\horstoeko\zugferd\entities\extended\ram\CreditorFinancialAccountType $payeePartyCreditorFinancialAccount = null)
@@ -158,7 +158,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payerSpecifiedDebtorFinancialInstitution
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\DebtorFinancialInstitutionType
+     * @return \horstoeko\zugferd\entities\extended\ram\DebtorFinancialInstitutionType|null
      */
     public function getPayerSpecifiedDebtorFinancialInstitution()
     {
@@ -168,7 +168,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payerSpecifiedDebtorFinancialInstitution
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\DebtorFinancialInstitutionType $payerSpecifiedDebtorFinancialInstitution
+     * @param  \horstoeko\zugferd\entities\extended\ram\DebtorFinancialInstitutionType|null $payerSpecifiedDebtorFinancialInstitution
      * @return self
      */
     public function setPayerSpecifiedDebtorFinancialInstitution(?\horstoeko\zugferd\entities\extended\ram\DebtorFinancialInstitutionType $payerSpecifiedDebtorFinancialInstitution = null)
@@ -180,7 +180,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Gets as payeeSpecifiedCreditorFinancialInstitution
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\CreditorFinancialInstitutionType
+     * @return \horstoeko\zugferd\entities\extended\ram\CreditorFinancialInstitutionType|null
      */
     public function getPayeeSpecifiedCreditorFinancialInstitution()
     {
@@ -190,7 +190,7 @@ class TradeSettlementPaymentMeansType
     /**
      * Sets a new payeeSpecifiedCreditorFinancialInstitution
      *
-     * @param  \horstoeko\zugferd\entities\extended\ram\CreditorFinancialInstitutionType $payeeSpecifiedCreditorFinancialInstitution
+     * @param  \horstoeko\zugferd\entities\extended\ram\CreditorFinancialInstitutionType|null $payeeSpecifiedCreditorFinancialInstitution
      * @return self
      */
     public function setPayeeSpecifiedCreditorFinancialInstitution(?\horstoeko\zugferd\entities\extended\ram\CreditorFinancialInstitutionType $payeeSpecifiedCreditorFinancialInstitution = null)

--- a/src/entities/extended/ram/TradeTaxType.php
+++ b/src/entities/extended/ram/TradeTaxType.php
@@ -11,64 +11,64 @@ class TradeTaxType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $calculatedAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $calculatedAmount
      */
     private $calculatedAmount = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var string $exemptionReason
+     * @var string|null $exemptionReason
      */
     private $exemptionReason = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $basisAmount
      */
     private $basisAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $lineTotalBasisAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $lineTotalBasisAmount
      */
     private $lineTotalBasisAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\AmountType $allowanceChargeBasisAmount
+     * @var \horstoeko\zugferd\entities\extended\udt\AmountType|null $allowanceChargeBasisAmount
      */
     private $allowanceChargeBasisAmount = null;
 
     /**
-     * @var string $categoryCode
+     * @var string|null $categoryCode
      */
     private $categoryCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\CodeType $exemptionReasonCode
+     * @var \horstoeko\zugferd\entities\extended\udt\CodeType|null $exemptionReasonCode
      */
     private $exemptionReasonCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateType $taxPointDate
+     * @var \horstoeko\zugferd\entities\extended\udt\DateType|null $taxPointDate
      */
     private $taxPointDate = null;
 
     /**
-     * @var string $dueDateTypeCode
+     * @var string|null $dueDateTypeCode
      */
     private $dueDateTypeCode = null;
 
     /**
-     * @var float $rateApplicablePercent
+     * @var float|null $rateApplicablePercent
      */
     private $rateApplicablePercent = null;
 
     /**
      * Gets as calculatedAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getCalculatedAmount()
     {
@@ -78,7 +78,7 @@ class TradeTaxType
     /**
      * Sets a new calculatedAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $calculatedAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $calculatedAmount
      * @return self
      */
     public function setCalculatedAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $calculatedAmount = null)
@@ -90,7 +90,7 @@ class TradeTaxType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -112,7 +112,7 @@ class TradeTaxType
     /**
      * Gets as exemptionReason
      *
-     * @return string
+     * @return string|null
      */
     public function getExemptionReason()
     {
@@ -134,7 +134,7 @@ class TradeTaxType
     /**
      * Gets as basisAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getBasisAmount()
     {
@@ -144,7 +144,7 @@ class TradeTaxType
     /**
      * Sets a new basisAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $basisAmount
      * @return self
      */
     public function setBasisAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $basisAmount = null)
@@ -156,7 +156,7 @@ class TradeTaxType
     /**
      * Gets as lineTotalBasisAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getLineTotalBasisAmount()
     {
@@ -166,7 +166,7 @@ class TradeTaxType
     /**
      * Sets a new lineTotalBasisAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $lineTotalBasisAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $lineTotalBasisAmount
      * @return self
      */
     public function setLineTotalBasisAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $lineTotalBasisAmount = null)
@@ -178,7 +178,7 @@ class TradeTaxType
     /**
      * Gets as allowanceChargeBasisAmount
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\AmountType
+     * @return \horstoeko\zugferd\entities\extended\udt\AmountType|null
      */
     public function getAllowanceChargeBasisAmount()
     {
@@ -188,7 +188,7 @@ class TradeTaxType
     /**
      * Sets a new allowanceChargeBasisAmount
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType $allowanceChargeBasisAmount
+     * @param  \horstoeko\zugferd\entities\extended\udt\AmountType|null $allowanceChargeBasisAmount
      * @return self
      */
     public function setAllowanceChargeBasisAmount(?\horstoeko\zugferd\entities\extended\udt\AmountType $allowanceChargeBasisAmount = null)
@@ -200,7 +200,7 @@ class TradeTaxType
     /**
      * Gets as categoryCode
      *
-     * @return string
+     * @return string|null
      */
     public function getCategoryCode()
     {
@@ -222,7 +222,7 @@ class TradeTaxType
     /**
      * Gets as exemptionReasonCode
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\CodeType
+     * @return \horstoeko\zugferd\entities\extended\udt\CodeType|null
      */
     public function getExemptionReasonCode()
     {
@@ -232,7 +232,7 @@ class TradeTaxType
     /**
      * Sets a new exemptionReasonCode
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType $exemptionReasonCode
+     * @param  \horstoeko\zugferd\entities\extended\udt\CodeType|null $exemptionReasonCode
      * @return self
      */
     public function setExemptionReasonCode(?\horstoeko\zugferd\entities\extended\udt\CodeType $exemptionReasonCode = null)
@@ -244,7 +244,7 @@ class TradeTaxType
     /**
      * Gets as taxPointDate
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateType|null
      */
     public function getTaxPointDate()
     {
@@ -254,7 +254,7 @@ class TradeTaxType
     /**
      * Sets a new taxPointDate
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateType $taxPointDate
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateType|null $taxPointDate
      * @return self
      */
     public function setTaxPointDate(?\horstoeko\zugferd\entities\extended\udt\DateType $taxPointDate = null)
@@ -266,7 +266,7 @@ class TradeTaxType
     /**
      * Gets as dueDateTypeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getDueDateTypeCode()
     {
@@ -288,7 +288,7 @@ class TradeTaxType
     /**
      * Gets as rateApplicablePercent
      *
-     * @return float
+     * @return float|null
      */
     public function getRateApplicablePercent()
     {

--- a/src/entities/extended/ram/UniversalCommunicationType.php
+++ b/src/entities/extended/ram/UniversalCommunicationType.php
@@ -11,19 +11,19 @@ class UniversalCommunicationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\IDType $uRIID
+     * @var \horstoeko\zugferd\entities\extended\udt\IDType|null $uRIID
      */
     private $uRIID = null;
 
     /**
-     * @var string $completeNumber
+     * @var string|null $completeNumber
      */
     private $completeNumber = null;
 
     /**
      * Gets as uRIID
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\IDType
+     * @return \horstoeko\zugferd\entities\extended\udt\IDType|null
      */
     public function getURIID()
     {
@@ -33,7 +33,7 @@ class UniversalCommunicationType
     /**
      * Sets a new uRIID
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\IDType $uRIID
+     * @param  \horstoeko\zugferd\entities\extended\udt\IDType|null $uRIID
      * @return self
      */
     public function setURIID(?\horstoeko\zugferd\entities\extended\udt\IDType $uRIID = null)
@@ -45,7 +45,7 @@ class UniversalCommunicationType
     /**
      * Gets as completeNumber
      *
-     * @return string
+     * @return string|null
      */
     public function getCompleteNumber()
     {

--- a/src/entities/extended/rsm/CrossIndustryInvoiceType.php
+++ b/src/entities/extended/rsm/CrossIndustryInvoiceType.php
@@ -11,24 +11,24 @@ class CrossIndustryInvoiceType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ExchangedDocumentContextType $exchangedDocumentContext
+     * @var \horstoeko\zugferd\entities\extended\ram\ExchangedDocumentContextType|null $exchangedDocumentContext
      */
     private $exchangedDocumentContext = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\ExchangedDocumentType $exchangedDocument
+     * @var \horstoeko\zugferd\entities\extended\ram\ExchangedDocumentType|null $exchangedDocument
      */
     private $exchangedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\ram\SupplyChainTradeTransactionType $supplyChainTradeTransaction
+     * @var \horstoeko\zugferd\entities\extended\ram\SupplyChainTradeTransactionType|null $supplyChainTradeTransaction
      */
     private $supplyChainTradeTransaction = null;
 
     /**
      * Gets as exchangedDocumentContext
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ExchangedDocumentContextType
+     * @return \horstoeko\zugferd\entities\extended\ram\ExchangedDocumentContextType|null
      */
     public function getExchangedDocumentContext()
     {
@@ -50,7 +50,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as exchangedDocument
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\ExchangedDocumentType
+     * @return \horstoeko\zugferd\entities\extended\ram\ExchangedDocumentType|null
      */
     public function getExchangedDocument()
     {
@@ -72,7 +72,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as supplyChainTradeTransaction
      *
-     * @return \horstoeko\zugferd\entities\extended\ram\SupplyChainTradeTransactionType
+     * @return \horstoeko\zugferd\entities\extended\ram\SupplyChainTradeTransactionType|null
      */
     public function getSupplyChainTradeTransaction()
     {

--- a/src/entities/extended/udt/AmountType.php
+++ b/src/entities/extended/udt/AmountType.php
@@ -11,12 +11,12 @@ class AmountType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $currencyID
+     * @var string|null $currencyID
      */
     private $currencyID = null;
 
@@ -34,7 +34,7 @@ class AmountType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class AmountType
     /**
      * Gets as currencyID
      *
-     * @return string
+     * @return string|null
      */
     public function getCurrencyID()
     {

--- a/src/entities/extended/udt/BinaryObjectType.php
+++ b/src/entities/extended/udt/BinaryObjectType.php
@@ -11,17 +11,17 @@ class BinaryObjectType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $mimeCode
+     * @var string|null $mimeCode
      */
     private $mimeCode = null;
 
     /**
-     * @var string $filename
+     * @var string|null $filename
      */
     private $filename = null;
 
@@ -39,7 +39,7 @@ class BinaryObjectType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -62,7 +62,7 @@ class BinaryObjectType
     /**
      * Gets as mimeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getMimeCode()
     {
@@ -84,7 +84,7 @@ class BinaryObjectType
     /**
      * Gets as filename
      *
-     * @return string
+     * @return string|null
      */
     public function getFilename()
     {

--- a/src/entities/extended/udt/CodeType.php
+++ b/src/entities/extended/udt/CodeType.php
@@ -11,17 +11,17 @@ class CodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $listID
+     * @var string|null $listID
      */
     private $listID = null;
 
     /**
-     * @var string $listVersionID
+     * @var string|null $listVersionID
      */
     private $listVersionID = null;
 
@@ -39,7 +39,7 @@ class CodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -62,7 +62,7 @@ class CodeType
     /**
      * Gets as listID
      *
-     * @return string
+     * @return string|null
      */
     public function getListID()
     {
@@ -84,7 +84,7 @@ class CodeType
     /**
      * Gets as listVersionID
      *
-     * @return string
+     * @return string|null
      */
     public function getListVersionID()
     {

--- a/src/entities/extended/udt/DateTimeType.php
+++ b/src/entities/extended/udt/DateTimeType.php
@@ -11,14 +11,14 @@ class DateTimeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @var \horstoeko\zugferd\entities\extended\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      */
     private $dateTimeString = null;
 
     /**
      * Gets as dateTimeString
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType\DateTimeStringAType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateTimeType\DateTimeStringAType|null
      */
     public function getDateTimeString()
     {
@@ -28,7 +28,7 @@ class DateTimeType
     /**
      * Sets a new dateTimeString
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      * @return self
      */
     public function setDateTimeString(?\horstoeko\zugferd\entities\extended\udt\DateTimeType\DateTimeStringAType $dateTimeString = null)

--- a/src/entities/extended/udt/DateTimeType/DateTimeStringAType.php
+++ b/src/entities/extended/udt/DateTimeType/DateTimeStringAType.php
@@ -9,12 +9,12 @@ class DateTimeStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateTimeStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateTimeStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/extended/udt/DateType.php
+++ b/src/entities/extended/udt/DateType.php
@@ -11,14 +11,14 @@ class DateType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\extended\udt\DateType\DateStringAType $dateString
+     * @var \horstoeko\zugferd\entities\extended\udt\DateType\DateStringAType|null $dateString
      */
     private $dateString = null;
 
     /**
      * Gets as dateString
      *
-     * @return \horstoeko\zugferd\entities\extended\udt\DateType\DateStringAType
+     * @return \horstoeko\zugferd\entities\extended\udt\DateType\DateStringAType|null
      */
     public function getDateString()
     {
@@ -28,7 +28,7 @@ class DateType
     /**
      * Sets a new dateString
      *
-     * @param  \horstoeko\zugferd\entities\extended\udt\DateType\DateStringAType $dateString
+     * @param  \horstoeko\zugferd\entities\extended\udt\DateType\DateStringAType|null $dateString
      * @return self
      */
     public function setDateString(?\horstoeko\zugferd\entities\extended\udt\DateType\DateStringAType $dateString = null)

--- a/src/entities/extended/udt/DateType/DateStringAType.php
+++ b/src/entities/extended/udt/DateType/DateStringAType.php
@@ -9,12 +9,12 @@ class DateStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/extended/udt/IDType.php
+++ b/src/entities/extended/udt/IDType.php
@@ -11,12 +11,12 @@ class IDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $schemeID
+     * @var string|null $schemeID
      */
     private $schemeID = null;
 
@@ -34,7 +34,7 @@ class IDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class IDType
     /**
      * Gets as schemeID
      *
-     * @return string
+     * @return string|null
      */
     public function getSchemeID()
     {

--- a/src/entities/extended/udt/IndicatorType.php
+++ b/src/entities/extended/udt/IndicatorType.php
@@ -11,14 +11,14 @@ class IndicatorType
 {
 
     /**
-     * @var bool $indicator
+     * @var bool|null $indicator
      */
     private $indicator = null;
 
     /**
      * Gets as indicator
      *
-     * @return bool
+     * @return bool|null
      */
     public function getIndicator()
     {

--- a/src/entities/extended/udt/MeasureType.php
+++ b/src/entities/extended/udt/MeasureType.php
@@ -11,12 +11,12 @@ class MeasureType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $unitCode
+     * @var string|null $unitCode
      */
     private $unitCode = null;
 
@@ -34,7 +34,7 @@ class MeasureType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class MeasureType
     /**
      * Gets as unitCode
      *
-     * @return string
+     * @return string|null
      */
     public function getUnitCode()
     {

--- a/src/entities/extended/udt/NumericType.php
+++ b/src/entities/extended/udt/NumericType.php
@@ -11,7 +11,7 @@ class NumericType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class NumericType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {

--- a/src/entities/extended/udt/PercentType.php
+++ b/src/entities/extended/udt/PercentType.php
@@ -11,7 +11,7 @@ class PercentType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class PercentType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {

--- a/src/entities/extended/udt/QuantityType.php
+++ b/src/entities/extended/udt/QuantityType.php
@@ -11,12 +11,12 @@ class QuantityType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $unitCode
+     * @var string|null $unitCode
      */
     private $unitCode = null;
 
@@ -34,7 +34,7 @@ class QuantityType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class QuantityType
     /**
      * Gets as unitCode
      *
-     * @return string
+     * @return string|null
      */
     public function getUnitCode()
     {

--- a/src/entities/extended/udt/RateType.php
+++ b/src/entities/extended/udt/RateType.php
@@ -11,7 +11,7 @@ class RateType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class RateType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {

--- a/src/entities/extended/udt/TextType.php
+++ b/src/entities/extended/udt/TextType.php
@@ -11,7 +11,7 @@ class TextType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TextType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/minimum/qdt/CountryIDType.php
+++ b/src/entities/minimum/qdt/CountryIDType.php
@@ -11,7 +11,7 @@ class CountryIDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CountryIDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/minimum/qdt/CurrencyCodeType.php
+++ b/src/entities/minimum/qdt/CurrencyCodeType.php
@@ -11,7 +11,7 @@ class CurrencyCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class CurrencyCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/minimum/qdt/DocumentCodeType.php
+++ b/src/entities/minimum/qdt/DocumentCodeType.php
@@ -11,7 +11,7 @@ class DocumentCodeType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class DocumentCodeType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {

--- a/src/entities/minimum/ram/DocumentContextParameterType.php
+++ b/src/entities/minimum/ram/DocumentContextParameterType.php
@@ -11,14 +11,14 @@ class DocumentContextParameterType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\minimum\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\IDType
+     * @return \horstoeko\zugferd\entities\minimum\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/minimum/ram/ExchangedDocumentContextType.php
+++ b/src/entities/minimum/ram/ExchangedDocumentContextType.php
@@ -11,19 +11,19 @@ class ExchangedDocumentContextType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      */
     private $businessProcessSpecifiedDocumentContextParameter = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType $guidelineSpecifiedDocumentContextParameter
+     * @var \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType|null $guidelineSpecifiedDocumentContextParameter
      */
     private $guidelineSpecifiedDocumentContextParameter = null;
 
     /**
      * Gets as businessProcessSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType|null
      */
     public function getBusinessProcessSpecifiedDocumentContextParameter()
     {
@@ -33,7 +33,7 @@ class ExchangedDocumentContextType
     /**
      * Sets a new businessProcessSpecifiedDocumentContextParameter
      *
-     * @param  \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter
+     * @param  \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType|null $businessProcessSpecifiedDocumentContextParameter
      * @return self
      */
     public function setBusinessProcessSpecifiedDocumentContextParameter(?\horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType $businessProcessSpecifiedDocumentContextParameter = null)
@@ -45,7 +45,7 @@ class ExchangedDocumentContextType
     /**
      * Gets as guidelineSpecifiedDocumentContextParameter
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType
+     * @return \horstoeko\zugferd\entities\minimum\ram\DocumentContextParameterType|null
      */
     public function getGuidelineSpecifiedDocumentContextParameter()
     {

--- a/src/entities/minimum/ram/ExchangedDocumentType.php
+++ b/src/entities/minimum/ram/ExchangedDocumentType.php
@@ -11,24 +11,24 @@ class ExchangedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\minimum\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
-     * @var string $typeCode
+     * @var string|null $typeCode
      */
     private $typeCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\DateTimeType $issueDateTime
+     * @var \horstoeko\zugferd\entities\minimum\udt\DateTimeType|null $issueDateTime
      */
     private $issueDateTime = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\IDType
+     * @return \horstoeko\zugferd\entities\minimum\udt\IDType|null
      */
     public function getID()
     {
@@ -50,7 +50,7 @@ class ExchangedDocumentType
     /**
      * Gets as typeCode
      *
-     * @return string
+     * @return string|null
      */
     public function getTypeCode()
     {
@@ -72,7 +72,7 @@ class ExchangedDocumentType
     /**
      * Gets as issueDateTime
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\DateTimeType
+     * @return \horstoeko\zugferd\entities\minimum\udt\DateTimeType|null
      */
     public function getIssueDateTime()
     {

--- a/src/entities/minimum/ram/HeaderTradeAgreementType.php
+++ b/src/entities/minimum/ram/HeaderTradeAgreementType.php
@@ -11,29 +11,29 @@ class HeaderTradeAgreementType
 {
 
     /**
-     * @var string $buyerReference
+     * @var string|null $buyerReference
      */
     private $buyerReference = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\TradePartyType $sellerTradeParty
+     * @var \horstoeko\zugferd\entities\minimum\ram\TradePartyType|null $sellerTradeParty
      */
     private $sellerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\TradePartyType $buyerTradeParty
+     * @var \horstoeko\zugferd\entities\minimum\ram\TradePartyType|null $buyerTradeParty
      */
     private $buyerTradeParty = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @var \horstoeko\zugferd\entities\minimum\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      */
     private $buyerOrderReferencedDocument = null;
 
     /**
      * Gets as buyerReference
      *
-     * @return string
+     * @return string|null
      */
     public function getBuyerReference()
     {
@@ -55,7 +55,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as sellerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\minimum\ram\TradePartyType|null
      */
     public function getSellerTradeParty()
     {
@@ -77,7 +77,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerTradeParty
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\TradePartyType
+     * @return \horstoeko\zugferd\entities\minimum\ram\TradePartyType|null
      */
     public function getBuyerTradeParty()
     {
@@ -99,7 +99,7 @@ class HeaderTradeAgreementType
     /**
      * Gets as buyerOrderReferencedDocument
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\ReferencedDocumentType
+     * @return \horstoeko\zugferd\entities\minimum\ram\ReferencedDocumentType|null
      */
     public function getBuyerOrderReferencedDocument()
     {
@@ -109,7 +109,7 @@ class HeaderTradeAgreementType
     /**
      * Sets a new buyerOrderReferencedDocument
      *
-     * @param  \horstoeko\zugferd\entities\minimum\ram\ReferencedDocumentType $buyerOrderReferencedDocument
+     * @param  \horstoeko\zugferd\entities\minimum\ram\ReferencedDocumentType|null $buyerOrderReferencedDocument
      * @return self
      */
     public function setBuyerOrderReferencedDocument(?\horstoeko\zugferd\entities\minimum\ram\ReferencedDocumentType $buyerOrderReferencedDocument = null)

--- a/src/entities/minimum/ram/HeaderTradeSettlementType.php
+++ b/src/entities/minimum/ram/HeaderTradeSettlementType.php
@@ -11,19 +11,19 @@ class HeaderTradeSettlementType
 {
 
     /**
-     * @var string $invoiceCurrencyCode
+     * @var string|null $invoiceCurrencyCode
      */
     private $invoiceCurrencyCode = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\TradeSettlementHeaderMonetarySummationType $specifiedTradeSettlementHeaderMonetarySummation
+     * @var \horstoeko\zugferd\entities\minimum\ram\TradeSettlementHeaderMonetarySummationType|null $specifiedTradeSettlementHeaderMonetarySummation
      */
     private $specifiedTradeSettlementHeaderMonetarySummation = null;
 
     /**
      * Gets as invoiceCurrencyCode
      *
-     * @return string
+     * @return string|null
      */
     public function getInvoiceCurrencyCode()
     {
@@ -45,7 +45,7 @@ class HeaderTradeSettlementType
     /**
      * Gets as specifiedTradeSettlementHeaderMonetarySummation
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\TradeSettlementHeaderMonetarySummationType
+     * @return \horstoeko\zugferd\entities\minimum\ram\TradeSettlementHeaderMonetarySummationType|null
      */
     public function getSpecifiedTradeSettlementHeaderMonetarySummation()
     {

--- a/src/entities/minimum/ram/LegalOrganizationType.php
+++ b/src/entities/minimum/ram/LegalOrganizationType.php
@@ -11,14 +11,14 @@ class LegalOrganizationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\minimum\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\IDType
+     * @return \horstoeko\zugferd\entities\minimum\udt\IDType|null
      */
     public function getID()
     {
@@ -28,7 +28,7 @@ class LegalOrganizationType
     /**
      * Sets a new iD
      *
-     * @param  \horstoeko\zugferd\entities\minimum\udt\IDType $iD
+     * @param  \horstoeko\zugferd\entities\minimum\udt\IDType|null $iD
      * @return self
      */
     public function setID(?\horstoeko\zugferd\entities\minimum\udt\IDType $iD = null)

--- a/src/entities/minimum/ram/ReferencedDocumentType.php
+++ b/src/entities/minimum/ram/ReferencedDocumentType.php
@@ -11,14 +11,14 @@ class ReferencedDocumentType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\IDType $issuerAssignedID
+     * @var \horstoeko\zugferd\entities\minimum\udt\IDType|null $issuerAssignedID
      */
     private $issuerAssignedID = null;
 
     /**
      * Gets as issuerAssignedID
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\IDType
+     * @return \horstoeko\zugferd\entities\minimum\udt\IDType|null
      */
     public function getIssuerAssignedID()
     {

--- a/src/entities/minimum/ram/SupplyChainTradeTransactionType.php
+++ b/src/entities/minimum/ram/SupplyChainTradeTransactionType.php
@@ -11,24 +11,24 @@ class SupplyChainTradeTransactionType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\HeaderTradeAgreementType $applicableHeaderTradeAgreement
+     * @var \horstoeko\zugferd\entities\minimum\ram\HeaderTradeAgreementType|null $applicableHeaderTradeAgreement
      */
     private $applicableHeaderTradeAgreement = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\HeaderTradeDeliveryType $applicableHeaderTradeDelivery
+     * @var \horstoeko\zugferd\entities\minimum\ram\HeaderTradeDeliveryType|null $applicableHeaderTradeDelivery
      */
     private $applicableHeaderTradeDelivery = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\HeaderTradeSettlementType $applicableHeaderTradeSettlement
+     * @var \horstoeko\zugferd\entities\minimum\ram\HeaderTradeSettlementType|null $applicableHeaderTradeSettlement
      */
     private $applicableHeaderTradeSettlement = null;
 
     /**
      * Gets as applicableHeaderTradeAgreement
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\HeaderTradeAgreementType
+     * @return \horstoeko\zugferd\entities\minimum\ram\HeaderTradeAgreementType|null
      */
     public function getApplicableHeaderTradeAgreement()
     {
@@ -50,7 +50,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeDelivery
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\HeaderTradeDeliveryType
+     * @return \horstoeko\zugferd\entities\minimum\ram\HeaderTradeDeliveryType|null
      */
     public function getApplicableHeaderTradeDelivery()
     {
@@ -72,7 +72,7 @@ class SupplyChainTradeTransactionType
     /**
      * Gets as applicableHeaderTradeSettlement
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\HeaderTradeSettlementType
+     * @return \horstoeko\zugferd\entities\minimum\ram\HeaderTradeSettlementType|null
      */
     public function getApplicableHeaderTradeSettlement()
     {

--- a/src/entities/minimum/ram/TaxRegistrationType.php
+++ b/src/entities/minimum/ram/TaxRegistrationType.php
@@ -11,14 +11,14 @@ class TaxRegistrationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\IDType $iD
+     * @var \horstoeko\zugferd\entities\minimum\udt\IDType|null $iD
      */
     private $iD = null;
 
     /**
      * Gets as iD
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\IDType
+     * @return \horstoeko\zugferd\entities\minimum\udt\IDType|null
      */
     public function getID()
     {

--- a/src/entities/minimum/ram/TradeAddressType.php
+++ b/src/entities/minimum/ram/TradeAddressType.php
@@ -11,14 +11,14 @@ class TradeAddressType
 {
 
     /**
-     * @var string $countryID
+     * @var string|null $countryID
      */
     private $countryID = null;
 
     /**
      * Gets as countryID
      *
-     * @return string
+     * @return string|null
      */
     public function getCountryID()
     {

--- a/src/entities/minimum/ram/TradePartyType.php
+++ b/src/entities/minimum/ram/TradePartyType.php
@@ -11,17 +11,17 @@ class TradePartyType
 {
 
     /**
-     * @var string $name
+     * @var string|null $name
      */
     private $name = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @var \horstoeko\zugferd\entities\minimum\ram\LegalOrganizationType|null $specifiedLegalOrganization
      */
     private $specifiedLegalOrganization = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\TradeAddressType $postalTradeAddress
+     * @var \horstoeko\zugferd\entities\minimum\ram\TradeAddressType|null $postalTradeAddress
      */
     private $postalTradeAddress = null;
 
@@ -35,7 +35,7 @@ class TradePartyType
     /**
      * Gets as name
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -57,7 +57,7 @@ class TradePartyType
     /**
      * Gets as specifiedLegalOrganization
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\LegalOrganizationType
+     * @return \horstoeko\zugferd\entities\minimum\ram\LegalOrganizationType|null
      */
     public function getSpecifiedLegalOrganization()
     {
@@ -67,7 +67,7 @@ class TradePartyType
     /**
      * Sets a new specifiedLegalOrganization
      *
-     * @param  \horstoeko\zugferd\entities\minimum\ram\LegalOrganizationType $specifiedLegalOrganization
+     * @param  \horstoeko\zugferd\entities\minimum\ram\LegalOrganizationType|null $specifiedLegalOrganization
      * @return self
      */
     public function setSpecifiedLegalOrganization(?\horstoeko\zugferd\entities\minimum\ram\LegalOrganizationType $specifiedLegalOrganization = null)
@@ -79,7 +79,7 @@ class TradePartyType
     /**
      * Gets as postalTradeAddress
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\TradeAddressType
+     * @return \horstoeko\zugferd\entities\minimum\ram\TradeAddressType|null
      */
     public function getPostalTradeAddress()
     {
@@ -89,7 +89,7 @@ class TradePartyType
     /**
      * Sets a new postalTradeAddress
      *
-     * @param  \horstoeko\zugferd\entities\minimum\ram\TradeAddressType $postalTradeAddress
+     * @param  \horstoeko\zugferd\entities\minimum\ram\TradeAddressType|null $postalTradeAddress
      * @return self
      */
     public function setPostalTradeAddress(?\horstoeko\zugferd\entities\minimum\ram\TradeAddressType $postalTradeAddress = null)
@@ -145,7 +145,7 @@ class TradePartyType
     /**
      * Sets a new specifiedTaxRegistration
      *
-     * @param  \horstoeko\zugferd\entities\minimum\ram\TaxRegistrationType[] $specifiedTaxRegistration
+     * @param  \horstoeko\zugferd\entities\minimum\ram\TaxRegistrationType[]|null $specifiedTaxRegistration
      * @return self
      */
     public function setSpecifiedTaxRegistration(?array $specifiedTaxRegistration = null)

--- a/src/entities/minimum/ram/TradeSettlementHeaderMonetarySummationType.php
+++ b/src/entities/minimum/ram/TradeSettlementHeaderMonetarySummationType.php
@@ -11,7 +11,7 @@ class TradeSettlementHeaderMonetarySummationType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\AmountType $taxBasisTotalAmount
+     * @var \horstoeko\zugferd\entities\minimum\udt\AmountType|null $taxBasisTotalAmount
      */
     private $taxBasisTotalAmount = null;
 
@@ -23,19 +23,19 @@ class TradeSettlementHeaderMonetarySummationType
     ];
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\AmountType $grandTotalAmount
+     * @var \horstoeko\zugferd\entities\minimum\udt\AmountType|null $grandTotalAmount
      */
     private $grandTotalAmount = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\AmountType $duePayableAmount
+     * @var \horstoeko\zugferd\entities\minimum\udt\AmountType|null $duePayableAmount
      */
     private $duePayableAmount = null;
 
     /**
      * Gets as taxBasisTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\AmountType
+     * @return \horstoeko\zugferd\entities\minimum\udt\AmountType|null
      */
     public function getTaxBasisTotalAmount()
     {
@@ -101,7 +101,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Sets a new taxTotalAmount
      *
-     * @param  \horstoeko\zugferd\entities\minimum\udt\AmountType[] $taxTotalAmount
+     * @param  \horstoeko\zugferd\entities\minimum\udt\AmountType[]|null $taxTotalAmount
      * @return self
      */
     public function setTaxTotalAmount(?array $taxTotalAmount = null)
@@ -113,7 +113,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as grandTotalAmount
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\AmountType
+     * @return \horstoeko\zugferd\entities\minimum\udt\AmountType|null
      */
     public function getGrandTotalAmount()
     {
@@ -135,7 +135,7 @@ class TradeSettlementHeaderMonetarySummationType
     /**
      * Gets as duePayableAmount
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\AmountType
+     * @return \horstoeko\zugferd\entities\minimum\udt\AmountType|null
      */
     public function getDuePayableAmount()
     {

--- a/src/entities/minimum/rsm/CrossIndustryInvoiceType.php
+++ b/src/entities/minimum/rsm/CrossIndustryInvoiceType.php
@@ -11,24 +11,24 @@ class CrossIndustryInvoiceType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\ExchangedDocumentContextType $exchangedDocumentContext
+     * @var \horstoeko\zugferd\entities\minimum\ram\ExchangedDocumentContextType|null $exchangedDocumentContext
      */
     private $exchangedDocumentContext = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\ExchangedDocumentType $exchangedDocument
+     * @var \horstoeko\zugferd\entities\minimum\ram\ExchangedDocumentType|null $exchangedDocument
      */
     private $exchangedDocument = null;
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\ram\SupplyChainTradeTransactionType $supplyChainTradeTransaction
+     * @var \horstoeko\zugferd\entities\minimum\ram\SupplyChainTradeTransactionType|null $supplyChainTradeTransaction
      */
     private $supplyChainTradeTransaction = null;
 
     /**
      * Gets as exchangedDocumentContext
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\ExchangedDocumentContextType
+     * @return \horstoeko\zugferd\entities\minimum\ram\ExchangedDocumentContextType|null
      */
     public function getExchangedDocumentContext()
     {
@@ -50,7 +50,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as exchangedDocument
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\ExchangedDocumentType
+     * @return \horstoeko\zugferd\entities\minimum\ram\ExchangedDocumentType|null
      */
     public function getExchangedDocument()
     {
@@ -72,7 +72,7 @@ class CrossIndustryInvoiceType
     /**
      * Gets as supplyChainTradeTransaction
      *
-     * @return \horstoeko\zugferd\entities\minimum\ram\SupplyChainTradeTransactionType
+     * @return \horstoeko\zugferd\entities\minimum\ram\SupplyChainTradeTransactionType|null
      */
     public function getSupplyChainTradeTransaction()
     {

--- a/src/entities/minimum/udt/AmountType.php
+++ b/src/entities/minimum/udt/AmountType.php
@@ -11,12 +11,12 @@ class AmountType
 {
 
     /**
-     * @var float $__value
+     * @var float|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $currencyID
+     * @var string|null $currencyID
      */
     private $currencyID = null;
 
@@ -34,7 +34,7 @@ class AmountType
      * Gets or sets the inner value
      *
      * @param  float $value
-     * @return float
+     * @return float|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class AmountType
     /**
      * Gets as currencyID
      *
-     * @return string
+     * @return string|null
      */
     public function getCurrencyID()
     {

--- a/src/entities/minimum/udt/DateTimeType.php
+++ b/src/entities/minimum/udt/DateTimeType.php
@@ -11,14 +11,14 @@ class DateTimeType
 {
 
     /**
-     * @var \horstoeko\zugferd\entities\minimum\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @var \horstoeko\zugferd\entities\minimum\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      */
     private $dateTimeString = null;
 
     /**
      * Gets as dateTimeString
      *
-     * @return \horstoeko\zugferd\entities\minimum\udt\DateTimeType\DateTimeStringAType
+     * @return \horstoeko\zugferd\entities\minimum\udt\DateTimeType\DateTimeStringAType|null
      */
     public function getDateTimeString()
     {
@@ -28,7 +28,7 @@ class DateTimeType
     /**
      * Sets a new dateTimeString
      *
-     * @param  \horstoeko\zugferd\entities\minimum\udt\DateTimeType\DateTimeStringAType $dateTimeString
+     * @param  \horstoeko\zugferd\entities\minimum\udt\DateTimeType\DateTimeStringAType|null $dateTimeString
      * @return self
      */
     public function setDateTimeString(?\horstoeko\zugferd\entities\minimum\udt\DateTimeType\DateTimeStringAType $dateTimeString = null)

--- a/src/entities/minimum/udt/DateTimeType/DateTimeStringAType.php
+++ b/src/entities/minimum/udt/DateTimeType/DateTimeStringAType.php
@@ -9,12 +9,12 @@ class DateTimeStringAType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $format
+     * @var string|null $format
      */
     private $format = null;
 
@@ -32,7 +32,7 @@ class DateTimeStringAType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -55,7 +55,7 @@ class DateTimeStringAType
     /**
      * Gets as format
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/src/entities/minimum/udt/IDType.php
+++ b/src/entities/minimum/udt/IDType.php
@@ -11,12 +11,12 @@ class IDType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
     /**
-     * @var string $schemeID
+     * @var string|null $schemeID
      */
     private $schemeID = null;
 
@@ -34,7 +34,7 @@ class IDType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {
@@ -57,7 +57,7 @@ class IDType
     /**
      * Gets as schemeID
      *
-     * @return string
+     * @return string|null
      */
     public function getSchemeID()
     {

--- a/src/entities/minimum/udt/TextType.php
+++ b/src/entities/minimum/udt/TextType.php
@@ -11,7 +11,7 @@ class TextType
 {
 
     /**
-     * @var string $__value
+     * @var string|null $__value
      */
     private $__value = null;
 
@@ -29,7 +29,7 @@ class TextType
      * Gets or sets the inner value
      *
      * @param  string $value
-     * @return string
+     * @return string|null
      */
     public function value()
     {


### PR DESCRIPTION
The generated entity classes have no constructor and declare every object property as `private $x = null;`, so the value really is `null` until a setter runs. The docblocks did not say so — no `@var`/`@return` in `src/entities` carried `|null` before this change.

### Rules applied
The two rules legitimately differ, which is why this was inconsistent:

- **`@var` / `@return` follow the property initializer.** `private $x = null;` with no constructor ⇒ nullable, regardless of whether the field is XSD-required.
- **`@param` follows the method signature.** xsd2php emits `?Type $x = null` for XSD-optional fields and `Type $x` for required ones — a strict setter keeps a non-null `@param`.
- **Array-backed properties (`= []`) are unchanged**, staying `Type[]`.

### On the qdt/udt code-type wrappers
These have a mandatory `__construct($value)`, so `$__value` looks like it could never be null. It can, on both real paths:

- **Read path** — JMS builds them with `UnserializeObjectConstructor`, which uses `Doctrine\Instantiator` and **never runs the constructor**.
- **Builder path** — `ZugferdObjectHelper::createClassInstance($classname, $constructorvalue = null)` does `new $className($constructorvalue)`, and several call sites pass no value at all (e.g. `getAmountType()` constructs first, then assigns via `tryCall`).

Both yield `null` in practice, so `value()` is documented `string|null` / `float|null`. Note a typed property (`private string $__value;`) is *not* a viable alternative: under JMS's instantiator it throws `Error: Typed property must not be accessed before initialization`.

---
Docblocks only; no runtime behaviour changes. Derived mechanically from the code rather than by hand. Tests are byte-identical to `master` (2131 tests / 15280 assertions / the 1 pre-existing failure).