### PR TITLE
[FIX] Small ObjectHelper / DocumentBuilder / JMS handler fixes

### DIFF
--- a/src/ZugferdDocumentBuilder.php
+++ b/src/ZugferdDocumentBuilder.php
@@ -85,7 +85,7 @@ class ZugferdDocumentBuilder extends ZugferdDocument
      * Creates a new ZugferdDocumentBuilder with profile $profile
      *
      * @param  integer $profileId
-     * @return ZugferdDocumentBuilder
+     * @return static
      */
     public static function createNew(int $profileId): ZugferdDocumentBuilder
     {

--- a/src/ZugferdDocumentBuilder.php
+++ b/src/ZugferdDocumentBuilder.php
@@ -95,7 +95,11 @@ class ZugferdDocumentBuilder extends ZugferdDocument
     /**
      * Initialized a new document with profile settings
      *
-     * @return ZugferdDocumentBuilder
+     * Returns $this, so a derived builder such as ZugferdQuickDescriptor keeps its own
+     * type through createNew(). The native return type cannot say static: the package
+     * still supports PHP 7.3.
+     *
+     * @return static
      */
     public function initNewDocument(): ZugferdDocumentBuilder
     {

--- a/src/ZugferdObjectHelper.php
+++ b/src/ZugferdObjectHelper.php
@@ -1840,11 +1840,12 @@ class ZugferdObjectHelper
     public static function isOneNullOrEmpty(array $args): bool
     {
         foreach ($args as $arg) {
+            // A date is never null or empty, and isNullOrEmpty() would cast it to string.
             if ($arg instanceof DateTimeInterface) {
-                if ($arg == null) {
-                    return true;
-                }
-            } elseif (self::isNullOrEmpty($arg)) {
+                continue;
+            }
+
+            if (self::isNullOrEmpty($arg)) {
                 return true;
             }
         }

--- a/src/jms/ZugferdTypesHandler.php
+++ b/src/jms/ZugferdTypesHandler.php
@@ -13,6 +13,7 @@ use DOMElement;
 use DOMText;
 use horstoeko\zugferd\ZugferdSettings;
 use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\GraphNavigatorInterface;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\XmlSerializationVisitor;
 
@@ -45,127 +46,127 @@ class ZugferdTypesHandler implements SubscribingHandlerInterface
     {
         return [
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\minimum\udt\AmountType',
                 'method' => 'serializeAmountType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basic\udt\AmountType',
                 'method' => 'serializeAmountType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basicwl\udt\AmountType',
                 'method' => 'serializeAmountType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\en16931\udt\AmountType',
                 'method' => 'serializeAmountType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\extended\udt\AmountType',
                 'method' => 'serializeAmountType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basic\udt\QuantityType',
                 'method' => 'serializeQuantityType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basicwl\udt\QuantityType',
                 'method' => 'serializeQuantityType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\en16931\udt\QuantityType',
                 'method' => 'serializeQuantityType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\extended\udt\QuantityType',
                 'method' => 'serializeQuantityType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basic\udt\PercentType',
                 'method' => 'serializePercentType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basicwl\udt\PercentType',
                 'method' => 'serializePercentType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\en16931\udt\PercentType',
                 'method' => 'serializePercentType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\extended\udt\PercentType',
                 'method' => 'serializePercentType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basic\udt\IndicatorType',
                 'method' => 'serializeIndicatorType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basicwl\udt\IndicatorType',
                 'method' => 'serializeIndicatorType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\en16931\udt\IndicatorType',
                 'method' => 'serializeIndicatorType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\extended\udt\IndicatorType',
                 'method' => 'serializeIndicatorType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basic\udt\MeasureType',
                 'method' => 'serializeMeasureType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\basicwl\udt\MeasureType',
                 'method' => 'serializeMeasureType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\en16931\udt\MeasureType',
                 'method' => 'serializeMeasureType'
             ],
             [
-                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'horstoeko\zugferd\entities\extended\udt\MeasureType',
                 'method' => 'serializeMeasureType'


### PR DESCRIPTION
Four small, independent fixes.

- **`remove always false condition`** — dead branch in `ZugferdObjectHelper` that could never be reached.
- **`use GraphNavigatorInterface for constants`** — `src/jms/ZugferdTypesHandler.php` referenced the constants via a concrete class where the interface is the correct source.
- **`fix phpdoc`** — `ZugferdDocumentBuilder` docblock correction.
- **`[FIX] initNewDocument must keep the static type`** — `createNew()` was annotated `@return ZugferdDocumentBuilder`, which erases the late-static type for subclasses; it now returns `static`.

---
Tests: same result as `master` (the 1 pre-existing `KositValidatorTest` failure; no new failures).